### PR TITLE
write_wav only normalizes on floating point data

### DIFF
--- a/librosa/output.py
+++ b/librosa/output.py
@@ -198,7 +198,8 @@ def write_wav(path, y, sr, norm=False):
         sampling rate of `y`
 
     norm : boolean [scalar]
-        enable amplitude normalization
+        enable amplitude normalization.
+        For floating point `y`, scale the data to the range [-1, +1].
 
     Examples
     --------

--- a/librosa/output.py
+++ b/librosa/output.py
@@ -183,7 +183,7 @@ def times_csv(path, times, annotations=None, delimiter=',', fmt='%0.3f'):
                 writer.writerow([(fmt % t), lab])
 
 
-def write_wav(path, y, sr, norm=True):
+def write_wav(path, y, sr, norm=False):
     """Output a time series as a .wav file
 
     Parameters
@@ -214,7 +214,7 @@ def write_wav(path, y, sr, norm=True):
     util.valid_audio(y, mono=False)
 
     # normalize
-    if norm:
+    if norm and np.issubdtype(y.dtype, np.float):
         wav = util.normalize(y, norm=np.inf, axis=None)
     else:
         wav = y


### PR DESCRIPTION
Fixes #415 .

For now, this does not deprecate `write_wav`, as the IO question is a broader discussion.

Changes here:

- write_wav only normalizes floating point waveforms
- normalization is disabled by default

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/416)
<!-- Reviewable:end -->
