### PR TITLE
added real=True deprecation back to cqt. Fixes #440

### DIFF
--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -85,8 +85,12 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
         If `False`, do not scale the CQT. This is analogous to
         `norm=None` in FFT.
 
-    real : [DEPRECATED]
-        .. warning:: This parameter name deprecated in librosa 0.5.0
+    real : bool [DEPRECATED]
+        If `False`, return a complex-valued constant-Q transform (default).
+
+        If `True`, return the CQT magnitude.
+
+        .. warning:: This parameter is deprecated in librosa 0.5.0
             It will be removed in librosa 0.6.0.
 
 

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -3,6 +3,8 @@
 '''Constant-Q transforms'''
 from __future__ import division
 
+from warnings import warn
+
 import numpy as np
 import scipy.fftpack as fft
 
@@ -257,6 +259,15 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
                                              window=window,
                                              filter_scale=filter_scale)
         C /= np.sqrt(lengths[:, np.newaxis])
+
+    if not isinstance(real, util.Deprecated):
+        warn('Real-valued CQT (real=True) is deprecated in 0.4.2. '
+             'The `real` parameter will be removed in 0.6.0.'
+             'Use np.abs(librosa.cqt(...)) '
+             'instead of real=True to maintain forward compatibility.',
+             DeprecationWarning)
+        if real:
+            C = np.abs(C)
 
     return C
 

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -9,6 +9,8 @@ Run me as follows:
 """
 from __future__ import division
 
+import warnings
+
 # Disable cache
 import os
 try:
@@ -298,3 +300,25 @@ def test_hcqt_white_noise():
             for fmin in librosa.note_to_hz(['C1', 'C2']):
                 for n_octaves in [6, 7]:
                     yield __test, fmin, n_octaves * 12, scale, sr, y
+
+
+def test_cqt_real_warning():
+
+    def __test(real):
+        warnings.resetwarnings()
+        warnings.simplefilter('always')
+        with warnings.catch_warnings(record=True) as out:
+            C = librosa.cqt(y=y, sr=sr, real=real)
+            assert len(out) > 0
+            assert out[0].category is DeprecationWarning
+
+            if real:
+                assert np.isrealobj(C)
+            else:
+                assert np.iscomplexobj(C)
+
+    sr = 22050
+    y = np.zeros(2 * sr)
+
+    yield __test, False
+    yield __test, True


### PR DESCRIPTION
This fixes #440.

`real=True` still works, but throws a deprecation warning.

The parameter will be removed in 0.6.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/474)
<!-- Reviewable:end -->
