### PR TITLE
fixed chroma_cens test. resolves #539

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ before_install:
     - export PATH="$HOME/env/miniconda$TRAVIS_PYTHON_VERSION/bin:$PATH";
     - hash -r
     - source activate test-environment
+    - conda list
 
 install:
     # install your own package into the environment

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -1097,7 +1097,7 @@ def chroma_cens(y=None, sr=22050, C=None, hop_length=512, fmin=None,
     win /= np.sum(win)
     win = np.atleast_2d(win)
 
-    cens = scipy.signal.convolve2d(chroma_quant, win, mode='same')
+    cens = scipy.signal.convolve2d(chroma_quant, win, mode='same', boundary='fill')
 
     # L2-Normalization
     return util.normalize(cens, norm=norm, axis=0)

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -1093,11 +1093,12 @@ def chroma_cens(y=None, sr=22050, C=None, hop_length=512, fmin=None,
         chroma_quant += (chroma > cur_quant_step) * QUANT_WEIGHTS[cur_quant_step_idx]
 
     # Apply temporal smoothing
-    win = scipy.signal.hanning(win_len_smooth + 2, sym=False)
+    win = scipy.signal.hanning(win_len_smooth + 2)
     win /= np.sum(win)
     win = np.atleast_2d(win)
 
-    cens = scipy.signal.convolve2d(chroma_quant, win, mode='same', boundary='fill')
+    cens = scipy.signal.convolve2d(chroma_quant, win,
+                                   mode='same', boundary='fill')
 
     # L2-Normalization
     return util.normalize(cens, norm=norm, axis=0)

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -1097,7 +1097,7 @@ def chroma_cens(y=None, sr=22050, C=None, hop_length=512, fmin=None,
     win /= np.sum(win)
     win = np.atleast_2d(win)
 
-    cens = scipy.signal.convolve2d(chroma_quant, win, mode='same', boundary='wrap')
+    cens = scipy.signal.convolve2d(chroma_quant, win, mode='same', boundary='fill')
 
     # L2-Normalization
     return util.normalize(cens, norm=norm, axis=0)

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -1097,7 +1097,7 @@ def chroma_cens(y=None, sr=22050, C=None, hop_length=512, fmin=None,
     win /= np.sum(win)
     win = np.atleast_2d(win)
 
-    cens = scipy.signal.convolve2d(chroma_quant, win, mode='same', boundary='fill')
+    cens = scipy.signal.convolve2d(chroma_quant, win, mode='same', boundary='wrap')
 
     # L2-Normalization
     return util.normalize(cens, norm=norm, axis=0)

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -640,4 +640,5 @@ def test_cens():
         # load CENS-41-1 features
         ct_chroma_cens = load(os.path.join('data', cur_fn_ct_chroma_cens))
 
-        assert np.allclose(ct_chroma_cens['f_CENS'], lr_chroma_cens, rtol=1e-15, atol=1e-15)
+        maxdev = np.max(np.abs(ct_chroma_cens['f_CENS'] - lr_chroma_cens))
+        assert np.allclose(ct_chroma_cens['f_CENS'], lr_chroma_cens, rtol=1e-15, atol=1e-15), maxdev

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -640,5 +640,5 @@ def test_cens():
         # load CENS-41-1 features
         ct_chroma_cens = load(os.path.join('data', cur_fn_ct_chroma_cens))
 
-        maxdev = np.max(np.abs(ct_chroma_cens['f_CENS'] - lr_chroma_cens))
+        maxdev = np.abs(ct_chroma_cens['f_CENS'] - lr_chroma_cens)
         assert np.allclose(ct_chroma_cens['f_CENS'], lr_chroma_cens, rtol=1e-15, atol=1e-15), maxdev


### PR DESCRIPTION
This fixes #539 by adding an explicit `boundary` mode parameter to the 2d convolution in `chroma_cens`, and brings the code up to spec for scipy 0.19.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/548)
<!-- Reviewable:end -->
