### PR TITLE
fixed #552, error in spectral bandwidth shape

### DIFF
--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -244,9 +244,9 @@ def spectral_bandwidth(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
         freq = fft_frequencies(sr=sr, n_fft=n_fft)
 
     if freq.ndim == 1:
-        deviation = np.abs(np.subtract.outer(freq, np.squeeze(centroid)))
+        deviation = np.abs(np.subtract.outer(freq, centroid[0]))
     else:
-        deviation = np.abs(freq - np.squeeze(centroid))
+        deviation = np.abs(freq - centroid[0])
 
     # Column-normalize S
     if norm:

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -206,6 +206,40 @@ def test_spectral_bandwidth_synthetic():
             yield __test, S, freq, sr, n_fft, norm, p
 
 
+def test_spectral_bandwidth_onecol():
+    # This test checks for issue https://github.com/librosa/librosa/issues/552
+    # failure when the spectrogram has a single column
+
+    def __test(S, freq):
+        bw = librosa.feature.spectral_bandwidth(S=S, freq=freq)
+
+        assert bw.shape == (1, 1)
+
+    k = 5
+
+    srand()
+    # construct a fake spectrogram
+    sr = 22050
+    n_fft = 1024
+    S = np.zeros((1 + n_fft // 2, 1))
+    S[k, :] = 1.0
+
+    # With vanilla frequencies
+    yield __test, S, None
+
+    # With explicit frequencies
+    freq = librosa.fft_frequencies(sr=sr, n_fft=n_fft)
+    yield __test, S, freq
+
+    # And if we modify the frequencies
+    freq = 3 * librosa.fft_frequencies(sr=sr, n_fft=n_fft)
+    yield __test, S, freq
+
+    # Or if we make up random frequencies for each frame
+    freq = np.random.randn(*S.shape)
+    yield __test, S, freq
+
+
 def test_spectral_bandwidth_errors():
 
     @raises(librosa.ParameterError)
@@ -217,6 +251,7 @@ def test_spectral_bandwidth_errors():
 
     S = - np.ones((513, 10)) * 1.j
     yield __test, S
+
 
 
 def test_spectral_rolloff_synthetic():


### PR DESCRIPTION
This is a bugfix for #552, where a single-column input spectrum produces output of the wrong shape.

The fix is simple: replace `squeeze(centroid)` with `centroid[0]`.  I've also added a new test to cover this case.

This should be merge-ready as soon as tests pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/553)
<!-- Reviewable:end -->
