### PR TITLE
Harmonic/Percussive/Residual source separation [round 2]

### DIFF
--- a/librosa/decompose.py
+++ b/librosa/decompose.py
@@ -184,20 +184,27 @@ def decompose(S, n_components=None, transformer=None, sort=False, fit=True, **kw
 
 
 @cache
-def hpss(S, kernel_size=31, power=2.0, mask=False):
+def hpss(S, kernel_size=31, power=2.0, mask=False, margin=1.0):
     """Median-filtering harmonic percussive source separation (HPSS).
 
-    Decomposes an input spectrogram `S = H + P`
+    If margin = 1.0, decomposes an input spectrogram `S = H + P`
     where `H` contains the harmonic components,
     and `P` contains the percussive components.
 
-    This implementation is based upon the algorithm described by [1]_.
+    If margin > 1.0, decomposes an input spectrogram `S = H + P + R` 
+    where `R` contains residual components not included in `H` or `P`. 
+
+    This implementation is based upon the algorithm described by [1]_ and [2]_.
 
     .. [1] Fitzgerald, Derry.
         "Harmonic/percussive separation using median filtering."
         13th International Conference on Digital Audio Effects (DAFX10),
         Graz, Austria, 2010.
 
+    .. [2] Driedger, Müller, Disch.
+        "Extending harmonic-percussive separation of audio."
+        15th International Society for Music Information Retrieval Conference (ISMIR 2014),
+        Taipei, Taiwan, 2014.
 
     Parameters
     ----------
@@ -208,10 +215,9 @@ def hpss(S, kernel_size=31, power=2.0, mask=False):
         kernel size(s) for the median filters.
 
         - If scalar, the same size is used for both harmonic and percussive.
-        - If iterable, the first value specifies the width of the
+        - If tuple, the first value specifies the width of the
           harmonic filter, and the second value specifies the width
           of the percussive filter.
-
 
     power : float >= 0 [scalar]
         Exponent for the Wiener filter when constructing mask matrices.
@@ -224,6 +230,13 @@ def hpss(S, kernel_size=31, power=2.0, mask=False):
     mask : bool
         Return the masking matrices instead of components
 
+    margin : float or tuple (margin_harmonic, margin_percussive)
+        margin size(s) for the masks (as described in [2]_)
+
+        - If scalar, the same size is used for both harmonic and percussive.
+        - If tuple, the first value specifies the margin of the
+          harmonic mask, and the second value specifies the margin
+          of the percussive mask.    
 
     Returns
     -------
@@ -285,6 +298,20 @@ def hpss(S, kernel_size=31, power=2.0, mask=False):
            [ 1.,  1., ...,  1.,  1.],
            [ 1.,  1., ...,  1.,  1.]])
 
+
+    Separate into harmonic/percussive/residual components by using a margin > 1.0
+
+    >>> H, P = librosa.decompose.hpss(D, margin=3.0)
+    >>> R = D - (H+P)
+    >>> y_harm = librosa.core.istft(H)
+    >>> y_perc = librosa.core.istft(P)
+    >>> y_resi = librosa.core.istft(R)
+
+
+    Get a more isolated percussive component by widening its margin 
+
+    >>> H, P = librosa.decompose.hpss(D, margin=(1.0,5.0))
+
     """
 
     if np.iscomplexobj(S):
@@ -299,6 +326,17 @@ def hpss(S, kernel_size=31, power=2.0, mask=False):
         win_harm = kernel_size[0]
         win_perc = kernel_size[1]
 
+    if np.isscalar(margin):
+        margin_harm = margin
+        margin_perc = margin
+    else:
+        margin_harm = margin[0]
+        margin_perc = margin[1]
+
+    # margin minimum is 1.0
+    if margin_harm < 1 or margin_perc < 1: 
+        raise ParameterError("Margins must be >= 1.0. A typical range is between 1 and 10.")
+
     # Compute median filters. Pre-allocation here preserves memory layout.
     harm = np.empty_like(S)
     harm[:] = median_filter(S, size=(1, win_harm), mode='reflect')
@@ -307,10 +345,11 @@ def hpss(S, kernel_size=31, power=2.0, mask=False):
     perc[:] = median_filter(S, size=(win_perc, 1), mode='reflect')
 
     if mask or power < util.SMALL_FLOAT:
-        mask_harm = (harm > perc).astype(float)
-        mask_perc = 1 - mask_harm
+        mask_harm = (harm >  perc * margin_harm).astype(float)
+        mask_perc = (perc >= harm * margin_perc).astype(float)
         if mask:
             return mask_harm, mask_perc
+
     else:
         perc = perc ** power
         zero_perc = (perc < util.SMALL_FLOAT)
@@ -320,13 +359,18 @@ def hpss(S, kernel_size=31, power=2.0, mask=False):
         zero_harm = (harm < util.SMALL_FLOAT)
         harm[zero_harm] = 0.0
 
-        # Find points where both are zero, equalize
-        harm[zero_harm & zero_perc] = 0.5
-        perc[zero_harm & zero_perc] = 0.5
+        # For margin==1, the residual component must be zero, so we split zeros evenly.
+        if margin_harm == 1 and margin_perc == 1:
+            harm[zero_harm & zero_perc] = 0.5
+            perc[zero_harm & zero_perc] = 0.5
 
         # Compute harmonic mask
-        mask_harm = harm / (harm + perc)
-        mask_perc = perc / (harm + perc)
+        mask_harm = harm / (harm + perc * margin_harm**power)
+        mask_harm[np.isnan(mask_harm)] = 0
+        
+        # Compute percussive mask
+        mask_perc = perc / (perc + harm * margin_perc**power)
+        mask_harm[np.isnan(mask_perc)] = 0
 
     return ((S * mask_harm) * phase, (S * mask_perc) * phase)
 

--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -41,7 +41,7 @@ __all__ = ['hpss', 'harmonic', 'percussive',
            'remix']
 
 
-def hpss(y):
+def hpss(y, **kwargs):
     '''Decompose an audio time series into harmonic and percussive components.
 
     This function automates the STFT->HPSS->ISTFT pipeline, and ensures that
@@ -52,6 +52,9 @@ def hpss(y):
     ----------
     y : np.ndarray [shape=(n,)]
         audio time series
+    kwargs : additional keyword arguments.
+        See `librosa.decompose.hpss` for details.
+
 
     Returns
     -------
@@ -70,8 +73,12 @@ def hpss(y):
 
     Examples
     --------
+    >>> # Extract harmonic and percussive components
     >>> y, sr = librosa.load(librosa.util.example_audio_file())
     >>> y_harmonic, y_percussive = librosa.effects.hpss(y)
+
+    >>> # Get a more isolated percussive component by widening its margin 
+    >>> y_harmonic, y_percussive = librosa.effects.hpss(y, margin=(1.0,5.0))
 
     '''
 
@@ -79,7 +86,7 @@ def hpss(y):
     stft = core.stft(y)
 
     # Decompose into harmonic and percussives
-    stft_harm, stft_perc = decompose.hpss(stft)
+    stft_harm, stft_perc = decompose.hpss(stft, **kwargs)
 
     # Invert the STFTs.  Adjust length to match the input.
     y_harm = util.fix_length(core.istft(stft_harm, dtype=y.dtype), len(y))
@@ -87,14 +94,15 @@ def hpss(y):
 
     return y_harm, y_perc
 
-
-def harmonic(y):
+def harmonic(y, **kwargs):
     '''Extract harmonic elements from an audio time-series.
 
     Parameters
     ----------
     y : np.ndarray [shape=(n,)]
         audio time series
+    kwargs : additional keyword arguments.
+        See `librosa.decompose.hpss` for details.
 
     Returns
     -------
@@ -109,8 +117,13 @@ def harmonic(y):
 
     Examples
     --------
+    >>> # Extract harmonic component 
     >>> y, sr = librosa.load(librosa.util.example_audio_file())
     >>> y_harmonic = librosa.effects.harmonic(y)
+
+    >>> # Use a margin > 1.0 for greater harmonic separation
+    >>> y_harmonic = librosa.effects.harmonic(y, margin=3.0)
+
 
     '''
 
@@ -118,21 +131,22 @@ def harmonic(y):
     stft = core.stft(y)
 
     # Remove percussives
-    stft_harm = decompose.hpss(stft)[0]
+    stft_harm = decompose.hpss(stft, **kwargs)[0]
 
     # Invert the STFTs
     y_harm = util.fix_length(core.istft(stft_harm, dtype=y.dtype), len(y))
 
     return y_harm
 
-
-def percussive(y):
+def percussive(y, **kwargs):
     '''Extract percussive elements from an audio time-series.
 
     Parameters
     ----------
     y : np.ndarray [shape=(n,)]
         audio time series
+    kwargs : additional keyword arguments.
+        See `librosa.decompose.hpss` for details.
 
     Returns
     -------
@@ -146,9 +160,14 @@ def percussive(y):
     librosa.decompose.hpss : HPSS for spectrograms
 
     Examples
-    --------
+    --------    
+    >>> # Extract percussive component 
     >>> y, sr = librosa.load(librosa.util.example_audio_file())
     >>> y_percussive = librosa.effects.percussive(y)
+
+    >>> # Use a margin > 1.0 for greater percussive separation
+    >>> y_percussive = librosa.effects.percussive(y, margin=3.0)
+
 
     '''
 
@@ -156,7 +175,7 @@ def percussive(y):
     stft = core.stft(y)
 
     # Remove harmonics
-    stft_perc = decompose.hpss(stft)[1]
+    stft_perc = decompose.hpss(stft, **kwargs)[1]
 
     # Invert the STFT
     y_perc = util.fix_length(core.istft(stft_perc, dtype=y.dtype), len(y))

--- a/tests/test_decompose.py
+++ b/tests/test_decompose.py
@@ -70,25 +70,39 @@ def test_sorted_decompose():
     assert np.allclose(X, W.dot(H), rtol=1e-2, atol=1e-2)
 
 
+
 def test_real_hpss():
 
     # Load an audio signal
     y, sr = librosa.load('data/test1_22050.wav')
 
     D = np.abs(librosa.stft(y))
+    
+    def __hpss_test(window, power, mask, margin):
+        H, P = librosa.decompose.hpss(D, kernel_size=window, power=power, mask=mask, margin=margin)
 
-    def __hpss_test(w, p, m):
-        H, P = librosa.decompose.hpss(D, kernel_size=w, power=p, mask=m)
-
-        if m:
-            assert np.allclose(H + P, np.ones_like(D))
+        if margin == 1.0 or margin == (1.0, 1.0):
+            if mask:
+                assert np.allclose(H + P, np.ones_like(D))
+            else:
+                assert np.allclose(H + P, D)
         else:
-            assert np.allclose(H + P, D)
+            if mask: 
+                assert not np.any(H.astype(bool) & P.astype(bool))
+            else:
+                assert np.all(H + P <= D)
 
     for window in [31, (5, 5)]:
         for power in [0, 1, 2]:
             for mask in [False, True]:
-                yield __hpss_test, window, power, mask
+                for margin in [1.0, 3.0, (1.0,1.0), (9.0, 10.0)]:
+                    yield __hpss_test, window, power, mask, margin
+
+@raises(librosa.ParameterError)
+def test_hpss_margin_error():
+    y, sr = librosa.load('data/test1_22050.wav')
+    D = np.abs(librosa.stft(y))
+    H, P = librosa.decompose.hpss(D, margin=0.9)
 
 
 def test_complex_hpss():


### PR DESCRIPTION
As discussed in #283 and #304 

# New updates in this pull request
* `decompose.hpss`
  - computes soft-masks when margin > 1.0, using formula discussed in #304 
  - can handle large powers that cause numeric overflow
    - soft-mask reverts to binary mask only for values that overflow _(because soft mask approaches binary mask as power becomes large)_
    - numeric divide/invalid/overflow warnings suppressed 
  - throws parameter error if margin < 1.0
* `tests/test_decompose.py`
    - tests various margins and powers, including powers that cause overflows 
    - tests margin parameter error
* `examples/hprss.py` not included

# Updates included from #304 
* `decompose.hpss` takes an optional margin argument (float or tuple), returns (H, P) according to Dreidger et al. Includes additional examples in comments.
* `effects.percussive` takes an optional margin argument (float)
* `effects.harmonic` takes an optional margin argument (float)
* `effects.residual(y, margin=(2.0, 3.0))` returns the residual component between the margins

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/355)
<!-- Reviewable:end -->
