### PR TITLE
Use builtins.range from the future library

### DIFF
--- a/librosa/core.py
+++ b/librosa/core.py
@@ -11,6 +11,7 @@ import numpy as np
 import numpy.fft as fft
 import scipy.signal
 import scipy.ndimage
+from builtins import range
 
 from . import filters
 from . import feature
@@ -358,7 +359,7 @@ def stft(y, n_fft=2048, hop_length=None, win_length=None, window=None,
     n_columns = int(_MAX_MEM_BLOCK / (stft_matrix.shape[0]
                                       * stft_matrix.itemsize))
 
-    for bl_s in xrange(0, stft_matrix.shape[1], n_columns):
+    for bl_s in range(0, stft_matrix.shape[1], n_columns):
         bl_t = min(bl_s + n_columns, stft_matrix.shape[1])
 
         # RFFT and Conjugate here to match phase from DPWE code

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -5,6 +5,7 @@
 import numpy as np
 import scipy.signal
 import librosa
+from builtins import range
 
 
 def dct(n_filters, n_input):
@@ -34,7 +35,7 @@ def dct(n_filters, n_input):
 
     samples = np.arange(1, 2*n_input, 2) * np.pi / (2.0 * n_input)
 
-    for i in xrange(1, n_filters):
+    for i in range(1, n_filters):
         basis[i, :] = np.cos(i*samples) * np.sqrt(2.0/n_input)
 
     return basis

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         'scipy >= 0.13.0',
         'scikit-learn >= 0.14.0',
         'matplotlib',
+        'future',
     ],
     extras_require={
         'resample': 'scikits.samplerate>=0.3'


### PR DESCRIPTION
I saw `Programming Language :: Python :: 3.3` in setup.py classifiers and thought librosa is Python 3 ready... It turns out it isn't, but there's an open issue for it (#86). I assume the link there is the author's preferred porting guide, so I used the future library.

This change makes _the parts I need_ run under Python 3. Hopefully it's useful. Unfortunately I don't have "matlab" so I can't run the tests.
