### PR TITLE
import display submodule

### DIFF
--- a/librosa/__init__.py
+++ b/librosa/__init__.py
@@ -11,6 +11,7 @@ from .version import show_versions
 from . import cache
 from . import core
 from . import beat
+from . import display
 from . import decompose
 from . import effects
 from . import feature


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/master/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
<!-- Example: Fixes #123 -->


#### What does this implement/fix? Explain your changes.
when following the example on http://librosa.github.io/librosa/generated/librosa.feature.chroma_stft.html
on how to use specshow I got the following traceback: "AtributeError: module 'librosa' has no attribute 'display' " This commit fixes the previous issue. 
My code imported only "librosa" and it worked when doing "from librosa import display". 

#### Any other comments?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/588)
<!-- Reviewable:end -->
