### PR TITLE
fixed a bug in feature.rmse time-domain

### DIFF
--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -496,12 +496,12 @@ def spectral_rolloff(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
 
 
 def rmse(y=None, S=None, n_fft=2048, hop_length=512):
-    '''Compute root-mean-square (RMS) energy for each frame, either from the 
+    '''Compute root-mean-square (RMS) energy for each frame, either from the
     audio samples `y` or from a spectrogram `S`.
-    
-    Computing the energy from audio samples is faster as it doesn't require a 
-    STFT calculation. However, using a spectrogram will give a more accurate 
-    representation of energy over time because its frames can be windowed, 
+
+    Computing the energy from audio samples is faster as it doesn't require a
+    STFT calculation. However, using a spectrogram will give a more accurate
+    representation of energy over time because its frames can be windowed,
     thus prefer using `S` if it's already available.
 
 
@@ -527,7 +527,7 @@ def rmse(y=None, S=None, n_fft=2048, hop_length=512):
 
 
     Examples
-    --------    
+    --------
     >>> y, sr = librosa.load(librosa.util.example_audio_file())
     >>> librosa.feature.rmse(y=y)
     array([[ 0.   ,  0.056, ...,  0.   ,  0.   ]], dtype=float32)
@@ -549,22 +549,21 @@ def rmse(y=None, S=None, n_fft=2048, hop_length=512):
     ...                          y_axis='log', x_axis='time')
     >>> plt.title('log Power spectrogram')
     >>> plt.tight_layout()
-    
-    Use a STFT window of constant ones and no frame centering to get consistent 
+
+    Use a STFT window of constant ones and no frame centering to get consistent
     results with the RMS energy computed from the audio samples `y`
-    
+
     >>> S = librosa.magphase(librosa.stft(y, window=np.ones, center=False)[0]
     >>> librosa.feature.rmse(S=S)
-    
 
     '''
     if y is not None and S is not None:
         raise ValueError('Either `y` or `S` should be input.')
     if y is not None:
-        x = util.frame(to_mono(y))
+        x = util.frame(to_mono(y), frame_length=n_fft, hop_length=hop_length)
     elif S is not None:
-        x, _ = _spectrogram(y=y, S=S, n_fft=n_fft, hop_length=hop_length)    
-    else: 
+        x, _ = _spectrogram(y=y, S=S, n_fft=n_fft, hop_length=hop_length)
+    else:
         raise ValueError('Either `y` or `S` must be input.')
     return np.sqrt(np.mean(np.abs(x)**2, axis=0, keepdims=True))
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -317,34 +317,36 @@ def test_rmse():
         rmse = librosa.feature.rmse(S=S)
 
         assert np.allclose(rmse, np.ones_like(rmse))
-        
-    def __test_consistency():
+
+    def __test_consistency(frame_length, hop_length):
         y, sr = librosa.load(__EXAMPLE_FILE, sr=None)
-        
+
         # Ensure audio is divisible into frame size.
-        frame_length = 2048
         y = librosa.util.fix_length(y, y.size - y.size % frame_length)
         assert y.size % frame_length == 0
-        
+
         # STFT magnitudes with a constant windowing function and no centering.
-        S = librosa.magphase(librosa.stft(y, 
+        S = librosa.magphase(librosa.stft(y,
                                           n_fft=frame_length,
-                                          window=np.ones, 
+                                          hop_length=hop_length,
+                                          window=np.ones,
                                           center=False))[0]
-                                          
+
         # Try both RMS methods.
-        rms1 = librosa.feature.rmse(S=S)
-        rms2 = librosa.feature.rmse(y=y)
+        rms1 = librosa.feature.rmse(S=S, n_fft=frame_length, hop_length=hop_length)
+        rms2 = librosa.feature.rmse(y=y, n_fft=frame_length, hop_length=hop_length)
 
         # Normalize envelopes.
         rms1 /= rms1.max()
         rms2 /= rms2.max()
-        
+
         # Ensure results are similar.
         np.testing.assert_allclose(rms1, rms2, rtol=1e-2)
 
-    yield __test_consistency
-    
+    for n_fft in [2048, 4096]:
+        for hop_length in [128, 512, 1024]:
+            yield __test_consistency, n_fft, hop_length
+
     for n in range(10, 100, 10):
         yield __test, n
 


### PR DESCRIPTION
This PR fixes a bug introduced in #407 where the `hop_length` and `frame_lenth` parameters were not propagated from `rmse` to `frame`.

It also adds expands test coverage to hit the failure case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/429)
<!-- Reviewable:end -->
