### PR TITLE
CQT length scale normalization

### DIFF
--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -22,7 +22,7 @@ __all__ = ['cqt', 'hybrid_cqt', 'pseudo_cqt']
 def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
         bins_per_octave=12, tuning=None, filter_scale=1,
         norm=1, sparsity=0.01, window='hann',
-        scale=True,
+        scale=False,
         real=util.Deprecated()):
     '''Compute the constant-Q transform of an audio signal.
 
@@ -264,7 +264,7 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
 @cache(level=20)
 def hybrid_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
                bins_per_octave=12, tuning=None, filter_scale=1,
-               norm=1, sparsity=0.01, window='hann', scale=True):
+               norm=1, sparsity=0.01, window='hann', scale=False):
     '''Compute the hybrid constant-Q transform of an audio signal.
 
     Here, the hybrid CQT uses the pseudo CQT for higher frequencies where

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -180,7 +180,7 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
     y, sr, hop_length = __early_downsample(y, sr, hop_length,
                                            res_type,
                                            n_octaves,
-                                           nyquist, filter_cutoff)
+                                           nyquist, filter_cutoff, scale)
 
     cqt_resp = []
 
@@ -573,7 +573,7 @@ def __early_downsample_count(nyquist, filter_cutoff, hop_length, n_octaves):
 
 
 def __early_downsample(y, sr, hop_length, res_type, n_octaves,
-                       nyquist, filter_cutoff):
+                       nyquist, filter_cutoff, scale):
     '''Perform early downsampling on an audio signal, if it applies.'''
 
     downsample_count = __early_downsample_count(nyquist, filter_cutoff,
@@ -589,10 +589,15 @@ def __early_downsample(y, sr, hop_length, res_type, n_octaves,
                                  '{:d}-octave CQT'.format(len(y), n_octaves))
 
         new_sr = sr / float(downsample_factor)
-        y = audio.resample(y, sr,
-                           new_sr,
+        y = audio.resample(y, sr, new_sr,
                            res_type=res_type,
                            scale=True)
+
+        # If we're not going to length-scale after CQT, we
+        # need to compensate for the downsampling factor here
+        if not scale:
+            y *= np.sqrt(downsample_factor)
+
         sr = new_sr
 
     return y, sr, hop_length

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -563,8 +563,8 @@ def __cqt_response(y, n_fft, hop_length, fft_basis):
 def __early_downsample_count(nyquist, filter_cutoff, hop_length, n_octaves):
     '''Compute the number of early downsampling operations'''
 
-    downsample_count1 = int(np.ceil(np.log2(audio.BW_FASTEST * nyquist /
-                                            filter_cutoff)) - 1)
+    downsample_count1 = max(0, int(np.ceil(np.log2(audio.BW_FASTEST * nyquist /
+                                                   filter_cutoff)) - 1) - 1)
 
     num_twos = __num_two_factors(hop_length)
     downsample_count2 = max(0, num_twos - n_octaves + 1)

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -22,7 +22,7 @@ __all__ = ['cqt', 'hybrid_cqt', 'pseudo_cqt']
 def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
         bins_per_octave=12, tuning=None, filter_scale=1,
         norm=1, sparsity=0.01, window='hann',
-        scale=False,
+        scale=True,
         real=util.Deprecated()):
     '''Compute the constant-Q transform of an audio signal.
 
@@ -264,7 +264,7 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
 @cache(level=20)
 def hybrid_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
                bins_per_octave=12, tuning=None, filter_scale=1,
-               norm=1, sparsity=0.01, window='hann', scale=False):
+               norm=1, sparsity=0.01, window='hann', scale=True):
     '''Compute the hybrid constant-Q transform of an audio signal.
 
     Here, the hybrid CQT uses the pseudo CQT for higher frequencies where
@@ -397,7 +397,7 @@ def hybrid_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
 @cache(level=20)
 def pseudo_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
                bins_per_octave=12, tuning=None, filter_scale=1,
-               norm=1, sparsity=0.01, window='hann', scale=False):
+               norm=1, sparsity=0.01, window='hann', scale=True):
     '''Compute the pseudo constant-Q transform of an audio signal.
 
     This uses a single fft size that is the smallest power of 2 that is greater

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -300,6 +300,6 @@ def test_hcqt_white_noise():
 
         for scale in [False, True]:
             for fmin in librosa.note_to_hz(['C1', 'C2']):
-                for n_octaves in range(2, 4):
+                for n_octaves in [6, 7]:
                     yield __test, fmin, n_octaves * 12, scale, sr, y
 

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -247,3 +247,57 @@ def test_hybrid_cqt_scale():
             center = int((len(x) / (2.0 * float(hop_length))) * hop_length)
             x[center] = 1
             yield __test, sr, hop_length, x
+
+
+def test_cqt_white_noise():
+
+    def __test(fmin, n_bins, scale, sr, y):
+
+        C = np.abs(librosa.cqt(y=y, sr=sr,
+                               fmin=fmin,
+                               n_bins=n_bins,
+                               scale=scale,
+                               real=False))
+
+        if not scale:
+            lengths = librosa.filters.constant_q_lengths(sr, fmin,
+                                                         n_bins=n_bins)
+            C /= np.sqrt(lengths[:, np.newaxis])
+
+        assert np.isclose(np.mean(C), 1, atol=2e-1), np.mean(C)
+        assert np.isclose(np.std(C), 0.5, atol=5e-1), np.std(C)
+
+    for sr in [22050, 44100]:
+        y = np.random.randn(10 * sr)
+
+        for scale in [False, True]:
+            for fmin in librosa.note_to_hz(['C0', 'C1', 'C2']):
+                for n_octaves in range(1, 5):
+                    yield __test, fmin, n_octaves * 12, scale, sr, y
+
+
+def test_hcqt_white_noise():
+
+    def __test(fmin, n_bins, scale, sr, y):
+
+        C = librosa.hybrid_cqt(y=y, sr=sr,
+                               fmin=fmin,
+                               n_bins=n_bins,
+                               scale=scale)
+
+        if not scale:
+            lengths = librosa.filters.constant_q_lengths(sr, fmin,
+                                                         n_bins=n_bins)
+            C /= np.sqrt(lengths[:, np.newaxis])
+
+        assert np.isclose(np.mean(C), 1, atol=2e-1), np.mean(C)
+        assert np.isclose(np.std(C), 0.5, atol=5e-1), np.std(C)
+
+    for sr in [22050, 44100]:
+        y = np.random.randn(10 * sr)
+
+        for scale in [False, True]:
+            for fmin in librosa.note_to_hz(['C0', 'C1', 'C2']):
+                for n_octaves in range(1, 5):
+                    yield __test, fmin, n_octaves * 12, scale, sr, y
+

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -245,6 +245,6 @@ def test_hybrid_cqt_scale():
         for hop_scale in range(1, 9):
             hop_length = 64 * hop_scale
             # Center the impulse response on a frame
-            center = (len(x) / (2 * float(hop_length))) * hop_length
+            center = (len(x) // (2 * float(hop_length))) * hop_length
             x[center] = 1
             yield __test, sr, hop_length, x

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -187,7 +187,7 @@ def test_cqt_fail_short_early():
 @raises(librosa.ParameterError)
 def test_cqt_fail_short_late():
 
-    y = np.zeros(64)
+    y = np.zeros(16)
     librosa.cqt(y, sr=22050, real=False)
 
 def test_cqt_impulse():
@@ -197,7 +197,6 @@ def test_cqt_impulse():
         C = np.abs(librosa.cqt(y=y, sr=sr, hop_length=hop_length, real=False))
 
         max_response = np.max(C, axis=1)
-
 
         ref_response = np.max(max_response)
         continuity = np.abs(np.diff(max_response))
@@ -215,7 +214,7 @@ def test_cqt_impulse():
         for hop_scale in range(1, 9):
             hop_length = 64 * hop_scale
             # Center the impulse response on a frame
-            center = (len(x) / (2 * float(hop_length))) * hop_length
+            center = int((len(x) / (2.0 * float(hop_length))) * hop_length)
             x[center] = 1
             yield __test, sr, hop_length, x
 
@@ -245,6 +244,6 @@ def test_hybrid_cqt_scale():
         for hop_scale in range(1, 9):
             hop_length = 64 * hop_scale
             # Center the impulse response on a frame
-            center = (len(x) // (2 * float(hop_length))) * hop_length
+            center = int((len(x) / (2.0 * float(hop_length))) * hop_length)
             x[center] = 1
             yield __test, sr, hop_length, x

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -264,15 +264,17 @@ def test_cqt_white_noise():
                                                          n_bins=n_bins)
             C /= np.sqrt(lengths[:, np.newaxis])
 
-        assert np.isclose(np.mean(C), 1, atol=2e-1), np.mean(C)
-        assert np.isclose(np.std(C), 0.5, atol=5e-1), np.std(C)
+        # Only compare statistics across the time dimension
+        # we want ~ constant mean and variance across frequencies
+        assert np.allclose(np.mean(C, axis=1), 1.0, atol=2.5e-1), np.mean(C, axis=1)
+        assert np.allclose(np.std(C, axis=1), 0.5, atol=5e-1), np.std(C, axis=1)
 
-    for sr in [22050, 44100]:
-        y = np.random.randn(10 * sr)
+    for sr in [22050]:
+        y = np.random.randn(30 * sr)
 
         for scale in [False, True]:
-            for fmin in librosa.note_to_hz(['C0', 'C1', 'C2']):
-                for n_octaves in range(1, 5):
+            for fmin in librosa.note_to_hz(['C1', 'C2']):
+                for n_octaves in range(2, 4):
                     yield __test, fmin, n_octaves * 12, scale, sr, y
 
 
@@ -290,14 +292,14 @@ def test_hcqt_white_noise():
                                                          n_bins=n_bins)
             C /= np.sqrt(lengths[:, np.newaxis])
 
-        assert np.isclose(np.mean(C), 1, atol=2e-1), np.mean(C)
-        assert np.isclose(np.std(C), 0.5, atol=5e-1), np.std(C)
+        assert np.allclose(np.mean(C, axis=1), 1.0, atol=2.5e-1), np.mean(C, axis=1)
+        assert np.allclose(np.std(C, axis=1), 0.5, atol=5e-1), np.std(C, axis=1)
 
-    for sr in [22050, 44100]:
-        y = np.random.randn(10 * sr)
+    for sr in [22050]:
+        y = np.random.randn(30 * sr)
 
         for scale in [False, True]:
-            for fmin in librosa.note_to_hz(['C0', 'C1', 'C2']):
-                for n_octaves in range(1, 5):
+            for fmin in librosa.note_to_hz(['C1', 'C2']):
+                for n_octaves in range(2, 4):
                     yield __test, fmin, n_octaves * 12, scale, sr, y
 


### PR DESCRIPTION
This PR implements #412, and a couple of bug-fixes.  Summary of contents:

- Added a `scale` boolean option to all CQT methods.  If enabled, CQT bands are normalized by `sqrt(n[i])` where `n[i]` is the length of the `i`th filter.  This is analogous to `norm='ortho'` mode in `np.fft.fft`.
- Early downsampling is less aggressive by one octave.  Previously, it was too aggressive, and the top-end of each octave was close to nyquist, which resulted in attenuation.
- Magnitude is now continuous and approximately equal for full, hybrid, and pseudo CQT.  This fixes some of the unresolved continuity errors noted in #347.
- Expanded the CQT unit tests to include a white noise continuity test.


Using `scale=True` means that white noise input will look like white noise output in CQT space (flat spectrum).  With `scale=False` (current default), white noise in looks like `1/sqrt(f)`.

`scale=True` makes an impulse look like `sqrt(f)` as opposed to constant for `scale=False`.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/417)
<!-- Reviewable:end -->
