### PR TITLE
Removed util.SMALL_FLOAT

### DIFF
--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -247,8 +247,7 @@ def piptrack(y=None, sr=22050, S=None, n_fft=2048, hop_length=None,
 
     # Suppress divide-by-zeros.
     # Points where shift == 0 will never be selected by localmax anyway
-    tiny = np.finfo(shift.dtype).tiny
-    shift = avg / (shift + (np.abs(shift) < tiny))
+    shift = avg / (shift + (np.abs(shift) < util.tiny(shift)))
 
     # Pad back up to the same shape as S
     avg = np.pad(avg, ([1, 1], [0, 0]), mode='constant')

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -247,7 +247,8 @@ def piptrack(y=None, sr=22050, S=None, n_fft=2048, hop_length=None,
 
     # Suppress divide-by-zeros.
     # Points where shift == 0 will never be selected by localmax anyway
-    shift = avg / (shift + (np.abs(shift) < util.SMALL_FLOAT))
+    tiny = np.finfo(shift.dtype).tiny
+    shift = avg / (shift + (np.abs(shift) < tiny))
 
     # Pad back up to the same shape as S
     avg = np.pad(avg, ([1, 1], [0, 0]), mode='constant')

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -312,7 +312,8 @@ def istft(stft_matrix, hop_length=None, win_length=None, window=None,
         ifft_window_sum[sample:(sample + n_fft)] += ifft_window_square
 
     # Normalize by sum of squared window
-    approx_nonzero_indices = ifft_window_sum > util.SMALL_FLOAT
+    tiny = np.finfo(ifft_window_sum.dtype).tiny
+    approx_nonzero_indices = ifft_window_sum > tiny
     y[approx_nonzero_indices] /= ifft_window_sum[approx_nonzero_indices]
 
     if center:

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -312,8 +312,7 @@ def istft(stft_matrix, hop_length=None, win_length=None, window=None,
         ifft_window_sum[sample:(sample + n_fft)] += ifft_window_square
 
     # Normalize by sum of squared window
-    tiny = np.finfo(ifft_window_sum.dtype).tiny
-    approx_nonzero_indices = ifft_window_sum > tiny
+    approx_nonzero_indices = ifft_window_sum > util.tiny(ifft_window_sum)
     y[approx_nonzero_indices] /= ifft_window_sum[approx_nonzero_indices]
 
     if center:

--- a/librosa/util/__init__.py
+++ b/librosa/util/__init__.py
@@ -24,7 +24,7 @@ Array operations
     sparsify_rows
 
     buf_to_float
-
+    tiny
 
 Matching
 --------

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -1484,8 +1484,14 @@ def softmask(X, X_ref, power=1, split_zeros=False):
     return mask
 
 
-def tiny(x, default=1e-20):
-    '''Compute the tiny-value corresponding to an input's data type
+def tiny(x):
+    '''Compute the tiny-value corresponding to an input's data type.
+
+    This is the smallest "usable" number representable in `x`'s
+    data type (e.g., float32).
+
+    This is primarily useful for determining a threshold for
+    numerical underflow in division or multiplication operations.
 
     Parameters
     ----------
@@ -1496,12 +1502,36 @@ def tiny(x, default=1e-20):
     Returns
     -------
     tiny_value : float
-        The smallest positive usable number for the type of x.
-        If x is integer-typed, then `default` is returned.
+        The smallest positive usable number for the type of `x`.
+        If `x` is integer-typed, then the tiny value for `np.float32`
+        is returned instead.
 
     See Also
     --------
     numpy.finfo
+
+    Examples
+    --------
+
+    For a standard double-precision floating point number:
+    >>> librosa.util.tiny(1.0)
+    2.2250738585072014e-308
+
+    Or explicitly as double-precision
+    >>> librosa.util.tiny(np.asarray(1e-5, dtype=np.float64))
+    2.2250738585072014e-308
+
+    Or complex numbers
+    >>> librosa.util.tiny(1j)
+    2.2250738585072014e-308
+
+    Single-precision floating point:
+    >>> librosa.util.tiny(np.asarray(1e-5, dtype=np.float32))
+    1.1754944e-38
+
+    Integer
+    >>> librosa.util.tiny(5)
+    1.1754944e-38
     '''
 
     # Make sure we have an array view
@@ -1509,6 +1539,8 @@ def tiny(x, default=1e-20):
 
     # Only floating types generate a tiny
     if np.issubdtype(x.dtype, float) or np.issubdtype(x.dtype, complex):
-        return np.finfo(x.dtype).tiny
+        dtype = x.dtype
+    else:
+        dtype = np.float32
 
-    return default
+    return np.finfo(dtype).tiny

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -15,9 +15,7 @@ from .exceptions import ParameterError
 # Constrain STFT block sizes to 256 KB
 MAX_MEM_BLOCK = 2**8 * 2**10
 
-SMALL_FLOAT = 1e-20
-
-__all__ = ['MAX_MEM_BLOCK', 'SMALL_FLOAT',
+__all__ = ['MAX_MEM_BLOCK',
            'frame', 'pad_center', 'fix_length',
            'valid_audio', 'valid_int', 'valid_intervals',
            'fix_frames',
@@ -624,7 +622,8 @@ def normalize(S, norm=np.inf, axis=0):
         raise ParameterError('Unsupported norm: {}'.format(repr(norm)))
 
     # Avoid div-by-zero
-    length[length < SMALL_FLOAT] = 1.0
+    tiny = np.finfo(length.dtype).tiny
+    length[length < tiny] = 1.0
 
     return S / length
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -781,3 +781,22 @@ def test_softmask_fail():
     yield failure, np.ones(3), np.ones(4), 1, False
     yield failure, np.ones(3), np.ones(3), 0, False
     yield failure, np.ones(3), np.ones(3), -1, False
+
+
+def test_tiny():
+
+    def __test(x, value):
+
+        eq_(value, librosa.util.tiny(x))
+
+
+    for x, value in [(1, np.finfo(np.float32).tiny),
+                     (np.ones(3, dtype=int), np.finfo(np.float32).tiny),
+                     (np.ones(3, dtype=np.float32), np.finfo(np.float32).tiny),
+                     (1.0, np.finfo(np.float64).tiny),
+                     (np.ones(3, dtype=np.float64), np.finfo(np.float64).tiny),
+                     (1j, np.finfo(np.complex128).tiny),
+                     (np.ones(3, dtype=np.complex64), np.finfo(np.complex64).tiny),
+                     (np.ones(3, dtype=np.complex128), np.finfo(np.complex128).tiny)]:
+        yield __test, x, value
+


### PR DESCRIPTION
And replaced by calling `np.finfo(dtype).tiny`, which is a more precise and less arbitrary way to accomplish what we need from the `SMALL_FLOAT` constant.

fixes #358

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/372)
<!-- Reviewable:end -->
