### PR TITLE
explicitly close file descriptors in output tests

### DIFF
--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -16,13 +16,15 @@ from nose.tools import raises, eq_
 
 from test_core import srand
 
+
 def test_write_wav():
 
     def __test(mono, norm):
 
         y, sr = librosa.load('data/test1_22050.wav', sr=None, mono=mono)
 
-        _, tfname = tempfile.mkstemp()
+        fdesc, tfname = tempfile.mkstemp()
+        os.close(fdesc)
 
         librosa.output.write_wav(tfname, y, sr, norm=norm)
 
@@ -50,7 +52,8 @@ def test_times_csv():
 
     def __test(times, annotations, sep):
 
-        _, tfname = tempfile.mkstemp()
+        fdesc, tfname = tempfile.mkstemp()
+        os.close(fdesc)
 
         # Dump to disk
         librosa.output.times_csv(tfname, times, annotations=annotations,
@@ -92,7 +95,8 @@ def test_annotation():
 
     def __test(times, annotations, sep):
 
-        _, tfname = tempfile.mkstemp()
+        fdesc, tfname = tempfile.mkstemp()
+        os.close(fdesc)
 
         # Dump to disk
         librosa.output.annotation(tfname, times, annotations=annotations,


### PR DESCRIPTION
Toward fixing #447

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/451)
<!-- Reviewable:end -->
