### PR TITLE
Warn on empty mel filters

### DIFF
--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -15,12 +15,16 @@ except:
 import matplotlib
 matplotlib.use('Agg')
 import numpy as np
+import warnings
 import librosa
 
 from test_core import files, load
 
 __EXAMPLE_FILE = 'data/test1_22050.wav'
 
+
+warnings.resetwarnings()
+warnings.simplefilter('always')
 
 def test_onset_strength():
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -14,6 +14,9 @@ import matplotlib
 matplotlib.use('Agg')
 from nose.tools import with_setup, eq_
 
+import warnings
+warnings.resetwarnings()
+warnings.simplefilter('always')
 
 # Disable any initial cache settings
 for key in ['DIR', 'MMAP', 'COMPRESS', 'VERBOSE', 'LEVEL']:

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -10,6 +10,8 @@ Run me as follows:
 from __future__ import division
 
 import warnings
+warnings.resetwarnings()
+warnings.simplefilter('always')
 
 # Disable cache
 import os

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -24,6 +24,10 @@ from nose.tools import eq_, raises, make_decorator
 import matplotlib
 matplotlib.use('Agg')
 
+import warnings
+warnings.resetwarnings()
+warnings.simplefilter('always')
+
 
 # -- utilities --#
 def files(pattern):

--- a/tests/test_decompose.py
+++ b/tests/test_decompose.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # CREATED: 2013-10-06 22:31:29 by Dawen Liang <dl2771@columbia.edu>
 # unit tests for librosa.decompose
+import warnings
+warnings.resetwarnings()
+warnings.simplefilter('always')
 
 # Disable cache
 import os

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -3,6 +3,9 @@
 # CREATED:2015-02-14 22:51:01 by Brian McFee <brian.mcfee@nyu.edu>
 '''Unit tests for display module'''
 
+import warnings
+warnings.resetwarnings()
+warnings.simplefilter('always')
 
 # Disable cache
 import os

--- a/tests/test_dtw.py
+++ b/tests/test_dtw.py
@@ -3,6 +3,9 @@ import numpy as np
 
 from test_core import srand
 
+import warnings
+warnings.resetwarnings()
+warnings.simplefilter('always')
 
 def test_dtw_global():
     # Example taken from:

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
 '''Unit tests for the effects module'''
+import warnings
+warnings.resetwarnings()
+warnings.simplefilter('always')
 
 # Disable cache
 import os

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -14,6 +14,9 @@ matplotlib.use('Agg')
 import numpy as np
 import librosa
 from nose.tools import raises
+import warnings
+warnings.resetwarnings()
+warnings.simplefilter('always')
 
 
 @raises(librosa.ParameterError)

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -4,6 +4,8 @@
 from __future__ import print_function
 import warnings
 import numpy as np
+warnings.resetwarnings()
+warnings.simplefilter('always')
 
 from nose.tools import raises, eq_
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -40,6 +40,9 @@ import warnings
 
 import librosa
 
+warnings.resetwarnings()
+warnings.simplefilter('always')
+
 # -- utilities --#
 def files(pattern):
     test_files = glob.glob(pattern)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -120,23 +120,22 @@ def test_melfb():
 
 def test_mel_gap():
 
-    warnings.resetwarnings()
-    warnings.simplefilter('always')
-
     # This configuration should trigger some empty filters
-    sr = 22050
+    sr = 44100
     n_fft = 1024
     fmin = 0
     fmax = 2000
     n_mels = 128
     htk = True
+
+    warnings.resetwarnings()
+    warnings.simplefilter('always')
     with warnings.catch_warnings(record=True) as out:
         librosa.filters.mel(sr, n_fft, n_mels=n_mels,
                             fmin=fmin, fmax=fmax, htk=htk)
 
         assert len(out) > 0
         assert out[0].category is UserWarning
-
         assert 'empty filters' in str(out[0].message).lower()
 
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -118,6 +118,28 @@ def test_melfb():
         yield (__test, infile)
 
 
+def test_mel_gap():
+
+    warnings.resetwarnings()
+    warnings.simplefilter('always')
+
+    # This configuration should trigger some empty filters
+    sr = 22050
+    n_fft = 1024
+    fmin = 0
+    fmax = 2000
+    n_mels = 128
+    htk = True
+    with warnings.catch_warnings(record=True) as out:
+        librosa.filters.mel(sr, n_fft, n_mels=n_mels,
+                            fmin=fmin, fmax=fmax, htk=htk)
+
+        assert len(out) > 0
+        assert out[0].category is UserWarning
+
+        assert 'empty filters' in str(out[0].message).lower()
+
+
 def test_chromafb():
 
     def __test(infile):

--- a/tests/test_met_features.py
+++ b/tests/test_met_features.py
@@ -4,6 +4,9 @@
 '''Regression tests on metlab features''' 
 
 from __future__ import print_function
+import warnings
+warnings.resetwarnings()
+warnings.simplefilter('always')
 # Disable cache
 import os
 try:

--- a/tests/test_onset.py
+++ b/tests/test_onset.py
@@ -16,6 +16,8 @@ import matplotlib
 matplotlib.use('Agg')
 
 import warnings
+warnings.resetwarnings()
+warnings.simplefilter('always')
 
 import numpy as np
 import librosa

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -15,6 +15,9 @@ import tempfile
 from nose.tools import raises, eq_
 
 from test_core import srand
+import warnings
+warnings.resetwarnings()
+warnings.simplefilter('always')
 
 def test_write_wav():
 

--- a/tests/test_segment.py
+++ b/tests/test_segment.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
 '''Tests for segmentation functions'''
+import warnings
+warnings.resetwarnings()
+warnings.simplefilter('always')
 
 # Disable cache
 import os

--- a/tests/test_time_frequency.py
+++ b/tests/test_time_frequency.py
@@ -2,6 +2,9 @@
 # -*- encoding: utf-8 -*-
 # CREATED:2015-02-14 19:13:49 by Brian McFee <brian.mcfee@nyu.edu>
 '''Unit tests for time and frequency conversion'''
+import warnings
+warnings.resetwarnings()
+warnings.simplefilter('always')
 
 import os
 try:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -17,6 +17,8 @@ np.set_printoptions(precision=3)
 from nose.tools import raises, eq_
 import six
 import warnings
+warnings.resetwarnings()
+warnings.simplefilter('always')
 
 import librosa
 


### PR DESCRIPTION
Fixes #478.  A warning is issued if the mel filter bank has all-zero rows corresponding to positive frequencies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/482)
<!-- Reviewable:end -->
