### PR TITLE
expose padding mode to user in stft/ifgram/cqt

### DIFF
--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -513,7 +513,7 @@ def pseudo_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
     fft_basis = np.abs(fft_basis)
 
     # Compute the magnitude STFT with Hann window
-    D = np.abs(stft(y, n_fft=n_fft, hop_length=hop_length, mode=pad_mode))
+    D = np.abs(stft(y, n_fft=n_fft, hop_length=hop_length, pad_mode=pad_mode))
 
     # Project onto the pseudo-cqt basis
     C = fft_basis.dot(D)
@@ -586,7 +586,8 @@ def __cqt_response(y, n_fft, hop_length, fft_basis, mode):
     '''Compute the filter response with a target STFT hop.'''
 
     # Compute the STFT matrix
-    D = stft(y, n_fft=n_fft, hop_length=hop_length, window=np.ones, mode=mode)
+    D = stft(y, n_fft=n_fft, hop_length=hop_length, window=np.ones,
+             pad_mode=mode)
 
     # And filter response energy
     return fft_basis.dot(D)

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -27,7 +27,7 @@ __all__ = ['stft', 'istft', 'magphase',
 
 @cache(level=20)
 def stft(y, n_fft=2048, hop_length=None, win_length=None, window='hann',
-         center=True, dtype=np.complex64):
+         center=True, dtype=np.complex64, mode='reflect'):
     """Short-time Fourier transform (STFT)
 
     Returns a complex-valued matrix D such that
@@ -72,6 +72,10 @@ def stft(y, n_fft=2048, hop_length=None, win_length=None, window='hann',
     dtype       : numeric type
         Complex numeric type for `D`.  Default is 64-bit complex.
 
+    mode : string
+        If `center=True`, the padding mode to use at the edges of the signal.
+        By default, STFT uses reflection padding.
+
 
     Returns
     -------
@@ -85,6 +89,7 @@ def stft(y, n_fft=2048, hop_length=None, win_length=None, window='hann',
 
     ifgram : Instantaneous frequency spectrogram
 
+    np.pad : array padding
 
     Notes
     -----
@@ -152,7 +157,7 @@ def stft(y, n_fft=2048, hop_length=None, win_length=None, window='hann',
     # Pad the time series so that frames are centered
     if center:
         util.valid_audio(y)
-        y = np.pad(y, int(n_fft // 2), mode='reflect')
+        y = np.pad(y, int(n_fft // 2), mode=mode)
 
     # Window the time series.
     y_frames = util.frame(y, frame_length=n_fft, hop_length=hop_length)
@@ -301,7 +306,7 @@ def istft(stft_matrix, hop_length=None, win_length=None, window='hann',
 
 def ifgram(y, sr=22050, n_fft=2048, hop_length=None, win_length=None,
            window='hann', norm=False, center=True, ref_power=1e-6,
-           clip=True, dtype=np.complex64):
+           clip=True, dtype=np.complex64, mode='reflect'):
     '''Compute the instantaneous frequency (as a proportion of the sampling rate)
     obtained as the time-derivative of the phase of the complex spectrum as
     described by [1]_.
@@ -366,6 +371,11 @@ def ifgram(y, sr=22050, n_fft=2048, hop_length=None, win_length=None,
     dtype : numeric type
         Complex numeric type for `D`.  Default is 64-bit complex.
 
+    mode : string
+        If `center=True`, the padding mode to use at the edges of the signal.
+        By default, STFT uses reflection padding.
+
+
     Returns
     -------
     if_gram : np.ndarray [shape=(1 + n_fft/2, t), dtype=real]
@@ -410,10 +420,12 @@ def ifgram(y, sr=22050, n_fft=2048, hop_length=None, win_length=None,
 
     stft_matrix = stft(y, n_fft=n_fft, hop_length=hop_length,
                        win_length=win_length,
-                       window=window, center=center, dtype=dtype)
+                       window=window, center=center,
+                       dtype=dtype, mode=mode)
 
     diff_stft = stft(y, n_fft=n_fft, hop_length=hop_length,
-                     window=d_window, center=center, dtype=dtype).conj()
+                     window=d_window, center=center,
+                     dtype=dtype, mode=mode).conj()
 
     # Compute power normalization. Suppress zeros.
     mag, phase = magphase(stft_matrix)

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -421,11 +421,11 @@ def ifgram(y, sr=22050, n_fft=2048, hop_length=None, win_length=None,
     stft_matrix = stft(y, n_fft=n_fft, hop_length=hop_length,
                        win_length=win_length,
                        window=window, center=center,
-                       dtype=dtype, mode=pad_mode)
+                       dtype=dtype, pad_mode=pad_mode)
 
     diff_stft = stft(y, n_fft=n_fft, hop_length=hop_length,
                      window=d_window, center=center,
-                     dtype=dtype, mode=pad_mode).conj()
+                     dtype=dtype, pad_mode=pad_mode).conj()
 
     # Compute power normalization. Suppress zeros.
     mag, phase = magphase(stft_matrix)

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -27,7 +27,7 @@ __all__ = ['stft', 'istft', 'magphase',
 
 @cache(level=20)
 def stft(y, n_fft=2048, hop_length=None, win_length=None, window='hann',
-         center=True, dtype=np.complex64, mode='reflect'):
+         center=True, dtype=np.complex64, pad_mode='reflect'):
     """Short-time Fourier transform (STFT)
 
     Returns a complex-valued matrix D such that
@@ -157,7 +157,7 @@ def stft(y, n_fft=2048, hop_length=None, win_length=None, window='hann',
     # Pad the time series so that frames are centered
     if center:
         util.valid_audio(y)
-        y = np.pad(y, int(n_fft // 2), mode=mode)
+        y = np.pad(y, int(n_fft // 2), mode=pad_mode)
 
     # Window the time series.
     y_frames = util.frame(y, frame_length=n_fft, hop_length=hop_length)
@@ -306,7 +306,7 @@ def istft(stft_matrix, hop_length=None, win_length=None, window='hann',
 
 def ifgram(y, sr=22050, n_fft=2048, hop_length=None, win_length=None,
            window='hann', norm=False, center=True, ref_power=1e-6,
-           clip=True, dtype=np.complex64, mode='reflect'):
+           clip=True, dtype=np.complex64, pad_mode='reflect'):
     '''Compute the instantaneous frequency (as a proportion of the sampling rate)
     obtained as the time-derivative of the phase of the complex spectrum as
     described by [1]_.
@@ -421,11 +421,11 @@ def ifgram(y, sr=22050, n_fft=2048, hop_length=None, win_length=None,
     stft_matrix = stft(y, n_fft=n_fft, hop_length=hop_length,
                        win_length=win_length,
                        window=window, center=center,
-                       dtype=dtype, mode=mode)
+                       dtype=dtype, mode=pad_mode)
 
     diff_stft = stft(y, n_fft=n_fft, hop_length=hop_length,
                      window=d_window, center=center,
-                     dtype=dtype, mode=mode).conj()
+                     dtype=dtype, mode=pad_mode).conj()
 
     # Compute power normalization. Suppress zeros.
     mag, phase = magphase(stft_matrix)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1215,7 +1215,8 @@ def test_padding():
     # different answers for different modes.
     # Does not validate the correctness of each mode.
 
-    y, sr = librosa.load('data/test1_44100.wav', sr=None, mono=True)
+    y, sr = librosa.load('data/test1_44100.wav', sr=None, mono=True,
+                         duration=1)
 
     def __test_stft(center, pad_mode):
         D1 = librosa.stft(y, center=center, pad_mode='reflect')
@@ -1262,9 +1263,21 @@ def test_padding():
         else:
             assert np.allclose(D1, D2)
 
+    def __test_pseudo_cqt(pad_mode):
+        D1 = librosa.pseudo_cqt(y, pad_mode='reflect')
+        D2 = librosa.pseudo_cqt(y, pad_mode=pad_mode)
+
+        assert D1.shape == D2.shape
+
+        if pad_mode != 'reflect':
+            assert not np.allclose(D1, D2)
+        else:
+            assert np.allclose(D1, D2)
+
     for pad_mode in ['reflect', 'constant']:
         yield __test_cqt, pad_mode
         yield __test_hybrid_cqt, pad_mode
+        yield __test_pseudo_cqt, pad_mode
         for center in [False, True]:
             yield __test_stft, center, pad_mode
             yield __test_ifgram, center, pad_mode

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1207,3 +1207,64 @@ def test_harmonics_2d_varying():
 def test_show_versions():
     # Nothing to test here, except that everything passes.
     librosa.show_versions()
+
+
+def test_padding():
+
+    # A simple test to verify that pad_mode is used properly by giving
+    # different answers for different modes.
+    # Does not validate the correctness of each mode.
+
+    y, sr = librosa.load('data/test1_44100.wav', sr=None, mono=True)
+
+    def __test_stft(center, pad_mode):
+        D1 = librosa.stft(y, center=center, pad_mode='reflect')
+        D2 = librosa.stft(y, center=center, pad_mode=pad_mode)
+
+        assert D1.shape == D2.shape
+
+        if center and pad_mode != 'reflect':
+            assert not np.allclose(D1, D2)
+        else:
+            assert np.allclose(D1, D2)
+
+    def __test_ifgram(center, pad_mode):
+        D1, F1 = librosa.ifgram(y, center=center, pad_mode='reflect')
+        D2, F2 = librosa.ifgram(y, center=center, pad_mode=pad_mode)
+
+        assert D1.shape == D2.shape
+
+        if center and pad_mode != 'reflect':
+            assert not np.allclose(D1, D2)
+        else:
+            assert np.allclose(D1, D2)
+            assert np.allclose(F1, F2)
+
+    def __test_cqt(pad_mode):
+        D1 = librosa.cqt(y, pad_mode='reflect')
+        D2 = librosa.cqt(y, pad_mode=pad_mode)
+
+        assert D1.shape == D2.shape
+
+        if pad_mode != 'reflect':
+            assert not np.allclose(D1, D2)
+        else:
+            assert np.allclose(D1, D2)
+
+    def __test_hybrid_cqt(pad_mode):
+        D1 = librosa.hybrid_cqt(y, pad_mode='reflect')
+        D2 = librosa.hybrid_cqt(y, pad_mode=pad_mode)
+
+        assert D1.shape == D2.shape
+
+        if pad_mode != 'reflect':
+            assert not np.allclose(D1, D2)
+        else:
+            assert np.allclose(D1, D2)
+
+    for pad_mode in ['reflect', 'constant']:
+        yield __test_cqt, pad_mode
+        yield __test_hybrid_cqt, pad_mode
+        for center in [False, True]:
+            yield __test_stft, center, pad_mode
+            yield __test_ifgram, center, pad_mode


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/master/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
Fixes #531 


#### What does this implement/fix? Explain your changes.

When STFT is center-aligned, we previously padded by reflection.

This PR allows the user to change the padding mode to anything supported by `np.pad`.  

#### Any other comments?

Note that the fancier modes (eg `linear_ramp`) require additional arguments which we don't expose.  Users desiring fancy padding should pad explicitly before calling `stft`.

The `pad_mode` parameter is also added to `ifgram` *EDIT* and `cqt`, `hybrid_cqt`, `pseudo_cqt`.

No additional action is necessary in `istft`.

~~~Question: should we expose this in `cqt` as well?~~~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/563)
<!-- Reviewable:end -->
