### PR TITLE
Fix hz_to_midi docstring

### DIFF
--- a/librosa/core/time_frequency.py
+++ b/librosa/core/time_frequency.py
@@ -509,7 +509,7 @@ def midi_to_hz(notes):
 
 
 def hz_to_midi(frequencies):
-    """Get the closest MIDI note number(s) for given frequencies
+    """Get MIDI note number(s) for given frequencies
 
     Examples
     --------
@@ -525,8 +525,8 @@ def hz_to_midi(frequencies):
 
     Returns
     -------
-    note_nums     : np.ndarray [shape=(n,), dtype=int]
-        closest MIDI notes to `frequencies`
+    note_nums     : np.ndarray [shape=(n,), dtype=float]
+        MIDI notes to `frequencies`
 
     See Also
     --------


### PR DESCRIPTION
`hz_to_midi` returns floats which is nice (like most `ftom` implementations) but the docstring makes it sound like results would be rounded.

Sidenote: maybe A4's frequency should be a parameter?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/622)
<!-- Reviewable:end -->
