### PR TITLE
fixed setup.py to prevent #614

### DIFF
--- a/.travis_dependencies.sh
+++ b/.travis_dependencies.sh
@@ -11,7 +11,7 @@ conda_create ()
     conda update -q conda
     conda config --add channels pypi
     conda info -a
-    deps='pip numpy scipy nose coverage scikit-learn matplotlib'
+    deps='pip numpy scipy nose coverage scikit-learn!=0.19.0 matplotlib'
 
     conda create -q -n $ENV_NAME "python=$TRAVIS_PYTHON_VERSION" $deps
     conda update --all

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'audioread >= 2.0.0',
         'numpy >= 1.8.0',
         'scipy >= 0.13.0',
-        'scikit-learn >= 0.14.0',
+        'scikit-learn >= 0.14.0, != 0.19.0',
         'joblib >= 0.7.0',
         'decorator >= 3.0.0',
         'six >= 1.3',


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/master/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
Fixes: #614 (sort of)


#### What does this implement/fix? Explain your changes.

This PR updates the requirements file to forbid scikit-learn 0.19.0 from satisfying installation requirements, in response to a bug noted in #614.


#### Any other comments?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/620)
<!-- Reviewable:end -->
