### PR TITLE
Fix some incorrect module names in show_versions

### DIFF
--- a/librosa/version.py
+++ b/librosa/version.py
@@ -31,7 +31,7 @@ def show_versions():
     core_deps = ['audioread',
                  'numpy',
                  'scipy',
-                 'scikit-learn',
+                 'sklearn',
                  'joblib',
                  'decorator',
                  'six',
@@ -40,7 +40,7 @@ def show_versions():
     extra_deps = ['numpydoc',
                   'sphinx',
                   'sphinx_rtd_theme',
-                  'sphinxcontrib-versioning',
+                  'sphinxcontrib',
                   'matplotlib',
                   'numba']
 

--- a/librosa/version.py
+++ b/librosa/version.py
@@ -40,7 +40,7 @@ def show_versions():
     extra_deps = ['numpydoc',
                   'sphinx',
                   'sphinx_rtd_theme',
-                  'sphinxcontrib',
+                  'sphinxcontrib.versioning',
                   'matplotlib',
                   'numba']
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/master/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
<!-- Example: Fixes #123 -->

https://github.com/librosa/librosa/issues/543

#### What does this implement/fix? Explain your changes.

This fixes some incorrect module names in `librosa.show_versions`. Without this patch, scikit-learn and sphinxcontrib versions don't show up in the output. 

before:
```py
In [2]: librosa.show_versions()
INSTALLED VERSIONS
------------------
python: 3.6.0 |Anaconda custom (64-bit)| (default, Dec 23 2016, 12:22:00) 
[GCC 4.4.7 20120313 (Red Hat 4.4.7-1)]

librosa: 0.5.1

audioread: installed, no version number available
numpy: 1.12.1
scipy: 0.19.0
scikit-learn: None
joblib: 0.11
decorator: 4.0.11
six: 1.10.0
resampy: 0.1.5

numpydoc: installed, no version number available
sphinx: 1.5.1
sphinx_rtd_theme: 0.2.4
sphinxcontrib-versioning: None
matplotlib: 2.0.0
numba: 0.32.0
```

after:
```py
In [2]: librosa.show_versions()
INSTALLED VERSIONS
------------------
python: 3.6.0 |Anaconda custom (64-bit)| (default, Dec 23 2016, 12:22:00) 
[GCC 4.4.7 20120313 (Red Hat 4.4.7-1)]

librosa: 0.5.1

audioread: installed, no version number available
numpy: 1.12.1
scipy: 0.19.0
sklearn: 0.18.1
joblib: 0.11
decorator: 4.0.11
six: 1.10.0
resampy: 0.1.5

numpydoc: installed, no version number available
sphinx: 1.5.1
sphinx_rtd_theme: 0.2.4
sphinxcontrib.versioning: 2.2.1
matplotlib: 2.0.0
numba: 0.32.0
```

#### Any other comments?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/587)
<!-- Reviewable:end -->
