### PR TITLE
clip effects.split output to duration

### DIFF
--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -542,5 +542,8 @@ def split(y, top_db=60, ref=np.max, frame_length=2048, hop_length=512):
     edges = core.frames_to_samples(np.concatenate(edges),
                                    hop_length=hop_length)
 
+    # Clip to the signal duration
+    edges = np.minimum(edges, y.shape[-1])
+
     # Stack the results back as an ndarray
     return edges.reshape((-1, 2))

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -197,6 +197,8 @@ def test_split():
                                           frame_length=frame_length,
                                           hop_length=hop_length)
 
+        assert np.all(intervals <= y.shape[-1])
+
         int_match = librosa.util.match_intervals(intervals, idx_true)
 
         for i in range(len(intervals)):
@@ -237,6 +239,14 @@ def test_split():
     # And without the silence at the end
     y = np.ones(5 * sr)
     y[::2] *= -1
+    idx_true = np.asarray([[0, 5 * sr]])
+    for frame_length in [1024, 2048, 4096]:
+        for hop_length in [256, 512, 1024]:
+            for top_db in [20, 60, 80]:
+                yield __test, hop_length, frame_length, top_db
+
+    # And once with a constant signal
+    y = np.ones(5 * sr)
     idx_true = np.asarray([[0, 5 * sr]])
     for frame_length in [1024, 2048, 4096]:
         for hop_length in [256, 512, 1024]:


### PR DESCRIPTION
#### Reference Issue
Fixes #617


#### What does this implement/fix? Explain your changes.

`effects.split` was returning sample indices beyond the input duration, as a result of frame-center to sample conversion.  This PR clips the sample indices to the valid range.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/619)
<!-- Reviewable:end -->
