### PR TITLE
Allow precomputing distance matrix in librosa.core.dtw

### DIFF
--- a/librosa/core/dtw.py
+++ b/librosa/core/dtw.py
@@ -174,17 +174,17 @@ def dtw(X=None, Y=None, C=None, metric='euclidean', step_sizes_sigma=None,
         weights_mul = np.array([1, 1, 1])
 
     if C is None and (X is None or Y is None):
-      raise ParameterError('If C is not supplied, both X and Y must be supplied')
+        raise ParameterError('If C is not supplied, both X and Y must be supplied')
     if C is not None and (X is not None or Y is not None):
-      raise ParameterError('If C is supplied, both X and Y must not be supplied')
+        raise ParameterError('If C is supplied, both X and Y must not be supplied')
 
     # calculate pair-wise distances, unless already supplied.
     if C is None:
-      # take care of dimensions
-      X = np.atleast_2d(X)
-      Y = np.atleast_2d(Y)
+        # take care of dimensions
+        X = np.atleast_2d(X)
+        Y = np.atleast_2d(Y)
 
-      C = cdist(X.T, Y.T, metric=metric)
+        C = cdist(X.T, Y.T, metric=metric)
 
     C = np.atleast_2d(C)
 

--- a/tests/test_dtw.py
+++ b/tests/test_dtw.py
@@ -3,7 +3,9 @@
 
 import librosa
 import numpy as np
+from scipy.spatial.distance import cdist
 
+from nose.tools import assert_raises
 from test_core import srand
 
 import warnings
@@ -26,6 +28,33 @@ def test_dtw_global():
     mut_D, _ = librosa.dtw(X, Y)
 
     assert np.array_equal(gt_D, mut_D)
+
+
+def test_dtw_global_supplied_distance_matrix():
+    # Example taken from:
+    # Meinard Mueller, Fundamentals of Music Processing
+    X = np.array([[1, 3, 3, 8, 1]])
+    Y = np.array([[2, 0, 0, 8, 7, 2]])
+
+    # Precompute distance matrix.
+    C = cdist(X.T, Y.T, metric='euclidean')
+
+    gt_D = np.array([[1., 2., 3., 10., 16., 17.],
+                     [2., 4., 5., 8., 12., 13.],
+                     [3., 5., 7., 10., 12., 13.],
+                     [9., 11., 13., 7., 8., 14.],
+                     [10, 10., 11., 14., 13., 9.]])
+
+    # Supply precomputed distance matrix and specify an invalid distance
+    # metric to verify that it isn't used.
+    mut_D, _ = librosa.dtw(C=C, metric='invalid')
+
+    assert np.array_equal(gt_D, mut_D)
+
+
+def test_dtw_incompatible_args():
+  assert_raises(librosa.util.exceptions.ParameterError, librosa.dtw, C=1, X=1, Y=1)
+  assert_raises(librosa.util.exceptions.ParameterError, librosa.dtw, C=None, X=None, Y=None)
 
 
 def test_dtw_global_diagonal():


### PR DESCRIPTION
Modifies librosa.core.dtw to allow passing in a precomputed distance matrix. 

Useful if you want to calculate the penalty based on the distance matrix, similar to https://github.com/craffel/pretty-midi/blob/master/examples/align_midi.py

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/574)
<!-- Reviewable:end -->
