### PR TITLE
Added numba strong requirement

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,3 +2,7 @@
 omit =
     */python?.?/*
     */site-packages/nose/*
+exclude_lines =
+    @numba.jit
+    @jit
+    pragma: no cover

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,15 +15,6 @@ python:
     - 3.5
     - 3.6
 
-env:
-    - ENABLE_NUMBA=false
-    - ENABLE_NUMBA=true
-
-matrix:
-    exclude:
-        - python: 3.4
-          env: ENABLE_NUMBA=true
-
 before_install:
     - bash .travis_dependencies.sh
     - export PATH="$HOME/env/miniconda$TRAVIS_PYTHON_VERSION/bin:$PATH";

--- a/.travis_dependencies.sh
+++ b/.travis_dependencies.sh
@@ -11,7 +11,7 @@ conda_create ()
     conda update -q conda
     conda config --add channels pypi
     conda info -a
-    deps='pip numpy scipy nose coverage scikit-learn!=0.19.0 matplotlib'
+    deps='pip numpy scipy nose coverage scikit-learn!=0.19.0 matplotlib numba'
 
     conda create -q -n $ENV_NAME "python=$TRAVIS_PYTHON_VERSION" $deps
     conda update --all
@@ -36,10 +36,6 @@ if [ ! -d "$src" ]; then
         conda install -c conda-forge ffmpeg
 
         pip install python-coveralls
-
-        if [ "$ENABLE_NUMBA" = true ]; then
-            conda install numba
-        fi
 
         source deactivate
     popd

--- a/librosa/core/dtw.py
+++ b/librosa/core/dtw.py
@@ -3,8 +3,9 @@
 """Sequence Alignment with Dynamic Time Warping."""
 
 import numpy as np
+from numba import jit
+
 from scipy.spatial.distance import cdist
-from ..util.decorators import optional_jit
 from ..util.exceptions import ParameterError
 
 __all__ = ['dtw', 'fill_off_diagonal']
@@ -241,7 +242,7 @@ def dtw(X=None, Y=None, C=None, metric='euclidean', step_sizes_sigma=None,
         return D
 
 
-@optional_jit(nopython=True)
+@jit(nopython=True)
 def calc_accu_cost(C, D, D_steps, step_sizes_sigma,
                    weights_mul, weights_add, max_0, max_1):
     '''Calculate the accumulated cost matrix D.
@@ -309,7 +310,7 @@ def calc_accu_cost(C, D, D_steps, step_sizes_sigma,
     return D, D_steps
 
 
-@optional_jit(nopython=True)
+@jit(nopython=True)
 def backtracking(D_steps, step_sizes_sigma):
     '''Backtrack optimal warping path.
 

--- a/librosa/util/decorators.py
+++ b/librosa/util/decorators.py
@@ -5,10 +5,11 @@
 
 import warnings
 from decorator import decorator
-from functools import wraps
 import six
+from numba.decorators import jit as optional_jit
 
 __all__ = ['moved', 'deprecated', 'optional_jit']
+
 
 def moved(moved_from, version, version_removed):
     '''This is a decorator which can be used to mark functions
@@ -57,28 +58,3 @@ def deprecated(version, version_removed):
         return func(*args, **kwargs)
 
     return decorator(__wrapper)
-
-
-'''Define the optional_jit decorator
-   If numba is importable, use numba.jit.
-   Else create a no-op decorator.
-'''
-try:
-    from numba.decorators import jit as optional_jit
-except ImportError:
-    # Decorator with optional arguments borrowed from
-    # http://stackoverflow.com/a/10288927
-    def magical_decorator(decorator):
-        @wraps(decorator)
-        def inner(*args, **kw):
-            if len(args) == 1 and not kw and callable(args[0]):
-                return decorator()(args[0])
-            else:
-                return decorator(*args, **kw)
-        return inner
-
-    @magical_decorator
-    def optional_jit(*_, **__):
-        def __wrapper(func, *args, **kwargs):
-            return func(*args, **kwargs)
-        return decorator(__wrapper)

--- a/setup.py
+++ b/setup.py
@@ -38,13 +38,12 @@ setup(
         'joblib >= 0.7.0',
         'decorator >= 3.0.0',
         'six >= 1.3',
-        'resampy >= 0.1.2'
+        'resampy >= 0.2.0'
     ],
     extras_require={
         'docs': ['numpydoc', 'sphinx!=1.3.1', 'sphinx_rtd_theme',
                  'matplotlib >= 2.0.0',
                  'sphinxcontrib-versioning >= 2.2.1'],
-        'numba': ['numba >= 0.25'],
         'tests': ['matplotlib >= 2.0.0'],
         'display': ['matplotlib >= 1.5'],
     }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/master/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
Fixes #624 


#### What does this implement/fix? Explain your changes.

This PR updates the resampy requirement to 0.2, and replaces `optional_jit` by a direct import of `numba.jit`.

#### Any other comments?

The numba-free test environments have been removed.

`optional_jit` should be properly deprecated and removed in the 0.7 series.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/625)
<!-- Reviewable:end -->
