### PR TITLE
Tempo frequencies

### DIFF
--- a/librosa/beat.py
+++ b/librosa/beat.py
@@ -238,17 +238,16 @@ def estimate_tempo(onset_envelope, sr=22050, hop_length=512, start_bpm=120,
     >>> # Compute 2-second windowed autocorrelation
     >>> hop_length = 512
     >>> ac = librosa.autocorrelate(onset_env, 2 * sr // hop_length)
-    >>> # Convert tempo estimate from bpm to frames
-    >>> tempo_frames = (60 * sr / hop_length) / tempo
-    >>> plt.plot(librosa.util.normalize(ac),
-    ...          label='Onset autocorrelation')
-    >>> plt.vlines([tempo_frames], 0, 1,
-    ...            color='r', alpha=0.75, linestyle='--',
+    >>> freqs = librosa.tempo_frequencies(len(ac), sr=sr,
+    ...                                   hop_length=hop_length)
+    >>> # Plot on a BPM axis.  We skip the first (0-lag) bin.
+    >>> plt.semilogx(freqs[1:], librosa.util.normalize(ac)[1:],
+    ...              label='Onset autocorrelation', basex=2)
+    >>> plt.axvline(tempo, 0, 1, color='r', alpha=0.75, linestyle='--',
     ...            label='Tempo: {:.2f} BPM'.format(tempo))
-    >>> librosa.display.time_ticks(librosa.frames_to_time(np.arange(len(ac)),
-    ...                                                   sr=sr))
-    >>> plt.xlabel('Lag')
-    >>> plt.legend()
+    >>> plt.xlabel('Tempo (BPM)')
+    >>> plt.grid()
+    >>> plt.legend(frameon=True)
     >>> plt.axis('tight')
     """
 

--- a/librosa/beat.py
+++ b/librosa/beat.py
@@ -99,23 +99,24 @@ def beat_track(y=None, sr=22050, onset_envelope=None, hop_length=512,
 
     >>> tempo, beats = librosa.beat.beat_track(y=y, sr=sr)
     >>> tempo
-    129.19921875
+    64.599609375
 
 
     Print the first 20 beat frames
 
     >>> beats[:20]
-    array([ 461,  500,  540,  580,  619,  658,  698,  737,  777,
-            817,  857,  896,  936,  976, 1016, 1055, 1095, 1135,
-           1175, 1214])
+    array([ 320,  357,  397,  436,  480,  525,  569,  609,  658,
+            698,  737,  777,  817,  857,  896,  936,  976, 1016,
+           1055, 1095])
 
 
     Or print them as timestamps
 
     >>> librosa.frames_to_time(beats[:20], sr=sr)
-    array([ 0.093,  0.534,  0.998,  1.463,  1.927,  2.368,  2.833,
-            3.297,  3.762,  4.203,  4.667,  5.132,  5.596,  6.06 ,
-            6.525,  6.989,  7.454,  7.918,  8.382,  8.847])
+    array([  7.43 ,   8.29 ,   9.218,  10.124,  11.146,  12.19 ,
+            13.212,  14.141,  15.279,  16.208,  17.113,  18.042,
+            18.971,  19.9  ,  20.805,  21.734,  22.663,  23.591,
+            24.497,  25.426])
 
 
     Track beats using a pre-computed onset envelope
@@ -127,16 +128,16 @@ def beat_track(y=None, sr=22050, onset_envelope=None, hop_length=512,
     >>> tempo
     64.599609375
     >>> beats[:20]
-    array([ 461,  500,  540,  580,  619,  658,  698,  737,  777,
-            817,  857,  896,  936,  976, 1016, 1055, 1095, 1135,
-           1175, 1214])
+    array([ 320,  357,  397,  436,  480,  525,  569,  609,  658,
+            698,  737,  777,  817,  857,  896,  936,  976, 1016,
+           1055, 1095])
 
 
     Plot the beat events against the onset strength envelope
 
     >>> import matplotlib.pyplot as plt
     >>> hop_length = 512
-    >>> plt.figure()
+    >>> plt.figure(figsize=(8, 4))
     >>> plt.plot(librosa.util.normalize(onset_env), label='Onset strength')
     >>> plt.vlines(beats, 0, 1, alpha=0.5, color='r',
     ...            linestyle='--', label='Beats')
@@ -230,7 +231,7 @@ def estimate_tempo(onset_envelope, sr=22050, hop_length=512, start_bpm=120,
     >>> onset_env = librosa.onset.onset_strength(y, sr=sr)
     >>> tempo = librosa.beat.estimate_tempo(onset_env, sr=sr)
     >>> tempo
-    129.19921875
+    103.359375
 
     Plot the estimated tempo against the onset autocorrelation
 
@@ -241,6 +242,7 @@ def estimate_tempo(onset_envelope, sr=22050, hop_length=512, start_bpm=120,
     >>> freqs = librosa.tempo_frequencies(len(ac), sr=sr,
     ...                                   hop_length=hop_length)
     >>> # Plot on a BPM axis.  We skip the first (0-lag) bin.
+    >>> plt.figure(figsize=(8,4))
     >>> plt.semilogx(freqs[1:], librosa.util.normalize(ac)[1:],
     ...              label='Onset autocorrelation', basex=2)
     >>> plt.axvline(tempo, 0, 1, color='r', alpha=0.75, linestyle='--',
@@ -267,13 +269,13 @@ def estimate_tempo(onset_envelope, sr=22050, hop_length=512, start_bpm=120,
     ac_window = min(maxcol, np.round(ac_size * fft_res))
 
     # Compute the autocorrelation
-    x_corr = core.autocorrelate(onset_envelope[mincol:maxcol], ac_window)
+    x_corr = core.autocorrelate(onset_envelope[mincol:maxcol], ac_window)[1:]
 
-    # re-weight the autocorrelation by log-normal prior
-    bpms = 60.0 * fft_res / (np.arange(1, ac_window+1))
+    # Get the BPM values for each bin, skipping the 0-lag bin
+    bpms = core.tempo_frequencies(ac_window, hop_length=hop_length, sr=sr)[1:]
 
-    # Smooth the autocorrelation by a log-normal distribution
-    x_corr = x_corr * np.exp(-0.5 * ((np.log2(bpms / start_bpm)) / std_bpm)**2)
+    # Weight the autocorrelation by a log-normal distribution centered start_bpm
+    x_corr *= np.exp(-0.5 * ((np.log2(bpms) - np.log2(start_bpm)) / std_bpm)**2)
 
     # Get the local maximum of weighted correlation
     x_peaks = util.localmax(x_corr)
@@ -289,7 +291,7 @@ def estimate_tempo(onset_envelope, sr=22050, hop_length=512, start_bpm=120,
     best_period = np.argmax(x_corr[candidates])
 
     if candidates[best_period] > 0:
-        return 60.0 * fft_res / candidates[best_period]
+        return bpms[candidates[best_period]]
 
     return start_bpm
 

--- a/librosa/core/__init__.py
+++ b/librosa/core/__init__.py
@@ -64,6 +64,7 @@ Time and frequency conversion
     fft_frequencies
     cqt_frequencies
     mel_frequencies
+    tempo_frequencies
 
 
 Pitch and tuning

--- a/librosa/core/time_frequency.py
+++ b/librosa/core/time_frequency.py
@@ -893,7 +893,7 @@ def tempo_frequencies(n_bins, hop_length=512, sr=22050):
                6.764,     6.747])
     '''
 
-    bin_frequencies = np.zeros(n_bins, dtype=np.float)
+    bin_frequencies = np.zeros(int(n_bins), dtype=np.float)
 
     bin_frequencies[0] = np.inf
     bin_frequencies[1:] = 60.0 * sr / (hop_length * np.arange(1.0, n_bins))

--- a/librosa/core/time_frequency.py
+++ b/librosa/core/time_frequency.py
@@ -20,6 +20,7 @@ __all__ = ['frames_to_samples', 'frames_to_time',
            'fft_frequencies',
            'cqt_frequencies',
            'mel_frequencies',
+           'tempo_frequencies',
            'A_weighting']
 
 
@@ -859,6 +860,45 @@ def mel_frequencies(n_mels=128, fmin=0.0, fmax=11025.0, htk=False):
     mels = np.linspace(min_mel, max_mel, n_mels)
 
     return mel_to_hz(mels, htk=htk)
+
+
+def tempo_frequencies(n_bins, hop_length=512, sr=22050):
+    '''Compute the frequencies (in beats-per-minute) corresponding
+    to an onset auto-correlation or tempogram matrix.
+
+    Parameters
+    ----------
+    n_bins : int > 0
+        The number of lag bins
+
+    hop_length : int > 0
+        The number of samples between each bin
+
+    sr : number > 0
+        The audio sampling rate
+
+    Returns
+    -------
+    bin_frequencies : ndarray [shape=(n_bins,)]
+        vector of bin frequencies measured in BPM.
+
+        .. note:: `bin_frequencies[0] = +np.inf` corresponds to 0-lag
+
+    Examples
+    --------
+    Get the tempo frequencies corresponding to a 384-bin (8-second) tempogram
+
+    >>> librosa.tempo_frequencies(384)
+    array([      inf,  2583.984,  1291.992, ...,     6.782,
+               6.764,     6.747])
+    '''
+
+    bin_frequencies = np.zeros(n_bins, dtype=np.float)
+
+    bin_frequencies[0] = np.inf
+    bin_frequencies[1:] = 60.0 * sr / (hop_length * np.arange(1.0, n_bins))
+
+    return bin_frequencies
 
 
 # A-weighting should be capitalized: suppress the naming warning

--- a/librosa/feature/rhythm.py
+++ b/librosa/feature/rhythm.py
@@ -90,24 +90,36 @@ def tempogram(y=None, sr=22050, onset_envelope=None, hop_length=512,
     >>> tempo = librosa.beat.estimate_tempo(oenv, sr=sr, hop_length=hop_length)
 
     >>> import matplotlib.pyplot as plt
-    >>> plt.figure(figsize=(8, 6))
-    >>> plt.subplot(3, 1, 1)
+    >>> plt.figure(figsize=(8, 8))
+    >>> plt.subplot(4, 1, 1)
     >>> plt.plot(oenv, label='Onset strength')
     >>> plt.xticks([])
     >>> plt.legend(frameon=True)
     >>> plt.axis('tight')
-    >>> plt.subplot(3, 1, 2)
+    >>> plt.subplot(4, 1, 2)
     >>> # We'll truncate the display to a narrower range of tempi
     >>> librosa.display.specshow(tempogram[:100], sr=sr, hop_length=hop_length,
     >>>                          x_axis='time', y_axis='tempo',
     ...                          tmin=tempo/4, tmax=2*tempo, n_yticks=4)
-    >>> plt.subplot(3, 1, 3)
-    >>> x = np.linspace(0, tempogram.shape[0] * float(hop_length) / sr, num=tempogram.shape[0])
+    >>> plt.subplot(4, 1, 3)
+    >>> x = np.linspace(0, tempogram.shape[0] * float(hop_length) / sr,
+    ...                 num=tempogram.shape[0])
     >>> plt.plot(x, np.mean(tempogram, axis=1), label='Mean local autocorrelation')
     >>> plt.plot(x, ac_global, '--', alpha=0.75, label='Global autocorrelation')
     >>> plt.xlabel('Lag (seconds)')
     >>> plt.axis('tight')
     >>> plt.legend(frameon=True)
+    >>> plt.subplot(4,1,4)
+    >>> # We can also plot on a BPM axis
+    >>> freqs = librosa.tempo_frequencies(tempogram.shape[0], hop_length=hop_length, sr=sr)
+    >>> plt.semilogx(freqs[1:], np.mean(tempogram[1:], axis=1),
+    ...              label='Mean local autocorrelation', basex=2)
+    >>> plt.semilogx(freqs[1:], ac_global[1:], '--', alpha=0.75,
+    ...              label='Global autocorrelation', basex=2)
+    >>> plt.legend(frameon=True)
+    >>> plt.xlabel('BPM')
+    >>> plt.axis('tight')
+    >>> plt.grid()
     >>> plt.tight_layout()
     '''
 

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -57,7 +57,7 @@ def test_tempo():
                                             start_bpm=120.0)
 
         assert (np.allclose(tempo, DATA['t'][0, 0]) or
-                np.allclose(tempo, DATA['t'][0, 1]))
+                np.allclose(tempo, DATA['t'][0, 1])), (tempo, DATA['t'])
 
     for infile in files('data/beat-tempo-*.mat'):
         yield (__test, infile)

--- a/tests/test_time_frequency.py
+++ b/tests/test_time_frequency.py
@@ -322,6 +322,29 @@ def test_cqt_frequencies():
                     yield __test, n_bins, fmin, bins_per_octave, tuning
 
 
+def test_tempo_frequencies():
+
+    def __test(n_bins, hop_length, sr):
+
+        freqs = librosa.tempo_frequencies(n_bins, hop_length=hop_length, sr=sr)
+
+        # Verify the length
+        eq_(len(freqs), n_bins)
+
+        # 0-bin should be infinite
+        assert not np.isfinite(freqs[0])
+
+        # remaining bins should be spaced by 1/hop_length
+        if n_bins > 1:
+            invdiff = (freqs[1:]**-1) * (60.0 * sr)
+            assert np.allclose(invdiff[0], hop_length)
+            assert np.allclose(np.diff(invdiff), np.asarray(hop_length)), np.diff(invdiff)
+
+    for n_bins in [1, 16, 128]:
+        for hop_length in [256, 512, 1024]:
+            for sr in [11025, 22050, 44100]:
+                yield __test, n_bins, hop_length, sr
+
 def test_A_weighting():
 
     def __test(min_db):


### PR DESCRIPTION
This PR adds a new frequency function `tempo_frequencies` which makes it easy to convert between lag (the index on autocorrelation and tempograms) and tempo (in BPM).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/354)
<!-- Reviewable:end -->
