### PR TITLE
Time domain RMS

### DIFF
--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Spectral feature extraction"""
+
 import numpy as np
 import scipy
 import scipy.signal

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -547,7 +547,7 @@ def rmse(y=None, S=None, n_fft=2048, hop_length=512):
     '''
     if y is not None:
         x = util.frame(to_mono(y))
-    if S is not None:
+    elif S is not None:
         x, _ = _spectrogram(y=y, S=S, n_fft=n_fft, hop_length=hop_length)
     else:
         raise ValueError('Either y or S must be input.')

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -550,10 +550,10 @@ def rmse(y=None, S=None, n_fft=2048, hop_length=512):
     >>> plt.title('log Power spectrogram')
     >>> plt.tight_layout()
     
-    Use a STFT window of constant ones to get consistent results with the RMS 
-    energy computed from the audio samples `y`
+    Use a STFT window of constant ones and no frame centering to get consistent 
+    results with the RMS energy computed from the audio samples `y`
     
-    >>> S = librosa.magphase(librosa.stft(y, window=np.ones)[0]
+    >>> S = librosa.magphase(librosa.stft(y, window=np.ones, center=False)[0]
     >>> librosa.feature.rmse(S=S)
     
 

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -560,17 +560,14 @@ def rmse(y=None, S=None, n_fft=2048, hop_length=512, mode='time-frequency'):
     >>> plt.tight_layout()
 
     '''
-    if mode == 'time':
+    if S is not None or mode == 'time-frequency':
+        x, _ = _spectrogram(y=y, S=S, n_fft=n_fft, hop_length=hop_length)    
+    elif mode == 'time':
         if y is None:
             raise ValueError("`y` must be input if `mode='time'`")
-        if S is not None:
-            warn("`y` and `S` both input with `mode='time'`. Ignoring `S`.")
         x = util.frame(to_mono(y))
-    elif mode == 'time-frequency':
-        x, _ = _spectrogram(y=y, S=S, n_fft=n_fft, hop_length=hop_length)    
     else: 
         raise ValueError('Invalid mode.')
-
     return np.sqrt(np.mean(np.abs(x)**2, axis=0, keepdims=True))
 
 

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Spectral feature extraction"""
-from warnings import warn
-
 import numpy as np
 import scipy
 import scipy.signal

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -11,7 +11,7 @@ from .. import filters
 from ..util.exceptions import ParameterError
 
 from ..core.time_frequency import fft_frequencies
-from ..core.audio import zero_crossings
+from ..core.audio import zero_crossings, to_mono
 from ..core.spectrum import logamplitude, _spectrogram
 from ..core.constantq import cqt, hybrid_cqt
 from ..core.pitch import estimate_tuning
@@ -502,7 +502,7 @@ def rmse(y=None, S=None, n_fft=2048, hop_length=512):
     Parameters
     ----------
     y : np.ndarray [shape=(n,)] or None
-        audio time series
+        (optional) audio time series
 
     S : np.ndarray [shape=(d, t)] or None
         (optional) spectrogram magnitude
@@ -545,10 +545,13 @@ def rmse(y=None, S=None, n_fft=2048, hop_length=512):
     >>> plt.tight_layout()
 
     '''
-
-    S, _ = _spectrogram(y=y, S=S, n_fft=n_fft, hop_length=hop_length)
-
-    return np.sqrt(np.mean(np.abs(S)**2, axis=0, keepdims=True))
+    if y is not None:
+        x = util.frame(to_mono(y))
+    if S is not None:
+        x, _ = _spectrogram(y=y, S=S, n_fft=n_fft, hop_length=hop_length)
+    else:
+        raise ValueError('Either y or S must be input.')
+    return np.sqrt(np.mean(np.abs(x)**2, axis=0, keepdims=True))
 
 
 def poly_features(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -317,7 +317,18 @@ def test_rmse():
         rmse = librosa.feature.rmse(S=S)
 
         assert np.allclose(rmse, np.ones_like(rmse))
+        
+    def __test_equal():
+        y, sr = librosa.load(__EXAMPLE_FILE, sr=None)
+        
+        # STFT magnitudes with a constant windowing function.
+        S = librosa.magphase(librosa.stft(y, window=np.ones))[0]
+        
+        np.testing.assert_array_equal(librosa.feature.rmse(S=S),
+                                      librosa.feature.rmse(y=y))  
 
+    yield __test_equal
+    
     for n in range(10, 100, 10):
         yield __test, n
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -337,13 +337,11 @@ def test_rmse():
         rms2 = librosa.feature.rmse(y=y)
 
         # Normalize envelopes.
-        rms1, rms2 = map(lambda x: librosa.util.normalize(x, axis=1), [rms1, 
-                                                                       rms2])
+        rms1 /= rms1.max()
+        rms2 /= rms2.max()
         
         # Ensure results are similar.
-        np.testing.assert_allclose(rms1,
-                                   rms2, 
-                                   rtol=1e-2)
+        np.testing.assert_allclose(rms1, rms2, rtol=1e-2)
 
     yield __test_consistency
     

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -324,8 +324,8 @@ def test_rmse():
         # STFT magnitudes with a constant windowing function.
         S = librosa.magphase(librosa.stft(y, window=np.ones))[0]
         
-        np.testing.assert_array_equal(librosa.feature.rmse(S=S),
-                                      librosa.feature.rmse(y=y))  
+        np.testing.assert_allclose(librosa.feature.rmse(S=S),
+                                   librosa.feature.rmse(y=y))  
 
     yield __test_equal
     


### PR DESCRIPTION
If a precomputed spectrogram is not given, calculate `rmse()` in the time domain (to avoid doing a costly STFT).

_(side note: could `rmse()` be renamed to `rms()`? RMSE implies root-mean-square error and it's confusing.)_

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/407)
<!-- Reviewable:end -->
