### PR TITLE
throw error in load function if file does not exist

### DIFF
--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -91,6 +91,8 @@ def load(path, sr=22050, mono=True, offset=0.0, duration=None,
     22050
 
     """
+    if not os.path.exists(os.path.realpath(path)):
+        raise IOError("path does not exist")
 
     y = []
     with audioread.audio_open(os.path.realpath(path)) as input_file:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -55,7 +55,6 @@ def test_load():
         yield (__test, infile)
     pass
 
-
 def test_segment_load():
 
     sample_len = 2003
@@ -77,6 +76,20 @@ def test_segment_load():
 
     y2, sr = librosa.load(test_file, sr=None, mono=False)
     assert np.allclose(y, y2[:, sample_offset:sample_offset+fs])
+
+
+def test_load_fail():
+    
+    @raises(IOError)
+    def __test(path):
+        librosa.load(path)
+
+    test_file_nonexistent = 'data/this_does_not_exist.wav'
+    paths = [test_file_nonexistent]
+
+    # Test for nonexistent files
+    for path in paths:
+        yield __test, path
 
 
 def test_resample_mono():


### PR DESCRIPTION
This is nit picky, but currently, if `librosa.load(path)` is called and `path` doesn't exist, you get the following traceback:

```python
librosa.load('asdf.wav')
---------------------------------------------------------------------------
IOError                                   Traceback (most recent call last)
<ipython-input-2-af865b77399f> in <module>()
----> 1 librosa.load('asdf.wav')

...librosa/core/audio.pyc in load(path, sr, mono, offset, duration, dtype)
    107 
    108     y = []
--> 109     with audioread.audio_open(os.path.realpath(path)) as input_file:
    110         sr_native = input_file.samplerate
    111         n_channels = input_file.channels

/usr/local/lib/python2.7/site-packages/audioread/__init__.pyc in audio_open(path)
     76     from . import rawread
     77     try:
---> 78         return rawread.RawAudioFile(path)
     79     except DecodeError:
     80         pass

/usr/local/lib/python2.7/site-packages/audioread/rawread.pyc in __init__(self, filename)
     47     """
     48     def __init__(self, filename):
---> 49         self._fh = open(filename, 'rb')
     50 
     51         try:

IOError: [Errno 2] No such file or directory: '/Users/rabitt/asdf.wav'
```

This PR adds a line at the beginning of the `librosa.load` function that checks if the file exists, so the traceback is more straightforward:

```python
librosa.load('asdf.wav')
---------------------------------------------------------------------------
IOError                                   Traceback (most recent call last)
<ipython-input-2-1209205161ba> in <module>()
----> 1 librosa.load('asdf.wav')

...librosa/core/audio.py in load(path, sr, mono, offset, duration, dtype)
     93     """
     94     if not os.path.exists(os.path.realpath(path)):
---> 95         raise IOError("path does not exist")
     96 
     97     y = []

IOError: path does not exist
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/438)
<!-- Reviewable:end -->
