### PR TITLE
Harmonic-Percussive-Residual Source Separation 

### DIFF
--- a/librosa/decompose.py
+++ b/librosa/decompose.py
@@ -373,4 +373,6 @@ def hpss(S, kernel_size=31, power=2.0, mask=False, margin=1.0):
         except DivideByZero:
             raise ParameterError("Power is too large. Try using power between 1 and 10.")
 
+
+
     return ((S * mask_harm) * phase, (S * mask_perc) * phase)

--- a/librosa/decompose.py
+++ b/librosa/decompose.py
@@ -181,20 +181,27 @@ def decompose(S, n_components=None, transformer=None, sort=False, fit=True, **kw
 
 
 @cache
-def hpss(S, kernel_size=31, power=2.0, mask=False):
+def hpss(S, kernel_size=31, power=2.0, mask=False, margin=1.0):
     """Median-filtering harmonic percussive source separation (HPSS).
 
-    Decomposes an input spectrogram `S = H + P`
+    If margin = 1.0, decomposes an input spectrogram `S = H + P`
     where `H` contains the harmonic components,
     and `P` contains the percussive components.
 
-    This implementation is based upon the algorithm described by [1]_.
+    If margin > 1.0, decomposes an input spectrogram `S = H + P + R` 
+    where `R` contains residual components not included in `H` or `P`. 
+
+    This implementation is based upon the algorithm described by [1]_ and [2]_.
 
     .. [1] Fitzgerald, Derry.
         "Harmonic/percussive separation using median filtering."
         13th International Conference on Digital Audio Effects (DAFX10),
         Graz, Austria, 2010.
 
+    .. [2] Driedger, Müller, Disch.
+        "Extending harmonic-percussive separation of audio."
+        15th International Society for Music Information Retrieval Conference (ISMIR 2014),
+        Taipei, Taiwan, 2014.
 
     Parameters
     ----------
@@ -205,10 +212,9 @@ def hpss(S, kernel_size=31, power=2.0, mask=False):
         kernel size(s) for the median filters.
 
         - If scalar, the same size is used for both harmonic and percussive.
-        - If iterable, the first value specifies the width of the
+        - If tuple, the first value specifies the width of the
           harmonic filter, and the second value specifies the width
           of the percussive filter.
-
 
     power : float >= 0 [scalar]
         Exponent for the Wiener filter when constructing mask matrices.
@@ -221,6 +227,13 @@ def hpss(S, kernel_size=31, power=2.0, mask=False):
     mask : bool
         Return the masking matrices instead of components
 
+    margin : float or tuple (margin_harmonic, margin_percussive)
+        margin size(s) for the masks (as described in [2]_)
+
+        - If scalar, the same size is used for both harmonic and percussive.
+        - If tuple, the first value specifies the margin of the
+          harmonic mask, and the second value specifies the margin
+          of the percussive mask.    
 
     Returns
     -------
@@ -282,6 +295,20 @@ def hpss(S, kernel_size=31, power=2.0, mask=False):
            [ 1.,  1., ...,  1.,  1.],
            [ 1.,  1., ...,  1.,  1.]])
 
+
+    Separate into harmonic/percussive/residual components by using a margin > 1.0
+
+    >>> H, P = librosa.decompose.hpss(D, margin=3.0)
+    >>> R = D - (H+P)
+    >>> y_harm = librosa.core.istft(H)
+    >>> y_perc = librosa.core.istft(P)
+    >>> y_resi = librosa.core.istft(R)
+
+
+    Get a more isolated percussive component by widening its margin 
+
+    >>> H, P = librosa.decompose.hpss(D, margin=(1.0,5.0))
+
     """
 
     if np.iscomplexobj(S):
@@ -296,6 +323,17 @@ def hpss(S, kernel_size=31, power=2.0, mask=False):
         win_harm = kernel_size[0]
         win_perc = kernel_size[1]
 
+    if np.isscalar(margin):
+        margin_harm = margin
+        margin_perc = margin
+    else:
+        margin_harm = margin[0]
+        margin_perc = margin[1]
+
+    # margin minimum is 1.0
+    if margin_harm < 1 or margin_perc < 1: 
+        raise ParameterError("Margins must be >= 1.0")
+
     # Compute median filters. Pre-allocation here preserves memory layout.
     harm = np.empty_like(S)
     harm[:] = median_filter(S, size=(1, win_harm), mode='reflect')
@@ -304,11 +342,13 @@ def hpss(S, kernel_size=31, power=2.0, mask=False):
     perc[:] = median_filter(S, size=(win_perc, 1), mode='reflect')
 
     if mask or power < util.SMALL_FLOAT:
-        mask_harm = (harm > perc).astype(float)
-        mask_perc = 1 - mask_harm
+        mask_harm = (harm >  perc * margin_harm).astype(float)
+        mask_perc = (perc >= harm * margin_perc).astype(float)
         if mask:
             return mask_harm, mask_perc
+
     else:
+
         perc = perc ** power
         zero_perc = (perc < util.SMALL_FLOAT)
         perc[zero_perc] = 0.0
@@ -317,12 +357,22 @@ def hpss(S, kernel_size=31, power=2.0, mask=False):
         zero_harm = (harm < util.SMALL_FLOAT)
         harm[zero_harm] = 0.0
 
-        # Find points where both are zero, equalize
-        harm[zero_harm & zero_perc] = 0.5
-        perc[zero_harm & zero_perc] = 0.5
+        # For margin==1, the residual component must be zero, so we split zeros evenly.
+        if margin_harm == 1 and margin_perc == 1:
+            harm[zero_harm & zero_perc] = 0.5
+            perc[zero_harm & zero_perc] = 0.5
 
-        # Compute harmonic mask
-        mask_harm = harm / (harm + perc)
-        mask_perc = perc / (harm + perc)
+        try: 
+            # Compute harmonic mask
+            mask_harm = harm / (harm + perc * margin_harm**power)
+            mask_harm[np.isnan(mask_harm)] = 0
+
+            # Compute percussive mask
+            mask_perc = perc / (perc + harm * margin_perc**power)
+            mask_perc[np.isnan(mask_perc)] = 0
+        except DivideByZero:
+            raise ParameterError("Power is too large. Try using power between 1 and 10.")
+
+
 
     return ((S * mask_harm) * phase, (S * mask_perc) * phase)

--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -36,7 +36,7 @@ from . import decompose
 from . import util
 from .util.exceptions import ParameterError
 
-__all__ = ['hpss', 'harmonic', 'percussive', 'residual',
+__all__ = ['hpss', 'harmonic', 'percussive',
            'time_stretch', 'pitch_shift',
            'remix']
 
@@ -68,7 +68,6 @@ def hpss(y, **kwargs):
     --------
     harmonic : Extract only the harmonic component
     percussive : Extract only the percussive component
-    residual : Extract only the residual component
     librosa.decompose.hpss : HPSS on spectrograms
 
 
@@ -114,7 +113,6 @@ def harmonic(y, **kwargs):
     --------
     hpss : Separate harmonic and percussive components
     percussive : Extract only the percussive component
-    residual : Extract only the residual component
     librosa.decompose.hpss : HPSS for spectrograms
 
     Examples
@@ -141,11 +139,7 @@ def harmonic(y, **kwargs):
     return y_harm
 
 
-<<<<<<< HEAD
 def percussive(y, **kwargs):
-=======
-def percussive(y, margin=1.0):
->>>>>>> b914064cf904ea1b18473044c32ab5fc29cde599
     '''Extract percussive elements from an audio time-series.
 
     Parameters
@@ -154,7 +148,7 @@ def percussive(y, margin=1.0):
         audio time series
     kwargs : additional keyword arguments.
         See `librosa.decompose.hpss` for details.
-        
+
     Returns
     -------
     y_percussive : np.ndarray [shape=(n,)]
@@ -164,7 +158,6 @@ def percussive(y, margin=1.0):
     --------
     hpss : Separate harmonic and percussive components
     harmonic : Extract only the harmonic component
-    residual : Extract only the residual component
     librosa.decompose.hpss : HPSS for spectrograms
 
     Examples
@@ -184,51 +177,11 @@ def percussive(y, margin=1.0):
 
     # Remove harmonics
     stft_perc = decompose.hpss(stft, **kwargs)[1]
+
     # Invert the STFT
     y_perc = util.fix_length(core.istft(stft_perc, dtype=y.dtype), len(y))
 
     return y_perc
-
-def residual(y, margin=3.0):
-    '''Extract residual (non-harmonic, non-percussive) elements from an audio time-series.
-
-    Parameters
-    ----------
-    y : np.ndarray [shape=(n,)]
-        audio time series
-    margin : float or tuple (margin_harmonic, margin_percussive)
-        use margin[s] > 1.0, the greater the margin the more that is captured in the residual component 
-
-    Returns
-    -------
-    y_residual : np.ndarray [shape=(n,)]
-        audio time series of just the residual portion
-
-    See Also
-    --------
-    hpss : Separate harmonic and percussive components
-    harmonic : Extract only the harmonic component
-    percussive : Extract only the percussive component
-    librosa.decompose.hpss : HPSS for spectrograms
-
-    Examples
-    --------
-    >>> y, sr = librosa.load(librosa.util.example_audio_file())
-    >>> y_residual = librosa.effects.residual(y)
-
-    '''
-
-    # Compute the STFT matrix
-    stft = core.stft(y)
-
-    # Subtract harmonics and percussives 
-    H, P = decompose.hpss(stft, margin=margin)
-    stft_resi = stft - (H + P)
-
-    # Invert the STFT
-    y_resi = util.fix_length(core.istft(stft_resi, dtype=y.dtype), len(y))
-
-    return y_resi
 
 
 def time_stretch(y, rate):

--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -11,7 +11,7 @@ Harmonic-percussive source separation
 
     hpss
     harmonic
-    percussive
+    percussive 
 
 Time and frequency
 ------------------
@@ -41,7 +41,7 @@ __all__ = ['hpss', 'harmonic', 'percussive',
            'remix']
 
 
-def hpss(y):
+def hpss(y, **kwargs):
     '''Decompose an audio time series into harmonic and percussive components.
 
     This function automates the STFT->HPSS->ISTFT pipeline, and ensures that
@@ -52,6 +52,9 @@ def hpss(y):
     ----------
     y : np.ndarray [shape=(n,)]
         audio time series
+    kwargs : additional keyword arguments.
+        See `librosa.decompose.hpss` for details.
+
 
     Returns
     -------
@@ -70,8 +73,12 @@ def hpss(y):
 
     Examples
     --------
+    >>> # Extract harmonic and percussive components
     >>> y, sr = librosa.load(librosa.util.example_audio_file())
     >>> y_harmonic, y_percussive = librosa.effects.hpss(y)
+
+    >>> # Get a more isolated percussive component by widening its margin 
+    >>> y_harmonic, y_percussive = librosa.effects.hpss(y, margin=(1.0,5.0))
 
     '''
 
@@ -79,7 +86,7 @@ def hpss(y):
     stft = core.stft(y)
 
     # Decompose into harmonic and percussives
-    stft_harm, stft_perc = decompose.hpss(stft)
+    stft_harm, stft_perc = decompose.hpss(stft, **kwargs)
 
     # Invert the STFTs.  Adjust length to match the input.
     y_harm = util.fix_length(core.istft(stft_harm, dtype=y.dtype), len(y))
@@ -87,14 +94,15 @@ def hpss(y):
 
     return y_harm, y_perc
 
-
-def harmonic(y):
+def harmonic(y, **kwargs):
     '''Extract harmonic elements from an audio time-series.
 
     Parameters
     ----------
     y : np.ndarray [shape=(n,)]
         audio time series
+    kwargs : additional keyword arguments.
+        See `librosa.decompose.hpss` for details.
 
     Returns
     -------
@@ -109,8 +117,13 @@ def harmonic(y):
 
     Examples
     --------
+    >>> # Extract harmonic component 
     >>> y, sr = librosa.load(librosa.util.example_audio_file())
     >>> y_harmonic = librosa.effects.harmonic(y)
+
+    >>> # Use a margin > 1.0 for greater harmonic separation
+    >>> y_harmonic = librosa.effects.harmonic(y, margin=3.0)
+
 
     '''
 
@@ -118,7 +131,7 @@ def harmonic(y):
     stft = core.stft(y)
 
     # Remove percussives
-    stft_harm = decompose.hpss(stft)[0]
+    stft_harm = decompose.hpss(stft, **kwargs)[0]
 
     # Invert the STFTs
     y_harm = util.fix_length(core.istft(stft_harm, dtype=y.dtype), len(y))
@@ -126,13 +139,15 @@ def harmonic(y):
     return y_harm
 
 
-def percussive(y):
+def percussive(y, **kwargs):
     '''Extract percussive elements from an audio time-series.
 
     Parameters
     ----------
     y : np.ndarray [shape=(n,)]
         audio time series
+    kwargs : additional keyword arguments.
+        See `librosa.decompose.hpss` for details.
 
     Returns
     -------
@@ -146,9 +161,14 @@ def percussive(y):
     librosa.decompose.hpss : HPSS for spectrograms
 
     Examples
-    --------
+    --------    
+    >>> # Extract percussive component 
     >>> y, sr = librosa.load(librosa.util.example_audio_file())
     >>> y_percussive = librosa.effects.percussive(y)
+
+    >>> # Use a margin > 1.0 for greater percussive separation
+    >>> y_percussive = librosa.effects.percussive(y, margin=3.0)
+
 
     '''
 
@@ -156,7 +176,7 @@ def percussive(y):
     stft = core.stft(y)
 
     # Remove harmonics
-    stft_perc = decompose.hpss(stft)[1]
+    stft_perc = decompose.hpss(stft, **kwargs)[1]
 
     # Invert the STFT
     y_perc = util.fix_length(core.istft(stft_perc, dtype=y.dtype), len(y))


### PR DESCRIPTION
As discussed in #283 

### Updates
- `decompose.hpss` takes an optional margin argument (float or tuple), returns (H, P) according to [ Dreidger et al.](http://www.terasoft.com.tw/conf/ismir2014/proceedings/T110_127_Paper.pdf) Includes additional examples in comments.
- `effects.percussive` takes an optional margin argument (float)
- `effects.harmonic` takes an optional margin argument (float)
- `effects.residual(y, margin=(2.0, 3.0))` returns the residual component between the margins
- `examples/hprss.py` performs a demo of h-p-r source separation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bmcfee/librosa/304)
<!-- Reviewable:end -->
