### PR TITLE
float_window always uses integer length now for forward scipy compatibility

### DIFF
--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -391,7 +391,7 @@ def __float_window(window_spec):
         '''The wrapped window'''
         n_min, n_max = int(np.floor(n)), int(np.ceil(n))
 
-        window = get_window(window_spec, n)
+        window = get_window(window_spec, n_min)
 
         if len(window) < n_max:
             window = np.pad(window, [(0, n_max - len(window))],


### PR DESCRIPTION
Resolves #449

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/452)
<!-- Reviewable:end -->
