### PR TITLE
rasterized specshow by default

### DIFF
--- a/librosa/display.py
+++ b/librosa/display.py
@@ -545,6 +545,11 @@ def specshow(data, x_coords=None, y_coords=None,
     kwargs : additional keyword arguments
         Arguments passed through to `matplotlib.pyplot.pcolormesh`.
 
+        By default, the following options are set:
+
+            - `rasterized=True`
+            - `shading='flat'`
+            - `edgecolors='None'`
 
     Returns
     -------
@@ -648,14 +653,15 @@ def specshow(data, x_coords=None, y_coords=None,
     >>> plt.tight_layout()
     '''
 
-    kwargs.setdefault('shading', 'flat')
-
     if np.issubdtype(data.dtype, np.complex):
         warnings.warn('Trying to display complex-valued input. '
                       'Showing magnitude instead.')
         data = np.abs(data)
 
     kwargs.setdefault('cmap', cmap(data))
+    kwargs.setdefault('rasterized', True)
+    kwargs.setdefault('edgecolors', 'None')
+    kwargs.setdefault('shading', 'flat')
 
     all_params = dict(kwargs=kwargs,
                       sr=sr,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/master/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
Fixes #562 


#### What does this implement/fix? Explain your changes.

`display.specshow` now rasterizes color meshes by default.  This reduces the memory footprint of plots, especially when exported to vector graphics formats (eg, pdf or svg).

#### Any other comments?

There should be no noticeable side effects to the user.  Users that want to override this behavior can call `specshow` with `rasterized=False`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/564)
<!-- Reviewable:end -->
