### PR TITLE
fixed #529, explicit length for istft

### DIFF
--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -179,7 +179,7 @@ def stft(y, n_fft=2048, hop_length=None, win_length=None, window='hann',
 
 @cache(level=30)
 def istft(stft_matrix, hop_length=None, win_length=None, window='hann',
-          center=True, dtype=np.float32):
+          center=True, dtype=np.float32, length=None):
     """
     Inverse short-time Fourier transform (ISTFT).
 
@@ -226,6 +226,10 @@ def istft(stft_matrix, hop_length=None, win_length=None, window='hann',
     dtype       : numeric type
         Real numeric type for `y`.  Default is 32-bit float.
 
+    length : int > 0, optional
+        If provided, the output `y` is zero-padded or clipped to exactly
+        `length` samples.
+
     Returns
     -------
     y : np.ndarray [shape=(n,)]
@@ -254,7 +258,7 @@ def istft(stft_matrix, hop_length=None, win_length=None, window='hann',
     >>> n_fft = 2048
     >>> y_pad = librosa.util.fix_length(y, n + n_fft // 2)
     >>> D = librosa.stft(y_pad, n_fft=n_fft)
-    >>> y_out = librosa.util.fix_length(librosa.istft(D), n)
+    >>> y_out = librosa.istft(D, length=n)
     >>> np.max(np.abs(y - y_out))
     1.4901161e-07
     """
@@ -293,8 +297,23 @@ def istft(stft_matrix, hop_length=None, win_length=None, window='hann',
     approx_nonzero_indices = ifft_window_sum > util.tiny(ifft_window_sum)
     y[approx_nonzero_indices] /= ifft_window_sum[approx_nonzero_indices]
 
-    if center:
-        y = y[int(n_fft // 2):-int(n_fft // 2)]
+    if length is None:
+        # If we don't need to control length, just do the usual center trimming
+        # to eliminate padded data
+        if center:
+            y = y[int(n_fft // 2):-int(n_fft // 2)]
+    else:
+        if center:
+            # If we're centering, crop off the first n_fft//2 samples
+            # and then trim/pad to the target length.
+            # We don't trim the end here, so that if the signal is zero-padded
+            # to a longer duration, the decay is smooth by windowing
+            start = int(n_fft // 2)
+        else:
+            # If we're not centering, start at 0 and trim/pad as necessary
+            start = 0
+
+        y = util.fix_length(y[start:], length)
 
     return y
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -444,11 +444,14 @@ def test_magphase():
 def test_istft_reconstruction():
     from scipy.signal import bartlett, hann, hamming, blackman, blackmanharris
 
-    def __test(x, n_fft, hop_length, window, atol):
+    def __test(x, n_fft, hop_length, window, atol, length):
         S = librosa.core.stft(
             x, n_fft=n_fft, hop_length=hop_length, window=window)
         x_reconstructed = librosa.core.istft(
-            S, hop_length=hop_length, window=window)
+            S, hop_length=hop_length, window=window, length=length)
+
+        if length is not None:
+            assert len(x_reconstructed) == length
 
         L = min(len(x), len(x_reconstructed))
         x = np.resize(x, L)
@@ -479,10 +482,11 @@ def test_istft_reconstruction():
                 # tests with pre-computed window fucntions
                 for hop_length_denom in six.moves.range(2, 9):
                     hop_length = n_fft // hop_length_denom
-                    yield (__test, x, n_fft, hop_length, win, atol)
-                    yield (__test, x, n_fft, hop_length, symwin, atol)
+                    for length in [None, len(x) - 1000, len(x + 1000)]:
+                        yield (__test, x, n_fft, hop_length, win, atol, length)
+                        yield (__test, x, n_fft, hop_length, symwin, atol, length)
                 # also tests with passing widnow function itself
-                yield (__test, x, n_fft, n_fft // 9, window_func, atol)
+                yield (__test, x, n_fft, n_fft // 9, window_func, atol, None)
 
         # test with default paramters
         x_reconstructed = librosa.core.istft(librosa.core.stft(x))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/master/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
<!-- Example: Fixes #123 -->
Fixes #529 

#### What does this implement/fix? Explain your changes.

Users can now specify the target signal length for inverse STFT.

If `length` is shorter than the expected signal length, it is trimmed.

If `length` is longer than the expected signal length, it is zero-padded.



#### Any other comments?

Note that with centering, the forward transform first pads the signal on both ends, and the inverse usually trims off the ending bit corresponding to the padding.  However, if the user calls with `length` greater than the expected signal length, we retain the padded fragment, which when combined with frame windowing, results in a smooth taper to zero before padding kicks in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/559)
<!-- Reviewable:end -->
