### PR TITLE
fixed #524, added safety check for frequency bands in spectral_contrast

### DIFF
--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -360,6 +360,10 @@ def spectral_contrast(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
     octa = np.zeros(n_bands + 2)
     octa[1:] = fmin * (2.0**np.arange(0, n_bands + 1))
 
+    if np.any(octa[:-1] >= 0.5 * sr):
+        raise ParameterError('Frequency band exceeds Nyquist. '
+                             'Reduce either fmin or n_bands.')
+
     valley = np.zeros((n_bands + 1, S.shape[1]))
     peak = np.zeros_like(valley)
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -353,6 +353,9 @@ def test_spectral_contrast_errors():
     # bad quantile
     yield __test, S, None, 200, 6, 2
 
+    # bands exceed nyquist
+    yield __test, S, None, 200, 7, 0.02
+
 
 def test_rmse():
 


### PR DESCRIPTION
This adds a safety check that none of the frequency bands in `spectral_contrast` lie entirely above nyquist.

It also adds a test case to cover #524.

This should be good to go, assuming tests pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/555)
<!-- Reviewable:end -->
