### PR TITLE
Checking input signal is valid, moved

### DIFF
--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -154,9 +154,11 @@ def stft(y, n_fft=2048, hop_length=None, win_length=None, window='hann',
     # Reshape so that the window can be broadcast
     fft_window = fft_window.reshape((-1, 1))
 
+    # Check audio is valid
+    util.valid_audio(y)
+
     # Pad the time series so that frames are centered
     if center:
-        util.valid_audio(y)
         y = np.pad(y, int(n_fft // 2), mode=pad_mode)
 
     # Window the time series.


### PR DESCRIPTION
Checks were only being performed if center channel, moved call outside if statement

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/master/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
Fixes https://github.com/librosa/librosa/issues/592


#### What does this implement/fix? Explain your changes.
audio checking wasn't being performed unless audio was center , we needed to move that upward and out of the if statement so all audio gets checked

#### Any other comments?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/593)
<!-- Reviewable:end -->
