### PR TITLE
fixed that some steps are ignored when len(step_size_sigma)>3 in dtw and added a parameters check

### DIFF
--- a/librosa/core/dtw.py
+++ b/librosa/core/dtw.py
@@ -169,9 +169,14 @@ def dtw(X=None, Y=None, C=None, metric='euclidean', step_sizes_sigma=None,
     if step_sizes_sigma is None:
         step_sizes_sigma = np.array([[1, 1], [0, 1], [1, 0]])
     if weights_add is None:
-        weights_add = np.array([0, 0, 0])
+        weights_add = np.zeros(len(step_sizes_sigma))
     if weights_mul is None:
-        weights_mul = np.array([1, 1, 1])
+        weights_mul = np.ones(len(step_sizes_sigma))
+
+    if len(step_sizes_sigma) != len(weights_add):
+        raise ParameterError('len(weights_add) must be equal to len(step_sizes_sigma)')
+    if len(step_sizes_sigma) != len(weights_mul):
+        raise ParameterError('len(weights_mul) must be equal to len(step_sizes_sigma)')
 
     if C is None and (X is None or Y is None):
         raise ParameterError('If C is not supplied, both X and Y must be supplied')


### PR DESCRIPTION
Hi there,
I found that some steps are ignored when `len(step_size_sigma) > 3` if `weights_add is None` or `weights_mul is None` in `librosa.dtw`.

For example, 
```python
D, wp = librosa.dtw(X, Y, subseq = True, backtrack = True, step_sizes_sigma = np.array([[2,1],[1,0],[1,1],[0,1],[1,2]]))
```

The last two parts of `step_sizes_sigma` will be ignored.

The reason is that the length of the default parameters of `weights_add` and `weights_mul` are both 3.


```python
# librosa/core/dtw.py (def dtw) line: 171-174
    if weights_add is None:
        weights_add = np.array([0, 0, 0])
    if weights_mul is None:
        weights_mul = np.array([1, 1, 1])
```

However, `zip` will cut down the extra parts in function `calc_accu_cost`.

```python
# librosa/core/dtw.py (def calc_accu_cost) line: 289-290
            for cur_step_idx, cur_w_add, cur_w_mul in zip(range(step_sizes_sigma.shape[0]),
                                                          weights_add, weights_mul):

```

It is a test.

```python
for a, b in zip(range(3), range(10)):
    print (a, b)
```

The output is that in Python2 or Python3:
```
(0, 0)
(1, 1)
(2, 2)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/594)
<!-- Reviewable:end -->
