### PR TITLE
Removed auto-import of display submodule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
 install:
     # install your own package into the environment
     # pip install -e rather than setup.py, so that coverage can find the source
-    - pip install -e ./
+    - pip install -e .[display]
 
 script:
     - python --version

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,6 +81,7 @@ import matplotlib.style
 matplotlib.style.use('seaborn-muted')
 import numpy as np
 import librosa
+import librosa.display
 np.random.seed(123)
 np.set_printoptions(precision=3, linewidth=64, edgeitems=2, threshold=200)
 """

--- a/librosa/__init__.py
+++ b/librosa/__init__.py
@@ -15,7 +15,6 @@ from . import cache
 from . import core
 from . import beat
 from . import decompose
-from . import display
 from . import effects
 from . import feature
 from . import filters
@@ -29,6 +28,3 @@ from .util.exceptions import * # pylint: disable=wildcard-import
 
 # Exporting all core functions is okay here: suppress the import warning
 from librosa.core import *  # pylint: disable=wildcard-import
-
-
-

--- a/setup.py
+++ b/setup.py
@@ -34,14 +34,15 @@ setup(
         'numpy >= 1.8.0',
         'scipy >= 0.13.0',
         'scikit-learn >= 0.14.0',
-        'matplotlib >= 1.5',
         'joblib >= 0.7.0',
         'decorator >= 3.0.0',
         'six >= 1.3',
         'resampy >= 0.1.2'
     ],
     extras_require={
-        'docs': ['numpydoc', 'sphinx!=1.3.1', 'sphinx_rtd_theme'],
-        'numba': ['numba >= 0.25', ]
+        'docs': ['numpydoc', 'sphinx!=1.3.1', 'sphinx_rtd_theme',
+                 'matplotlib >= 1.5'],
+        'numba': ['numba >= 0.25'],
+        'display': ['matplotlib >= 1.5'],
     }
 )

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -21,6 +21,7 @@ matplotlib.style.use('seaborn-ticks')
 import matplotlib.pyplot as plt
 
 import librosa
+import librosa.display
 import numpy as np
 
 from nose.tools import nottest, raises, eq_

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -324,8 +324,10 @@ def test_cmap_robust():
 
         if isinstance(cmap1, matplotlib.colors.ListedColormap):
             assert np.allclose(cmap1.colors, cmap2.colors)
+        elif isinstance(cmap1, matplotlib.colors.LinearSegmentedColormap):
+            eq_(cmap1.name, cmap2.name)
         else:
-            eq_(list(cmap1), list(cmap2))
+            eq_(cmap1, cmap2)
 
     # Inputs here are constructed to not need robust sign estimation
     for D in [1.0 + S_abs, -(1.0 + S_abs), S_signed, S_bin]:

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -325,7 +325,7 @@ def test_cmap_robust():
         if isinstance(cmap1, matplotlib.colors.ListedColormap):
             assert np.allclose(cmap1.colors, cmap2.colors)
         else:
-            eq_(cmap1, cmap2)
+            eq_(list(cmap1), list(cmap2))
 
     # Inputs here are constructed to not need robust sign estimation
     for D in [1.0 + S_abs, -(1.0 + S_abs), S_signed, S_bin]:


### PR DESCRIPTION
By popular demand #258 #281 #343 , the display submodule is no longer imported automatically.

I've also relaxed the installation requirements so that matplotlib is an optional dependency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/402)
<!-- Reviewable:end -->
