### PR TITLE
added frame centering to time-domain rmse

### DIFF
--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -501,6 +501,7 @@ def spectral_rolloff(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
 
 
 def rmse(y=None, S=None, frame_length=2048, hop_length=512,
+         center=True, pad_mode='reflect',
          n_fft=Deprecated()):
     '''Compute root-mean-square (RMS) energy for each frame, either from the
     audio samples `y` or from a spectrogram `S`.
@@ -524,6 +525,16 @@ def rmse(y=None, S=None, frame_length=2048, hop_length=512,
 
     hop_length : int > 0 [scalar]
         hop length for STFT. See `librosa.core.stft` for details.
+
+    center : bool
+        If `True` and operating on time-domain input (`y`), pad the signal
+        by `frame_length//2` on either side.
+
+        If operating on spectrogram input, this has no effect.
+
+    pad_mode : str
+        Padding mode for centered analysis.  See `np.pad` for valid
+        values.
 
     n_fft : [DEPRECATED]
         .. warning:: This parameter name was deprecated in librosa 0.5.0
@@ -574,7 +585,11 @@ def rmse(y=None, S=None, frame_length=2048, hop_length=512,
     if y is not None and S is not None:
         raise ValueError('Either `y` or `S` should be input.')
     if y is not None:
-        x = util.frame(to_mono(y),
+        y = to_mono(y)
+        if center:
+            y = np.pad(y, int(frame_length // 2), mode=pad_mode)
+
+        x = util.frame(y,
                        frame_length=frame_length,
                        hop_length=hop_length)
     elif S is not None:

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -154,12 +154,12 @@ def test_trim():
         assert np.allclose(yt, y[fidx])
 
         # Verify logamp
-        rms = librosa.feature.rmse(librosa.to_mono(yt))
+        rms = librosa.feature.rmse(y=librosa.to_mono(yt), center=False)
         logamp = librosa.logamplitude(rms**2, ref=ref, top_db=None)
         assert np.all(logamp > - top_db)
 
         # Verify logamp
-        rms_all = librosa.feature.rmse(librosa.to_mono(y)).squeeze()
+        rms_all = librosa.feature.rmse(y=librosa.to_mono(y)).squeeze()
         logamp_all = librosa.logamplitude(rms_all**2, ref=ref,
                                           top_db=None)
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -373,7 +373,7 @@ def test_rmse():
 
         assert np.allclose(rmse, np.ones_like(rmse))
 
-    def __test_consistency(frame_length, hop_length):
+    def __test_consistency(frame_length, hop_length, center):
         y, sr = librosa.load(__EXAMPLE_FILE, sr=None)
 
         # Ensure audio is divisible into frame size.
@@ -385,24 +385,26 @@ def test_rmse():
                                           n_fft=frame_length,
                                           hop_length=hop_length,
                                           window=np.ones,
-                                          center=False))[0]
+                                          center=center))[0]
 
         # Try both RMS methods.
         rms1 = librosa.feature.rmse(S=S, frame_length=frame_length,
                                     hop_length=hop_length)
         rms2 = librosa.feature.rmse(y=y, frame_length=frame_length,
-                                    hop_length=hop_length)
+                                    hop_length=hop_length, center=center)
 
+        assert rms1.shape == rms2.shape
         # Normalize envelopes.
         rms1 /= rms1.max()
         rms2 /= rms2.max()
 
         # Ensure results are similar.
-        np.testing.assert_allclose(rms1, rms2, rtol=1e-2)
+        np.testing.assert_allclose(rms1, rms2, rtol=5e-2)
 
     for frame_length in [2048, 4096]:
         for hop_length in [128, 512, 1024]:
-            yield __test_consistency, frame_length, hop_length
+            for center in [False, True]:
+                yield __test_consistency, frame_length, hop_length, center
 
     for n in range(10, 100, 10):
         yield __test, n


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/master/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
Example: Fixes #528


#### What does this implement/fix? Explain your changes.

This adds a frame centering option to `rmse`, enabled by default.  Padding mode can also be supplied as an argument, matching the `stft` API.

#### Any other comments?

This changes the default behavior of RMSE, but in the direction of consistency with the rest of the package.  I'm therefore in favor of treating the previous behavior as a bug, and including this in a minor revision.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/569)
<!-- Reviewable:end -->
