### PR TITLE
db to/from amplitude and power

### DIFF
--- a/librosa/core/__init__.py
+++ b/librosa/core/__init__.py
@@ -31,11 +31,22 @@ Spectral representations
     fmt
 
     interp_harmonics
+    salience
 
     phase_vocoder
-
     magphase
+
+Magnitude scaling
+-----------------
+.. autosummary::
+    :toctree: generated/
+
     logamplitude
+    amplitude_to_db
+    db_to_amplitude
+    power_to_db
+    db_to_power
+
     perceptual_weighting
     A_weighting
 
@@ -84,10 +95,7 @@ Dynamic Time Warping
     :toctree: generated/
 
     dtw
-    calc_accu_cost
-    backtracking
     band_mask
-
 """
 
 from .time_frequency import *  # pylint: disable=wildcard-import

--- a/librosa/core/__init__.py
+++ b/librosa/core/__init__.py
@@ -95,7 +95,6 @@ Dynamic Time Warping
     :toctree: generated/
 
     dtw
-    band_mask
 """
 
 from .time_frequency import *  # pylint: disable=wildcard-import

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -627,7 +627,7 @@ def clicks(times=None, frames=None, sr=22050, hop_length=512,
     >>> plt.figure()
     >>> S = librosa.feature.melspectrogram(y=y, sr=sr)
     >>> ax = plt.subplot(2,1,2)
-    >>> librosa.display.specshow(librosa.logamplitude(S, ref_power=np.max),
+    >>> librosa.display.specshow(librosa.power_to_db(S, ref=np.max),
     ...                          x_axis='time', y_axis='mel')
     >>> plt.subplot(2,1,1, sharex=ax)
     >>> librosa.display.waveplot(y_beat_times, sr=sr, label='Beat clicks')

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -117,7 +117,7 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
     >>> import matplotlib.pyplot as plt
     >>> y, sr = librosa.load(librosa.util.example_audio_file())
     >>> C = librosa.cqt(y, sr=sr)
-    >>> librosa.display.specshow(librosa.logamplitude(C**2, ref_power=np.max),
+    >>> librosa.display.specshow(librosa.amplitude_to_db(C, ref=np.max),
     ...                          sr=sr, x_axis='time', y_axis='cqt_note')
     >>> plt.colorbar(format='%+2.0f dB')
     >>> plt.title('Constant-Q power spectrum')

--- a/librosa/core/harmonic.py
+++ b/librosa/core/harmonic.py
@@ -71,8 +71,8 @@ def salience(S, freqs, h_range, weights=None, aggregate=None,
     (1025, 646)
     >>> import matplotlib.pyplot as plt
     >>> plt.figure()
-    >>> librosa.display.specshow(librosa.logamplitude(S_sal**2,
-    ...                                               ref_power=S_sal.max()*2),
+    >>> librosa.display.specshow(librosa.amplitude_to_db(S_sal,
+    ...                                                  ref=np.max),
     ...                          sr=sr, y_axis='log')
     >>> plt.tight_layout()
     """
@@ -185,8 +185,8 @@ def interp_harmonics(x, freqs, h_range, kind='linear', fill_value=0, axis=0):
     >>> plt.figure()
     >>> for i, _sh in enumerate(S_harm, 1):
     ...     plt.subplot(3, 2, i)
-    ...     librosa.display.specshow(librosa.logamplitude(_sh**2,
-    ...                                                   ref_power=S.max()**2),
+    ...     librosa.display.specshow(librosa.amplitude_to_db(_sh,
+    ...                                                      ref=S.max()),
     ...                              sr=sr, y_axis='log')
     ...     plt.title('h={:.3g}'.format(h_range[i-1]))
     ...     plt.yticks([])
@@ -292,8 +292,8 @@ def harmonics_1d(harmonic_out, x, freqs, h_range, kind='linear',
     >>> plt.figure()
     >>> for i, _sh in enumerate(S_harm, 1):
     ...     plt.subplot(3,2,i)
-    ...     librosa.display.specshow(librosa.logamplitude(_sh**2,
-    ...                                                   ref_power=S.max()**2),
+    ...     librosa.display.specshow(librosa.amplitude_to_db(_sh,
+    ...                                                      ref=S.max()),
     ...                              sr=sr, y_axis='log')
     ...     plt.title('h={:.3g}'.format(h_range[i-1]))
     ...     plt.yticks([])

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -601,10 +601,10 @@ def power_to_db(S, ref=1.0, amin=1e-10, top_db=80.0, ref_power=Deprecated()):
 
     ref : scalar or callable
         If scalar, the amplitude `abs(S)` is scaled relative to `ref`:
-        `log10(abs(S) / ref)`.
+        `10 * log10(S / ref)`.
         Zeros in the output correspond to positions where `S == ref`.
 
-        If callable, the reference value is computed as `ref(abs(S))`.
+        If callable, the reference value is computed as `ref(S)`.
 
     amin : float > 0 [scalar]
         minimum threshold for `abs(S)` and `ref`
@@ -621,7 +621,7 @@ def power_to_db(S, ref=1.0, amin=1e-10, top_db=80.0, ref_power=Deprecated()):
     Returns
     -------
     S_db   : np.ndarray
-        ``S_db ~= 10 * log10(abs(S)) - 10 * log10(abs(ref))``
+        ``S_db ~= 10 * log10(S) - 10 * log10(ref)``
 
     See Also
     --------
@@ -755,17 +755,17 @@ def amplitude_to_db(S, ref=1.0, amin=1e-5, top_db=80.0):
 
     ref : scalar or callable
         If scalar, the amplitude `abs(S)` is scaled relative to `ref`:
-        `log10(abs(S) / ref)`.
+        `20 * log10(S / ref)`.
         Zeros in the output correspond to positions where `S == ref`.
 
-        If callable, the reference value is computed as `ref(abs(S))`.
+        If callable, the reference value is computed as `ref(S)`.
 
     amin : float > 0 [scalar]
-        minimum threshold for `abs(S)` and `ref`
+        minimum threshold for `S` and `ref`
 
     top_db : float >= 0 [scalar]
         threshold the output at `top_db` below the peak:
-        ``max(10 * log10(S)) - top_db``
+        ``max(20 * log10(S)) - top_db``
 
 
     Returns

--- a/librosa/decompose.py
+++ b/librosa/decompose.py
@@ -137,14 +137,15 @@ def decompose(S, n_components=None, transformer=None, sort=False, fit=True, **kw
     >>> import matplotlib.pyplot as plt
     >>> plt.figure(figsize=(10,8))
     >>> plt.subplot(3, 1, 1)
-    >>> librosa.display.specshow(librosa.logamplitude(S**2,
-    ...                                               ref_power=np.max),
+    >>> librosa.display.specshow(librosa.amplitude_to_db(S,
+    ...                                                  ref=np.max),
     ...                          y_axis='log', x_axis='time')
     >>> plt.title('Input spectrogram')
     >>> plt.colorbar(format='%+2.0f dB')
     >>> plt.subplot(3, 2, 3)
-    >>> librosa.display.specshow(librosa.logamplitude(comps**2,
-    ...                          ref_power=np.max), y_axis='log')
+    >>> librosa.display.specshow(librosa.amplitude_to_db(comps,
+    ...                                                  ref=np.max),
+    ...                          y_axis='log')
     >>> plt.colorbar(format='%+2.0f dB')
     >>> plt.title('Components')
     >>> plt.subplot(3, 2, 4)
@@ -154,8 +155,8 @@ def decompose(S, n_components=None, transformer=None, sort=False, fit=True, **kw
     >>> plt.colorbar()
     >>> plt.subplot(3, 1, 3)
     >>> S_approx = comps.dot(acts)
-    >>> librosa.display.specshow(librosa.logamplitude(S_approx**2,
-    ...                                               ref_power=np.max),
+    >>> librosa.display.specshow(librosa.amplitude_to_db(S_approx,
+    ...                                                  ref=np.max),
     ...                          y_axis='log', x_axis='time')
     >>> plt.colorbar(format='%+2.0f dB')
     >>> plt.title('Reconstructed spectrogram')
@@ -272,20 +273,20 @@ def hpss(S, kernel_size=31, power=2.0, mask=False, margin=1.0):
     >>> import matplotlib.pyplot as plt
     >>> plt.figure()
     >>> plt.subplot(3, 1, 1)
-    >>> librosa.display.specshow(librosa.logamplitude(np.abs(D)**2,
-    ...                                               ref_power=np.max),
+    >>> librosa.display.specshow(librosa.amplitude_to_db(D,
+    ...                                                  ref=np.max),
     ...                          y_axis='log')
     >>> plt.colorbar(format='%+2.0f dB')
     >>> plt.title('Full power spectrogram')
     >>> plt.subplot(3, 1, 2)
-    >>> librosa.display.specshow(librosa.logamplitude(np.abs(H)**2,
-    ...                          ref_power=np.max),
+    >>> librosa.display.specshow(librosa.amplitude_to_db(H,
+    ...                                                  ref=np.max),
     ...                          y_axis='log')
     >>> plt.colorbar(format='%+2.0f dB')
     >>> plt.title('Harmonic power spectrogram')
     >>> plt.subplot(3, 1, 3)
-    >>> librosa.display.specshow(librosa.logamplitude(np.abs(P)**2,
-    ...                          ref_power=np.max),
+    >>> librosa.display.specshow(librosa.amplitude_to_db(P,
+    ...                                                  ref=np.max),
     ...                          y_axis='log')
     >>> plt.colorbar(format='%+2.0f dB')
     >>> plt.title('Percussive power spectrogram')

--- a/librosa/display.py
+++ b/librosa/display.py
@@ -492,7 +492,7 @@ def specshow(data, x_coords=None, y_coords=None,
     >>> y, sr = librosa.load(librosa.util.example_audio_file())
     >>> plt.figure(figsize=(12, 8))
 
-    >>> D = librosa.logamplitude(np.abs(librosa.stft(y))**2, ref_power=np.max)
+    >>> D = librosa.amplitude_to_db(librosa.stft(y), ref=np.max)
     >>> plt.subplot(4, 2, 1)
     >>> librosa.display.specshow(D, y_axis='linear')
     >>> plt.colorbar(format='%+2.0f dB')
@@ -509,7 +509,7 @@ def specshow(data, x_coords=None, y_coords=None,
 
     Or use a CQT scale
 
-    >>> CQT = librosa.logamplitude(librosa.cqt(y, sr=sr)**2, ref_power=np.max)
+    >>> CQT = librosa.amplitude_to_db(librosa.cqt(y, sr=sr), ref=np.max)
     >>> plt.subplot(4, 2, 3)
     >>> librosa.display.specshow(CQT, y_axis='cqt_note')
     >>> plt.colorbar(format='%+2.0f dB')

--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -380,7 +380,7 @@ def remix(y, intervals, align_zeros=True):
 
 
 def _signal_to_frame_nonsilent(y, frame_length=2048, hop_length=512, top_db=60,
-                               ref_power=np.max):
+                               ref=np.max):
     '''Frame-wise non-silent indicator for audio input.
 
     This is a helper function for `trim` and `split`.
@@ -400,7 +400,7 @@ def _signal_to_frame_nonsilent(y, frame_length=2048, hop_length=512, top_db=60,
         The threshold (in decibels) below reference to consider as
         silence
 
-    ref_power : callable or float
+    ref : callable or float
         The reference power
 
     Returns
@@ -416,12 +416,12 @@ def _signal_to_frame_nonsilent(y, frame_length=2048, hop_length=512, top_db=60,
                        frame_length=frame_length,
                        hop_length=hop_length)**2
 
-    return (core.logamplitude(mse.squeeze(),
-                              ref_power=ref_power,
-                              top_db=None) > - top_db)
+    return (core.power_to_db(mse.squeeze(),
+                             ref=ref,
+                             top_db=None) > - top_db)
 
 
-def trim(y, top_db=60, ref_power=np.max, frame_length=2048, hop_length=512):
+def trim(y, top_db=60, ref=np.max, frame_length=2048, hop_length=512):
     '''Trim leading and trailing silence from an audio signal.
 
     Parameters
@@ -433,7 +433,7 @@ def trim(y, top_db=60, ref_power=np.max, frame_length=2048, hop_length=512):
         The threshold (in decibels) below reference to consider as
         silence
 
-    ref_power : number or callable
+    ref : number or callable
         The reference power.  By default, it uses `np.max` and compares
         to the peak power in the signal.
 
@@ -468,7 +468,7 @@ def trim(y, top_db=60, ref_power=np.max, frame_length=2048, hop_length=512):
     non_silent = _signal_to_frame_nonsilent(y,
                                             frame_length=frame_length,
                                             hop_length=hop_length,
-                                            ref_power=ref_power,
+                                            ref=ref,
                                             top_db=top_db)
 
     nonzero = np.flatnonzero(non_silent)
@@ -486,7 +486,7 @@ def trim(y, top_db=60, ref_power=np.max, frame_length=2048, hop_length=512):
     return y[full_index], np.asarray([start, end])
 
 
-def split(y, top_db=60, ref_power=np.max, frame_length=2048, hop_length=512):
+def split(y, top_db=60, ref=np.max, frame_length=2048, hop_length=512):
     '''Split an audio signal into non-silent intervals.
 
     Parameters
@@ -498,7 +498,7 @@ def split(y, top_db=60, ref_power=np.max, frame_length=2048, hop_length=512):
         The threshold (in decibels) below reference to consider as
         silence
 
-    ref_power : number or callable
+    ref : number or callable
         The reference power.  By default, it uses `np.max` and compares
         to the peak power in the signal.
 
@@ -518,7 +518,7 @@ def split(y, top_db=60, ref_power=np.max, frame_length=2048, hop_length=512):
     non_silent = _signal_to_frame_nonsilent(y,
                                             frame_length=frame_length,
                                             hop_length=hop_length,
-                                            ref_power=ref_power,
+                                            ref=ref,
                                             top_db=top_db)
 
     # Interval slicing, adapted from

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -13,7 +13,7 @@ from ..util.deprecation import Deprecated, rename_kw
 
 from ..core.time_frequency import fft_frequencies
 from ..core.audio import zero_crossings, to_mono
-from ..core.spectrum import logamplitude, _spectrogram
+from ..core.spectrum import power_to_db, _spectrogram
 from ..core.constantq import cqt, hybrid_cqt
 from ..core.pitch import estimate_tuning
 
@@ -112,7 +112,7 @@ def spectral_centroid(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
     >>> plt.xlim([0, cent.shape[-1]])
     >>> plt.legend()
     >>> plt.subplot(2, 1, 2)
-    >>> librosa.display.specshow(librosa.logamplitude(S**2, ref_power=np.max),
+    >>> librosa.display.specshow(librosa.amplitude_to_db(S, ref=np.max),
     ...                          y_axis='log', x_axis='time')
     >>> plt.title('log Power spectrogram')
     >>> plt.tight_layout()
@@ -217,7 +217,7 @@ def spectral_bandwidth(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
     >>> plt.xlim([0, spec_bw.shape[-1]])
     >>> plt.legend()
     >>> plt.subplot(2, 1, 2)
-    >>> librosa.display.specshow(librosa.logamplitude(S**2, ref_power=np.max),
+    >>> librosa.display.specshow(librosa.amplitude_to_db(S, ref=np.max),
     ...                          y_axis='log', x_axis='time')
     >>> plt.title('log Power spectrogram')
     >>> plt.tight_layout()
@@ -323,8 +323,8 @@ def spectral_contrast(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
     >>> import matplotlib.pyplot as plt
     >>> plt.figure()
     >>> plt.subplot(2, 1, 1)
-    >>> librosa.display.specshow(librosa.logamplitude(S ** 2,
-    ...                                               ref_power=np.max),
+    >>> librosa.display.specshow(librosa.amplitude_to_db(S,
+    ...                                                  ref=np.max),
     ...                          y_axis='log')
     >>> plt.colorbar(format='%+2.0f dB')
     >>> plt.title('Power spectrogram')
@@ -391,7 +391,7 @@ def spectral_contrast(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
     if linear:
         return peak - valley
     else:
-        return logamplitude(peak) - logamplitude(valley)
+        return power_to_db(peak) - power_to_db(valley)
 
 
 def spectral_rolloff(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
@@ -460,7 +460,7 @@ def spectral_rolloff(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
     >>> plt.xlim([0, rolloff.shape[-1]])
     >>> plt.legend()
     >>> plt.subplot(2, 1, 2)
-    >>> librosa.display.specshow(librosa.logamplitude(S**2, ref_power=np.max),
+    >>> librosa.display.specshow(librosa.amplitude_to_db(S, ref=np.max),
     ...                          y_axis='log', x_axis='time')
     >>> plt.title('log Power spectrogram')
     >>> plt.tight_layout()
@@ -551,7 +551,7 @@ def rmse(y=None, S=None, frame_length=2048, hop_length=512,
     >>> plt.xlim([0, rms.shape[-1]])
     >>> plt.legend(loc='best')
     >>> plt.subplot(2, 1, 2)
-    >>> librosa.display.specshow(librosa.logamplitude(S**2, ref_power=np.max),
+    >>> librosa.display.specshow(librosa.amplitude_to_db(S, ref=np.max),
     ...                          y_axis='log', x_axis='time')
     >>> plt.title('log Power spectrogram')
     >>> plt.tight_layout()
@@ -652,7 +652,7 @@ def poly_features(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
     >>> plt.colorbar()
     >>> plt.title('Quadratic coefficients')
     >>> plt.subplot(3, 1, 3)
-    >>> librosa.display.specshow(librosa.logamplitude(S**2, ref_power=np.max),
+    >>> librosa.display.specshow(librosa.amplitude_to_db(S, ref=np.max),
     ...                          y_axis='log', x_axis='time')
     >>> plt.title('log Power spectrogram')
     >>> plt.colorbar(format='%+2.0f dB')
@@ -1245,7 +1245,7 @@ def mfcc(y=None, sr=22050, S=None, n_mfcc=20, **kwargs):
 
     >>> S = librosa.feature.melspectrogram(y=y, sr=sr, n_mels=128,
     ...                                    fmax=8000)
-    >>> librosa.feature.mfcc(S=librosa.logamplitude(S))
+    >>> librosa.feature.mfcc(S=librosa.power_to_db(S))
     array([[ -5.207e+02,  -4.898e+02, ...,  -5.207e+02,  -5.207e+02],
            [ -2.576e-14,   4.054e+01, ...,  -3.997e-14,  -3.997e-14],
            ...,
@@ -1269,7 +1269,7 @@ def mfcc(y=None, sr=22050, S=None, n_mfcc=20, **kwargs):
     """
 
     if S is None:
-        S = logamplitude(melspectrogram(y=y, sr=sr, **kwargs))
+        S = power_to_db(melspectrogram(y=y, sr=sr, **kwargs))
 
     return np.dot(filters.dct(n_mfcc, S.shape[0]), S)
 
@@ -1335,8 +1335,8 @@ def melspectrogram(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
 
     >>> import matplotlib.pyplot as plt
     >>> plt.figure(figsize=(10, 4))
-    >>> librosa.display.specshow(librosa.logamplitude(S,
-    ...                                               ref_power=np.max),
+    >>> librosa.display.specshow(librosa.power_to_db(S,
+    ...                                              ref=np.max),
     ...                          y_axis='mel', fmax=8000,
     ...                          x_axis='time')
     >>> plt.colorbar(format='%+2.0f dB')

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -687,8 +687,8 @@ def cq_to_chroma(n_input, bins_per_octave=12, n_chroma=12,
 
     >>> import matplotlib.pyplot as plt
     >>> plt.subplot(3, 1, 1)
-    >>> librosa.display.specshow(librosa.logamplitude(CQT**2,
-    ...                                               ref_power=np.max),
+    >>> librosa.display.specshow(librosa.amplitude_to_db(CQT,
+    ...                                                  ref=np.max),
     ...                          y_axis='cqt_note', x_axis='time')
     >>> plt.title('CQT Power')
     >>> plt.colorbar()

--- a/librosa/onset.py
+++ b/librosa/onset.py
@@ -107,10 +107,10 @@ def onset_detect(y=None, sr=22050, onset_envelope=None, hop_length=512,
 
 
     >>> import matplotlib.pyplot as plt
-    >>> D = np.abs(librosa.stft(y))**2
+    >>> D = librosa.stft(y)
     >>> plt.figure()
     >>> ax1 = plt.subplot(2, 1, 1)
-    >>> librosa.display.specshow(librosa.logamplitude(D, ref_power=np.max),
+    >>> librosa.display.specshow(librosa.amplitude_to_db(D, ref=np.max),
     ...                          x_axis='time', y_axis='log')
     >>> plt.title('Power spectrogram')
     >>> plt.subplot(2, 1, 2, sharex=ax1)
@@ -250,11 +250,11 @@ def onset_strength(y=None, sr=22050, S=None, lag=1, max_size=1,
     >>> import matplotlib.pyplot as plt
     >>> y, sr = librosa.load(librosa.util.example_audio_file(),
     ...                      duration=10.0)
-    >>> D = np.abs(librosa.stft(y))**2
+    >>> D = librosa.stft(y)
     >>> times = librosa.frames_to_time(np.arange(D.shape[1]))
     >>> plt.figure()
     >>> ax1 = plt.subplot(2, 1, 1)
-    >>> librosa.display.specshow(librosa.logamplitude(D, ref_power=np.max),
+    >>> librosa.display.specshow(librosa.amplitude_to_db(D, ref=np.max),
     ...                          y_axis='log', x_axis='time')
     >>> plt.title('Power spectrogram')
 
@@ -384,10 +384,10 @@ def onset_strength_multi(y=None, sr=22050, S=None, lag=1, max_size=1,
     >>> import matplotlib.pyplot as plt
     >>> y, sr = librosa.load(librosa.util.example_audio_file(),
     ...                      duration=10.0)
-    >>> D = np.abs(librosa.stft(y))**2
+    >>> D = librosa.stft(y)
     >>> plt.figure()
     >>> plt.subplot(2, 1, 1)
-    >>> librosa.display.specshow(librosa.logamplitude(D, ref_power=np.max),
+    >>> librosa.display.specshow(librosa.amplitude_to_db(D, ref=np.max),
     ...                          y_axis='log')
     >>> plt.title('Power spectrogram')
 
@@ -419,7 +419,7 @@ def onset_strength_multi(y=None, sr=22050, S=None, lag=1, max_size=1,
         S = np.abs(feature(y=y, sr=sr, **kwargs))
 
         # Convert to dBs
-        S = core.logamplitude(S)
+        S = core.power_to_db(S)
 
     # Retrieve the n_fft and hop_length,
     # or default values for onsets if not provided

--- a/librosa/segment.py
+++ b/librosa/segment.py
@@ -584,8 +584,8 @@ def subsegment(data, frames, n_segments=4, axis=-1):
 
     >>> import matplotlib.pyplot as plt
     >>> plt.figure()
-    >>> librosa.display.specshow(librosa.logamplitude(cqt**2,
-    ...                                               ref_power=np.max),
+    >>> librosa.display.specshow(librosa.amplitude_to_db(cqt,
+    ...                                                  ref=np.max),
     ...                          y_axis='cqt_hz', x_axis='time')
     >>> lims = plt.gca().get_ylim()
     >>> plt.vlines(beat_times, lims[0], lims[1], color='lime', alpha=0.9,

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -464,15 +464,15 @@ def axis_sort(S, axis=-1, index=False, value=None):
     >>> import matplotlib.pyplot as plt
     >>> plt.figure()
     >>> plt.subplot(2, 2, 1)
-    >>> librosa.display.specshow(librosa.logamplitude(W**2, ref_power=np.max),
+    >>> librosa.display.specshow(librosa.amplitude_to_db(W, ref=np.max),
     ...                          y_axis='log')
     >>> plt.title('W')
     >>> plt.subplot(2, 2, 2)
     >>> librosa.display.specshow(H, x_axis='time')
     >>> plt.title('H')
     >>> plt.subplot(2, 2, 3)
-    >>> librosa.display.specshow(librosa.logamplitude(W_sort**2,
-    ...                                               ref_power=np.max),
+    >>> librosa.display.specshow(librosa.amplitude_to_db(W_sort,
+    ...                                                  ref=np.max),
     ...                          y_axis='log')
     >>> plt.title('W sorted')
     >>> plt.subplot(2, 2, 4)
@@ -896,8 +896,8 @@ def peak_pick(x, pre_max, post_max, pre_avg, post_avg, delta, wait):
     ...                                sr=sr, hop_length=512)
     >>> plt.figure()
     >>> ax = plt.subplot(2, 1, 2)
-    >>> D = np.abs(librosa.stft(y))**2
-    >>> librosa.display.specshow(librosa.logamplitude(D, ref_power=np.max),
+    >>> D = librosa.stft(y)
+    >>> librosa.display.specshow(librosa.amplitude_to_db(D, ref=np.max),
     ...                          y_axis='log', x_axis='time')
     >>> plt.subplot(2, 1, 1, sharex=ax)
     >>> plt.plot(times, onset_env, alpha=0.8, label='Onset strength')
@@ -1331,21 +1331,21 @@ def sync(data, idx, aggregate=None, pad=True, axis=-1):
     >>> subbeat_t = librosa.frames_to_time(sub_beats, sr=sr)
     >>> plt.figure()
     >>> plt.subplot(3, 1, 1)
-    >>> librosa.display.specshow(librosa.logamplitude(cqt**2,
-    ...                                               ref_power=np.max),
+    >>> librosa.display.specshow(librosa.amplitude_to_db(cqt,
+    ...                                                  ref=np.max),
     ...                          x_axis='time')
     >>> plt.colorbar(format='%+2.0f dB')
     >>> plt.title('CQT power, shape={}'.format(cqt.shape))
     >>> plt.subplot(3, 1, 2)
-    >>> librosa.display.specshow(librosa.logamplitude(cqt_med**2,
-    ...                                               ref_power=np.max),
+    >>> librosa.display.specshow(librosa.amplitude_to_db(cqt_med,
+    ...                                                  ref=np.max),
     ...                          x_coords=beat_t, x_axis='time')
     >>> plt.colorbar(format='%+2.0f dB')
     >>> plt.title('Beat synchronous CQT power, '
     ...           'shape={}'.format(cqt_med.shape))
     >>> plt.subplot(3, 1, 3)
-    >>> librosa.display.specshow(librosa.logamplitude(cqt_med_sub**2,
-    ...                                               ref_power=np.max),
+    >>> librosa.display.specshow(librosa.amplitude_to_db(cqt_med_sub,
+    ...                                                  ref=np.max),
     ...                          x_coords=subbeat_t, x_axis='time')
     >>> plt.colorbar(format='%+2.0f dB')
     >>> plt.title('Sub-beat synchronous CQT power, '

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -143,9 +143,9 @@ def test_harmonic():
 
 def test_trim():
 
-    def __test(y, top_db, ref_power, trim_duration):
+    def __test(y, top_db, ref, trim_duration):
         yt, idx = librosa.effects.trim(y, top_db=top_db,
-                                       ref_power=ref_power)
+                                       ref=ref)
 
         # Test for index position
         fidx = [slice(None)] * y.ndim
@@ -154,12 +154,12 @@ def test_trim():
 
         # Verify logamp
         rms = librosa.feature.rmse(librosa.to_mono(yt))
-        logamp = librosa.logamplitude(rms**2, ref_power=ref_power, top_db=None)
+        logamp = librosa.logamplitude(rms**2, ref=ref, top_db=None)
         assert np.all(logamp > - top_db)
 
         # Verify logamp
         rms_all = librosa.feature.rmse(librosa.to_mono(y)).squeeze()
-        logamp_all = librosa.logamplitude(rms_all**2, ref_power=ref_power,
+        logamp_all = librosa.logamplitude(rms_all**2, ref=ref,
                                           top_db=None)
 
         start = int(librosa.samples_to_frames(idx[0]))
@@ -180,11 +180,11 @@ def test_trim():
     y = np.vstack([y, np.zeros_like(y)])
 
     for top_db in [60, 40, 20]:
-        for ref_power in [1, np.max]:
+        for ref in [1, np.max]:
             # Test stereo
-            yield __test, y, top_db, ref_power, trim_duration
+            yield __test, y, top_db, ref, trim_duration
             # Test mono
-            yield __test, y[0], top_db, ref_power, trim_duration
+            yield __test, y[0], top_db, ref, trim_duration
 
 
 def test_split():


### PR DESCRIPTION
This PR implements #421:

- logamplitude docstrings are slightly improved
- `logamplitude` aliases `power_to_db` 
- `db_to_power` provides the inverse mapping
- `amplitude_to_db` is a convenience function to side-step power conversion
- `db_to_amplitude` inverts `amplitude_to_db`
- Deprecated `ref_power` parameter, renamed to `ref`.
- All dependent code and examples have been updated to use the new interfaces.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/464)
<!-- Reviewable:end -->
