### PR TITLE
implemented multiband tempogram. fixes #518

### DIFF
--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -646,6 +646,44 @@ def test_tempogram_odf():
                     yield __test_peaks, tempo, win_length, window, norm
 
 
+def test_tempogram_odf_multi():
+
+    sr = 22050
+    hop_length = 512
+    duration = 8
+
+    # Generate a synthetic onset envelope
+    def __test(center, win_length, window, norm):
+        # Generate an evenly-spaced pulse train
+        odf = np.zeros((10, duration * sr // hop_length))
+        for i in range(10):
+            spacing = sr * 60. // (hop_length * (60 + 12 * i))
+            odf[i, ::int(spacing)] = 1
+
+        tempogram = librosa.feature.tempogram(onset_envelope=odf,
+                                              sr=sr,
+                                              hop_length=hop_length,
+                                              win_length=win_length,
+                                              window=window,
+                                              norm=norm)
+
+        for i in range(10):
+            tg_local = librosa.feature.tempogram(onset_envelope=odf[i],
+                                                 sr=sr,
+                                                 hop_length=hop_length,
+                                                 win_length=win_length,
+                                                 window=window,
+                                                 norm=norm)
+
+            assert np.allclose(tempogram[i], tg_local)
+
+    for center in [False, True]:
+        for win_length in [192, 384]:
+            for window in ['hann', np.ones, np.ones(win_length)]:
+                for norm in [None, 1, 2, np.inf]:
+                    yield __test, center, win_length, window, norm
+
+
 def test_cens():
     # load CQT data from Chroma Toolbox
     ct_cqt = load(os.path.join('data', 'features-CT-cqt.mat'))


### PR DESCRIPTION
#### Reference Issue
Fixes #518 


#### What does this implement/fix? Explain your changes.

This PR adds multi-channel tempogram support, eg for analyzing the output of `onset_strength_multi`.  The implementation is naive in that it simply iterates over each band of the input onset envelope and combines the results.  Probably there's some redundant work being done here, but this works for now.

#### Any other comments?

Testing is regression against independent sub-band calculation.

This also works nicely with the fast Mellin transform by setting `axis=1`, which should make it easier to reproduce Prockup'15's methods.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/633)
<!-- Reviewable:end -->
