### PR TITLE
Custom SciPy window, window length, and n_fft in STFT

### DIFF
--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -127,23 +127,19 @@ def stft(y, n_fft=None, hop_length=None, win_length=None, window=None,
     >>> plt.tight_layout()
 
     """
+    # By default, the window length (also called frame length) is 2048 samples
+    if win_length is None:
+        win_length = 2048
+
     if window is None:
         # Hann window is the default
-        if win_length is None:
-            win_length = 2048
         fft_window = scipy.signal.hann(win_length, sym=False)
     if six.callable(window):
         # Case where window is a user-defined function of win_length
-        if win_length is None:
-            win_length = 2048
         fft_window = window(win_length)
     elif isinstance(window, tuple):
         # Case where window is a tuple of arguments to be passed to get_window
-        if win_length is None:
-            win_length = window[1]
-        elif win_length != window[1]:
-            raise ParameterError('win_length must be equal to window[1]')
-        fft_window = filters.get_window(window)
+        fft_window = filters.get_window(window, win_length)
     else:
         # Case where window is an array
         fft_window = np.asarray(window)

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -148,11 +148,16 @@ def stft(y, n_fft=None, hop_length=None, win_length=None, window=None,
         fft_window = np.asarray(window)
         win_length = fft_window.size
 
+    # By default, the FFT length is equal to the window length
     if n_fft is None:
         # The FFT length is set equal to window length by default
         n_fft = win_length
-    elif n_fft > win_length:
+    elif n_fft < win_length:
         raise ParameterError('n_fft must be greater than win_length')
+
+    # By default, adjacent windows in time have a 75% overlap
+    if hop_length is None:
+        hop_length = int(win_length / 4)
 
     # Pad the window out to n_fft size
     fft_window = util.pad_center(fft_window, n_fft)

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -137,8 +137,8 @@ def stft(y, n_fft=None, hop_length=None, win_length=None, window=None,
     if six.callable(window):
         # Case where window is a user-defined function of win_length
         fft_window = window(win_length)
-    elif isinstance(window, tuple):
-        # Case where window is a tuple of arguments to be passed to get_window
+    elif isinstance(window, tuple) or isinstance(window, basestring):
+        # Case where window is in SciPy get_window format (string or tuple)
         fft_window = filters.get_window(window, win_length)
     else:
         # Case where window is an array

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -11,6 +11,7 @@ import six
 
 from . import time_frequency
 from .. import cache
+from .. import filters
 from .. import util
 from ..util.exceptions import ParameterError
 

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -719,3 +719,7 @@ def window_bandwidth(window, default=1.0):
         warnings.warn("Unknown window function '{:s}'.".format(key))
 
     return WINDOW_BANDWIDTHS.get(key, default)
+
+
+def get_window(window, Nx):
+    scipy.signal.get_window(window, Nx)

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -722,4 +722,4 @@ def window_bandwidth(window, default=1.0):
 
 
 def get_window(window, Nx):
-    scipy.signal.get_window(window, Nx)
+    return scipy.signal.get_window(window, Nx)


### PR DESCRIPTION
* I've defined `librosa.filters.get_window`. Right now it falls back to `scipy.signal.get_window`. We could add a try/catch statement in the future for non-SciPy windows in the future
* Now `win_length` and `n_fft` are defaults of each other. If neither of them is provided, falls back to 2048.
* no longer fails when user-defined `n_fft` is below the length of a
user-defined window (by function or array)
* still fails when user-defined `n_fft` is above that length
* calls `librosa.filters.get_window` when window is a tuple of arguments.
win_length is extracted as `window[1]` (second element in the tuple)

Now these work
```
X = librosa.stft(y, window=('kaiser', 4.0)) # n_fft = 2048

X = librosa.stft(y, window='boxcar') # n_fft = 2048
X = librosa.stft(y, window='boxcar', win_length = 1024) # n_fft = 1024
X = librosa.stft(y, window='boxcar', n_fft = 1024) # win_length = 1024

w = scipy.signal.triang(1024)
X = librosa.stft(y, window=w) # n_fft = 1024
```

Fixes #397 in what regards STFT.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/400)
<!-- Reviewable:end -->
