### PR TITLE
fix travis builds on trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
 sudo: false
 
-addons:
-  apt:
-    packages:
-    - ffmpeg
-
 cache:
   directories:
   - $HOME/env
@@ -15,14 +10,19 @@ notifications:
   email: false
 
 python:
-    - "2.7"
-    - "3.4"
-    - "3.5"
-    - "3.6"
+    - 2.7
+    - 3.4
+    - 3.5
+    - 3.6
 
 env:
     - ENABLE_NUMBA=false
     - ENABLE_NUMBA=true
+
+matrix:
+    exclude:
+        - python: 3.4
+        - env: ENABLE_NUMBA=true
 
 before_install:
     - bash .travis_dependencies.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
 matrix:
     exclude:
         - python: 3.4
-        - env: ENABLE_NUMBA=true
+          env: ENABLE_NUMBA=true
 
 before_install:
     - bash .travis_dependencies.sh

--- a/.travis_dependencies.sh
+++ b/.travis_dependencies.sh
@@ -33,6 +33,8 @@ if [ ! -d "$src" ]; then
 
         source activate $ENV_NAME
 
+        conda install -c conda-forge ffmpeg
+
         pip install python-coveralls
 
         if [ "$ENABLE_NUMBA" = true ]; then


### PR DESCRIPTION
#### Reference Issue
Fixes #603 

#### What does this implement/fix? Explain your changes.
This PR changes the travis config to install ffmpeg from conda-forge instead of apt.

It also adds a skip line for python 3.4 + numba in the build matrix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/604)
<!-- Reviewable:end -->
