### PR TITLE
Expanding window options for stft and friends

### DIFF
--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -13,7 +13,7 @@ from . import time_frequency
 from .. import cache
 from .. import util
 from ..util.exceptions import ParameterError
-from ..filters import get_window, hann_asym
+from ..filters import get_window
 
 __all__ = ['stft', 'istft', 'magphase',
            'ifgram',
@@ -136,9 +136,9 @@ def stft(y, n_fft=2048, hop_length=None, win_length=None, window=None,
         hop_length = int(win_length // 4)
 
     if window is None:
-        window = hann_asym
+        window = 'hann'
 
-    fft_window = get_window(window, win_length)
+    fft_window = get_window(window, win_length, fftbins=True)
 
     # Pad the window out to n_fft size
     fft_window = util.pad_center(fft_window, n_fft)
@@ -265,9 +265,10 @@ def istft(stft_matrix, hop_length=None, win_length=None, window=None,
 
     if window is None:
         # Default is an asymmetric Hann window.
-        window = hann_asym
+        window = 'hann'
 
-    ifft_window = get_window(window, win_length)
+    ifft_window = get_window(window, win_length, fftbins=True)
+
     # Pad out to match n_fft
     ifft_window = util.pad_center(ifft_window, n_fft)
 
@@ -386,7 +387,8 @@ def ifgram(y, sr=22050, n_fft=2048, hop_length=None, win_length=None,
         hop_length = int(win_length // 4)
 
     # Construct a padded hann window
-    window = util.pad_center(hann_asym(win_length), n_fft)
+    window = util.pad_center(get_window('hann', win_length, fftbins=True),
+                             n_fft)
 
     # Window for discrete differentiation
     freq_angular = np.linspace(0, 2 * np.pi, n_fft, endpoint=False)

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -384,8 +384,9 @@ def ifgram(y, sr=22050, n_fft=2048, hop_length=None, win_length=None,
         hop_length = int(win_length // 4)
 
     # Construct a padded hann window
-    win = util.pad_center(get_window(window, win_length, fftbins=True),
-                          n_fft)
+    fft_window = util.pad_center(get_window(window, win_length,
+                                            fftbins=True),
+                                 n_fft)
 
     # Window for discrete differentiation
     freq_angular = np.linspace(0, 2 * np.pi, n_fft, endpoint=False)
@@ -393,6 +394,7 @@ def ifgram(y, sr=22050, n_fft=2048, hop_length=None, win_length=None,
     d_window = np.sin(-freq_angular) * np.pi / n_fft
 
     stft_matrix = stft(y, n_fft=n_fft, hop_length=hop_length,
+                       win_length=win_length,
                        window=window, center=center, dtype=dtype)
 
     diff_stft = stft(y, n_fft=n_fft, hop_length=hop_length,
@@ -416,7 +418,7 @@ def ifgram(y, sr=22050, n_fft=2048, hop_length=None, win_length=None,
     if_gram = freq_angular[:n_fft//2 + 1] + bin_offset
 
     if norm:
-        stft_matrix = stft_matrix * 2.0 / win.sum()
+        stft_matrix = stft_matrix * 2.0 / fft_window.sum()
 
     if clip:
         np.clip(if_gram, 0, np.pi, out=if_gram)

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -53,10 +53,13 @@ def stft(y, n_fft=2048, hop_length=None, win_length=None, window='hann',
 
         If unspecified, defaults to ``win_length = n_fft``.
 
-    window : string, tuple, function, or np.ndarray [shape=(n_fft,)]
-        - a window specification (string or tuple); see `scipy.signal.get_window`
+    window : string, tuple, number, function, or np.ndarray [shape=(n_fft,)]
+        - a window specification (string, tuple, or number); 
+          see `scipy.signal.get_window`
         - a window function, such as `scipy.signal.hanning`
         - a vector or array of length `n_fft`
+
+        .. see also:: `filters.get_window`
 
     center      : boolean
         - If `True`, the signal `y` is padded so that frame
@@ -205,10 +208,13 @@ def istft(stft_matrix, hop_length=None, win_length=None, window='hann',
 
         If unspecified, defaults to `n_fft`.
 
-    window      : string, tuple, function, np.ndarray [shape=(n_fft,)]
-        - a window specification (string or tuple); see `scipy.signal.get_window`
+    window      : string, tuple, number, function, np.ndarray [shape=(n_fft,)]
+        - a window specification (string, tuple, or number);
+          see `scipy.signal.get_window`
         - a window function, such as `scipy.signal.hanning`
         - a user-specified window vector of length `n_fft`
+
+        .. see also:: `filters.get_window`
 
     center      : boolean
         - If `True`, `D` is assumed to have centered frames.
@@ -324,11 +330,14 @@ def ifgram(y, sr=22050, n_fft=2048, hop_length=None, win_length=None,
         Window length. Defaults to `n_fft`.
         See `stft` for details.
 
-    window : string, tuple, function, or np.ndarray [shape=(n_fft,)]
-        - a window specification (string or tuple); see `scipy.signal.get_window`
+    window : string, tuple, number, function, or np.ndarray [shape=(n_fft,)]
+        - a window specification (string, tuple, number);
+          see `scipy.signal.get_window`
         - a window function, such as `scipy.signal.hanning`
         - a user-specified window vector of length `n_fft`
         See `stft` for details.
+
+        .. see also:: `filters.get_window`
 
     norm : bool
         Normalize the STFT.

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -53,8 +53,8 @@ def stft(y, n_fft=2048, hop_length=None, win_length=None, window='hann',
 
         If unspecified, defaults to ``win_length = n_fft``.
 
-    window : None, function, np.ndarray [shape=(n_fft,)]
-        - None (default): use an asymmetric Hann window
+    window : string, tuple, function, or np.ndarray [shape=(n_fft,)]
+        - a window specification (string or tuple); see `scipy.signal.get_window`
         - a window function, such as `scipy.signal.hanning`
         - a vector or array of length `n_fft`
 
@@ -205,8 +205,8 @@ def istft(stft_matrix, hop_length=None, win_length=None, window='hann',
 
         If unspecified, defaults to `n_fft`.
 
-    window      : None, function, np.ndarray [shape=(n_fft,)]
-        - None (default): use an asymmetric Hann window
+    window      : string, tuple, function, np.ndarray [shape=(n_fft,)]
+        - a window specification (string or tuple); see `scipy.signal.get_window`
         - a window function, such as `scipy.signal.hanning`
         - a user-specified window vector of length `n_fft`
 
@@ -324,8 +324,10 @@ def ifgram(y, sr=22050, n_fft=2048, hop_length=None, win_length=None,
         Window length. Defaults to `n_fft`.
         See `stft` for details.
 
-    window : string, tuple, function, or np.ndarray
-        Window function to use in ifgram calculation.
+    window : string, tuple, function, or np.ndarray [shape=(n_fft,)]
+        - a window specification (string or tuple); see `scipy.signal.get_window`
+        - a window function, such as `scipy.signal.hanning`
+        - a user-specified window vector of length `n_fft`
         See `stft` for details.
 
     norm : bool

--- a/librosa/feature/rhythm.py
+++ b/librosa/feature/rhythm.py
@@ -48,8 +48,8 @@ def tempogram(y=None, sr=22050, onset_envelope=None, hop_length=512,
         If `True`, onset autocorrelation windows are centered.
         If `False`, windows are left-aligned.
 
-    window : string, function, tuple, or np.ndarray [shape=(win_length,)]
-        A window specification as in `core.stft`
+    window : string, function, number, tuple, or np.ndarray [shape=(win_length,)]
+        A window specification as in `core.stft`.
 
     norm : {np.inf, -np.inf, 0, float > 0, None}
         Normalization mode.  Set to `None` to disable normalization.

--- a/librosa/feature/rhythm.py
+++ b/librosa/feature/rhythm.py
@@ -49,8 +49,7 @@ def tempogram(y=None, sr=22050, onset_envelope=None, hop_length=512,
         If `False`, windows are left-aligned.
 
     window : string, function, tuple, or np.ndarray [shape=(win_length,)]
-        Window function to apply to onset strength function.
-        By default an asymmetric Hann window.
+        A window specification as in `core.stft`
 
     norm : {np.inf, -np.inf, 0, float > 0, None}
         Normalization mode.  Set to `None` to disable normalization.

--- a/librosa/feature/rhythm.py
+++ b/librosa/feature/rhythm.py
@@ -10,6 +10,7 @@ from .. import util
 
 from ..core.audio import autocorrelate
 from ..util.exceptions import ParameterError
+from ..filters import get_window
 
 
 __all__ = ['tempogram']
@@ -17,7 +18,7 @@ __all__ = ['tempogram']
 
 # -- Rhythmic features -- #
 def tempogram(y=None, sr=22050, onset_envelope=None, hop_length=512,
-              win_length=384, center=True, window=None, norm=np.inf):
+              win_length=384, center=True, window='hann', norm=np.inf):
     '''Compute the tempogram: local autocorrelation of the onset strength envelope. [1]_
 
     .. [1] Grosche, Peter, Meinard Müller, and Frank Kurth.
@@ -47,9 +48,9 @@ def tempogram(y=None, sr=22050, onset_envelope=None, hop_length=512,
         If `True`, onset autocorrelation windows are centered.
         If `False`, windows are left-aligned.
 
-    window : None, function, np.ndarray [shape=(win_length,)]
+    window : string, function, tuple, or np.ndarray [shape=(win_length,)]
         Window function to apply to onset strength function.
-        By default (`None`), an asymmetric Hann window.
+        By default an asymmetric Hann window.
 
     norm : {np.inf, -np.inf, 0, float > 0, None}
         Normalization mode.  Set to `None` to disable normalization.
@@ -65,8 +66,6 @@ def tempogram(y=None, sr=22050, onset_envelope=None, hop_length=512,
         if neither `y` nor `onset_envelope` are provided
 
         if `win_length < 1`
-
-        if `window` is an array and `len(window) != win_length`
 
     See Also
     --------
@@ -132,23 +131,15 @@ def tempogram(y=None, sr=22050, onset_envelope=None, hop_length=512,
     if win_length < 1:
         raise ParameterError('win_length must be a positive integer')
 
-    if window is None:
-        ac_window = scipy.signal.hann(win_length, sym=False)
-    elif six.callable(window):
-        ac_window = window(win_length)
-    else:
-        ac_window = np.asarray(window)
-        if ac_window.size != win_length:
-            raise ParameterError('Size mismatch between win_length and len(window)')
+    ac_window = get_window(window, win_length, fftbins=True)
 
     if onset_envelope is None:
         if y is None:
             raise ParameterError('Either y or onset_envelope must be provided')
 
-        onset_envelope = onset_strength(y=y, sr=sr,
-                                        hop_length=hop_length)
+        onset_envelope = onset_strength(y=y, sr=sr, hop_length=hop_length)
 
-    # Pad the envelope so that autocorrelation windows are centered on the input
+    # Center the autocorrelation windows
     n = len(onset_envelope)
 
     if center:
@@ -165,5 +156,6 @@ def tempogram(y=None, sr=22050, onset_envelope=None, hop_length=512,
         odf_frame = odf_frame[:, :n]
 
     # Window, autocorrelate, and normalize
-    return util.normalize(autocorrelate(odf_frame * ac_window[:, np.newaxis], axis=0),
+    return util.normalize(autocorrelate(odf_frame * ac_window[:, np.newaxis],
+                                        axis=0),
                           norm=norm, axis=0)

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -765,12 +765,14 @@ def get_window(window, Nx, fftbins=True):
 
     Parameters
     ----------
-    window : string, tuple, callable, or list-like
+    window : string, tuple, number, callable, or list-like
         The window specification:
 
         - If string, it's the name of the window function (e.g., `'hann'`)
         - If tuple, it's the name of the window function and any parameters
           (e.g., `('kaiser', 4.0)`)
+        - If numeric, it is treated as the beta parameter of the `'kaiser'`
+          window.
         - If callable, it's a function that accepts one integer argument
           (the window length)
         - If list-like, it's a pre-computed window of the correct length `Nx`
@@ -780,7 +782,7 @@ def get_window(window, Nx, fftbins=True):
 
     fftbins : bool, optional
         If True (default), create a periodic window for use with FFT
-        If False, create a symmetric window for use with filter design
+        If False, create a symmetric window for filter design applications.
 
     Returns
     -------
@@ -800,13 +802,16 @@ def get_window(window, Nx, fftbins=True):
     if six.callable(window):
         return window(Nx)
 
-    elif isinstance(window, (str, tuple)):
+    elif (isinstance(window, (six.string_types, tuple)) or
+          np.isscalar(window)):
         # TODO: if we add custom window functions in librosa, call them here
 
         return scipy.signal.get_window(window, Nx, fftbins=fftbins)
+
     elif isinstance(window, (np.ndarray, list)):
         if len(window) == Nx:
             return np.asarray(window)
+
         raise ParameterError('Window size mismatch: '
                              '{:d} != {:d}'.format(len(window), Nx))
     else:

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -756,6 +756,7 @@ def window_bandwidth(window, default=1.0):
     return WINDOW_BANDWIDTHS.get(key, default)
 
 
+@cache(level=10)
 def get_window(window, Nx, fftbins=True):
     '''Compute a window function
 

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -793,6 +793,10 @@ def get_window(window, Nx, fftbins=True):
     --------
     scipy.signal.get_window
 
+    Notes
+    -----
+    This function caches at level 10.
+
     Raises
     ------
     ParameterError

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -758,7 +758,10 @@ def window_bandwidth(window, default=1.0):
 
 @cache(level=10)
 def get_window(window, Nx, fftbins=True):
-    '''Compute a window function
+    '''Compute a window function.
+
+    This is a wrapper for `scipy.signal.get_window` that additionally
+    supports callable or pre-computed windows.
 
     Parameters
     ----------
@@ -798,7 +801,7 @@ def get_window(window, Nx, fftbins=True):
         return window(Nx)
 
     elif isinstance(window, (str, tuple)):
-        # TODO: if we add more window functions, put that index check here
+        # TODO: if we add custom window functions in librosa, call them here
 
         return scipy.signal.get_window(window, Nx, fftbins=fftbins)
     elif isinstance(window, (np.ndarray, list)):

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -19,7 +19,6 @@ Window functions
 .. autosummary::
     :toctree: generated/
 
-    hann_asym
     window_bandwidth
     get_window
 
@@ -57,8 +56,7 @@ __all__ = ['dct',
            'constant_q_lengths',
            'cq_to_chroma',
            'window_bandwidth',
-           'get_window',
-           'hann_asym']
+           'get_window']
 
 
 @cache(level=10)
@@ -809,24 +807,3 @@ def get_window(window, Nx, fftbins=True):
                              '{:d} != {:d}'.format(len(window), Nx))
     else:
         raise ParameterError('Invalid window specification: {}'.format(window))
-
-
-# -- Window functions
-def hann_asym(n):
-    '''Returns an asymmetric Hann window.
-
-    Parameters
-    ----------
-    n : int > 0
-        The length of the window
-
-    Returns
-    -------
-    window : np.ndarray
-        The window of length `n`
-
-    See Also
-    --------
-    scipy.signal.hann
-    '''
-    return scipy.signal.hann(n, sym=False)

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -772,7 +772,7 @@ def get_window(window, Nx, fftbins=True):
         - If tuple, it's the name of the window function and any parameters
           (e.g., `('kaiser', 4.0)`)
         - If numeric, it is treated as the beta parameter of the `'kaiser'`
-          window.
+          window, as in `scipy.signal.get_window`.
         - If callable, it's a function that accepts one integer argument
           (the window length)
         - If list-like, it's a pre-computed window of the correct length `Nx`

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -182,7 +182,7 @@ def test_stft():
             win_length = None
 
         else:
-            window = None
+            window = 'hann'
             win_length = DATA['hann_w'][0, 0]
 
         # Compute the STFT

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -475,11 +475,11 @@ def test_tempogram_fail():
     y = np.zeros(duration * sr)
 
     # Fail when no input is provided
-    yield __test, None, sr, None, hop_length, 384, True, None, np.inf
+    yield __test, None, sr, None, hop_length, 384, True, 'hann', np.inf
 
     # Fail when win_length is too small
     for win_length in [-384, -1, 0]:
-        yield __test, y, sr, None, hop_length, win_length, True, None, np.inf
+        yield __test, y, sr, None, hop_length, win_length, True, 'hann', np.inf
 
     # Fail when len(window) != win_length
     yield __test, y, sr, None, hop_length, 384, True, np.ones(win_length + 1), np.inf
@@ -580,7 +580,7 @@ def test_tempogram_odf():
             yield __test_equiv, tempo, center
 
         for win_length in [192, 384]:
-            for window in [None, np.ones, np.ones(win_length)]:
+            for window in ['hann', np.ones, np.ones(win_length)]:
                 for norm in [None, 1, 2, np.inf]:
                     yield __test_peaks, tempo, win_length, window, norm
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -317,15 +317,20 @@ def test_cq_to_chroma():
                                    n_chroma, fmin, base_c, window)
 
 
-def test_get_window_tuple():
-
-    x1 = scipy.signal.get_window(('kaiser', 4.0), 32)
-    x2 = librosa.filters.get_window(('kaiser', 4.0), 32)
-
-    assert np.allclose(x1, x2)
-
-
 @raises(librosa.ParameterError)
 def test_get_window_fail():
 
     librosa.filters.get_window(None, 32)
+
+
+def test_get_window():
+
+    def __test(window):
+
+        w1 = librosa.filters.get_window(window, 32)
+        w2 = scipy.signal.get_window(window, 32)
+
+        assert np.allclose(w1, w2)
+
+    for window in ['hann', u'hann', 4.0, ('kaiser', 4.0)]:
+        yield __test, window

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -315,3 +315,17 @@ def test_cq_to_chroma():
                                 tf = __test
                             yield (tf, n_bins, bins_per_octave,
                                    n_chroma, fmin, base_c, window)
+
+
+def test_get_window_tuple():
+
+    x1 = scipy.signal.get_window(('kaiser', 4.0), 32)
+    x2 = librosa.filters.get_window(('kaiser', 4.0), 32)
+
+    assert np.allclose(x1, x2)
+
+
+@raises(librosa.ParameterError)
+def test_get_window_fail():
+
+    librosa.filters.get_window(None, 32)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -336,6 +336,13 @@ def test_get_window():
         yield __test, window
 
 
+def test_get_window_func():
+
+    w1 = librosa.filters.get_window(scipy.signal.boxcar, 32)
+    w2 = scipy.signal.get_window('boxcar', 32)
+    assert np.allclose(w1, w2)
+
+
 def test_get_window_pre():
 
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -334,3 +334,17 @@ def test_get_window():
 
     for window in ['hann', u'hann', 4.0, ('kaiser', 4.0)]:
         yield __test, window
+
+
+def test_get_window_pre():
+
+
+    def __test(pre_win):
+        win = librosa.filters.get_window(pre_win, len(pre_win))
+        assert np.allclose(win, pre_win)
+
+
+    yield __test, scipy.signal.hann(16)
+    yield __test, list(scipy.signal.hann(16))
+    yield __test, [1, 1, 1]
+


### PR DESCRIPTION
Toward implementing #399.

This PR adds the following:

- `filters.get_window` -- a wrapper for `scipy.signal.get_window` that can handle generic callables, ndarrays, and any additional window functions we want to add (eg asymmetric triangles)
- `stft, istft, ifgram, tempogram` support for tuple windows via the above functionality
- removed `window=None` support from stft &co, since string identifiers are now valid. This breaks API.
- all `get_window` calls from stft-like ops are now explicitly `fftbins=True` (`sym=False`).  This breaks previous behavior, but is the right thing to do.  Symmetric windows can still be computed explicitly and passed as window vectors, so there's no loss in functionality.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/413)
<!-- Reviewable:end -->
