### PR TITLE
Onset backtracking

### DIFF
--- a/librosa/onset.py
+++ b/librosa/onset.py
@@ -107,10 +107,9 @@ def onset_detect(y=None, sr=22050, onset_envelope=None, hop_length=512,
     >>> y, sr = librosa.load(librosa.util.example_audio_file(),
     ...                      offset=30, duration=2.0)
     >>> onset_frames = librosa.onset.onset_detect(y=y, sr=sr)
-    >>> librosa.frames_to_time(onset_frames[:20], sr=sr)
-    array([ 0.046,  0.372,  0.488,  0.58 ,  0.72 ,  0.929,
-            1.161,  1.277,  1.393,  1.741,  1.834])
-
+    >>> librosa.frames_to_time(onset_frames, sr=sr)
+    array([ 0.07 ,  0.395,  0.511,  0.627,  0.766,  0.975,
+            1.207,  1.324,  1.44 ,  1.788,  1.881])
 
     Or use a pre-computed onset envelope
 

--- a/librosa/onset.py
+++ b/librosa/onset.py
@@ -380,11 +380,15 @@ def onset_backtrack(events, energy):
     >>> plt.legend(frameon=True, framealpha=0.75)
     '''
 
-    # Find points where energy is decreasing
-    minima = 1 + np.flatnonzero(energy[1:] <= energy[:-1])
+    # Find points where energy is non-increasing
+    # all points:  energy[i] <= energy[i-1]
+    # tail points: energy[i] < energy[i+1]
+    minima = np.flatnonzero((energy[1:-1] <= energy[:-2]) &
+                            (energy[1:-1] < energy[2:]))
 
-    # Pad on a 0, since we only do left-sided matching
-    minima = util.fix_frames(minima)
+    # Pad on a 0, just in case we have onsets with no preceding minimum
+    # Shift by one to account for slicing in minima detection
+    minima = util.fix_frames(1 + minima, x_min=0)
 
     # Only match going left from the detected events
     return minima[util.match_events(events, minima, right=False)]

--- a/librosa/onset.py
+++ b/librosa/onset.py
@@ -103,12 +103,11 @@ def onset_detect(y=None, sr=22050, onset_envelope=None, hop_length=512,
     Get onset times from a signal
 
     >>> y, sr = librosa.load(librosa.util.example_audio_file(),
-    ...                      duration=10.0)
+    ...                      offset=30, duration=2.0)
     >>> onset_frames = librosa.onset.onset_detect(y=y, sr=sr)
     >>> librosa.frames_to_time(onset_frames[:20], sr=sr)
-    array([ 0.07 ,  0.279,  0.511,  0.859,  1.091,  1.207,  1.463,
-            1.672,  1.904,  2.159,  2.368,  2.601,  2.949,  3.065,
-            3.297,  3.529,  3.762,  3.994,  4.203,  4.69 ])
+    array([ 0.046,  0.372,  0.488,  0.58 ,  0.72 ,  0.929,
+            1.161,  1.277,  1.393,  1.741,  1.834])
 
 
     Or use a pre-computed onset envelope

--- a/librosa/onset.py
+++ b/librosa/onset.py
@@ -29,7 +29,7 @@ __all__ = ['onset_detect',
 
 
 def onset_detect(y=None, sr=22050, onset_envelope=None, hop_length=512,
-                 backtrack=True, energy=None,
+                 backtrack=False, energy=None,
                  units='frames', **kwargs):
     """Basic onset detector.  Locate note onset events by picking peaks in an
     onset strength envelope.

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -823,7 +823,7 @@ def match_intervals(intervals_from, intervals_to):
     return output
 
 
-def match_events(events_from, events_to):
+def match_events(events_from, events_to, left=True, right=True):
     '''Match one set of events to another.
 
     This is useful for tasks such as matching beats to the nearest
@@ -861,6 +861,11 @@ def match_events(events_from, events_to):
       Array of events (eg, times, sample or frame indices) to
       match against.
 
+    left : bool
+    right : bool
+        If `False`, then matched events cannot be to the left (or right)
+        of source events.
+
     Returns
     -------
     event_mapping : np.ndarray [shape=(n,)]
@@ -882,6 +887,25 @@ def match_events(events_from, events_to):
     if len(events_from) == 0 or len(events_to) == 0:
         raise ParameterError('Attempting to match empty event list')
 
+    # If we can't match left or right, then only strict equivalence
+    # counts as a match.
+    if not (left or right) and not np.all(np.in1d(events_from, events_to)):
+            raise ParameterError('Cannot match events with left=right=False '
+                                 'and events_from is not contained '
+                                 'in events_to')
+
+    # If we can't match to the left, then there should be at least one
+    # target event greater-equal to every source event
+    if (not left) and max(events_to) < max(events_from):
+        raise ParameterError('Cannot match events with left=False '
+                             'and max(events_to) < max(events_from)')
+
+    # If we can't match to the right, then there should be at least one
+    # target event less-equal to every source event
+    if (not right) and min(events_to) > min(events_from):
+        raise ParameterError('Cannot match events with right=False '
+                             'and min(events_to) > min(events_from)')
+
     output = np.empty_like(events_from, dtype=np.int)
 
     n_rows = int(MAX_MEM_BLOCK / (np.prod(output.shape[1:]) * len(events_to)
@@ -895,9 +919,17 @@ def match_events(events_from, events_to):
         bl_t = min(bl_s + n_rows, len(events_from))
 
         event_block = events_from[bl_s:bl_t]
-        output[bl_s:bl_t] = np.argmin(np.abs(np.subtract.outer(event_block,
-                                                               events_to)),
-                                      axis=-1)
+
+        distance = np.abs(np.subtract.outer(event_block,
+                                            events_to)).astype(np.float)
+
+        if not right:
+            distance[np.less.outer(event_block, events_to)] = np.nan
+
+        if not left:
+            distance[np.greater.outer(event_block, events_to)] = np.nan
+
+        output[bl_s:bl_t] = np.nanargmin(distance, axis=-1)
 
     return output
 

--- a/tests/test_onset.py
+++ b/tests/test_onset.py
@@ -231,14 +231,19 @@ def test_onset_backtrack():
     oenv = librosa.onset.onset_strength(y=y, sr=sr)
     onsets = librosa.onset.onset_detect(onset_envelope=oenv, backtrack=False)
 
-    # Test backtracking
-    onsets_bt = librosa.onset.onset_backtrack(onsets, oenv)
+    def __test(energy):
+        # Test backtracking
+        onsets_bt = librosa.onset.onset_backtrack(onsets, energy)
 
-    # Make sure there are no negatives
-    assert np.all(onsets_bt >= 0)
+        # Make sure there are no negatives
+        assert np.all(onsets_bt >= 0)
 
-    # And that we never roll forward
-    assert np.all(onsets_bt <= onsets)
+        # And that we never roll forward
+        assert np.all(onsets_bt <= onsets)
 
-    # And that the detected peaks are actually minima
-    assert np.all(oenv[onsets_bt] <= oenv[np.maximum(0, onsets_bt - 1)])
+        # And that the detected peaks are actually minima
+        assert np.all(energy[onsets_bt] <= energy[np.maximum(0, onsets_bt - 1)])
+
+    yield __test, oenv
+    rmse = librosa.feature.rmse(y=y)
+    yield __test, rmse

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -387,6 +387,37 @@ def test_match_events():
                 yield __test, n, m
 
 
+def test_match_events_onesided():
+
+    events_from = np.asarray([5, 15, 25])
+    events_to = np.asarray([0, 10, 20, 30])
+
+    def __test(left, right, target):
+        match = librosa.util.match_events(events_from, events_to,
+                                          left=left, right=right)
+
+        assert np.allclose(target, events_to[match])
+
+    yield __test, False, True, [10, 20, 30]
+    yield __test, True, False, [0, 10, 20]
+
+    # Make a right-sided fail
+    events_from[0] = 40
+    yield raises(librosa.ParameterError)(__test), False, True, [10, 20, 30]
+
+    # Make a left-sided fail
+    events_from[0] = -1
+    yield raises(librosa.ParameterError)(__test), True, False, [10, 20, 30]
+
+    # Make a two-sided fail
+    events_from[0] = -1
+    yield raises(librosa.ParameterError)(__test), False, False, [10, 20, 30]
+
+    # Make a two-sided success
+    events_to[:-1] = events_from
+    yield __test, False, False, events_from
+
+
 def test_localmax():
 
     def __test(ndim, axis):


### PR DESCRIPTION
This PR implements #305: backtracking onset detections to the nearest previous minimum of an energy function.

This proceeds in a few steps:

- [x] Extend `match_events` to support one-sided matching.
- [x] Add a function `onset.onset_backtrack` that calls `match_events` with `right=False`
- [x] Add API support for `onset.onset_detect` to call into `onset_backtrack`.
- [x] expand testing for onset detection

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/473)
<!-- Reviewable:end -->
