### PR TITLE
stft conjugates the correct half of the spectrum

### DIFF
--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -178,7 +178,7 @@ def stft(y, n_fft=2048, hop_length=None, win_length=None, window='hann',
         # RFFT and Conjugate here to match phase from DPWE code
         stft_matrix[:, bl_s:bl_t] = fft.fft(fft_window *
                                             y_frames[:, bl_s:bl_t],
-                                            axis=0)[:stft_matrix.shape[0]].conj()
+                                            axis=0)[:stft_matrix.shape[0]]
 
     return stft_matrix
 
@@ -293,7 +293,7 @@ def istft(stft_matrix, hop_length=None, win_length=None, window='hann',
     for i in range(n_frames):
         sample = i * hop_length
         spec = stft_matrix[:, i].flatten()
-        spec = np.concatenate((spec.conj(), spec[-2:0:-1]), 0)
+        spec = np.concatenate((spec, spec[-2:0:-1].conj()), 0)
         ytmp = ifft_window * fft.ifft(spec).real
 
         y[sample:(sample + n_fft)] = y[sample:(sample + n_fft)] + ytmp
@@ -458,7 +458,7 @@ def ifgram(y, sr=22050, n_fft=2048, hop_length=None, win_length=None,
     # Pylint does not correctly infer the type here, but it's correct.
     # pylint: disable=maybe-no-member
     freq_angular = freq_angular.reshape((-1, 1))
-    bin_offset = (phase * diff_stft).imag / mag
+    bin_offset = (-phase * diff_stft).imag / mag
 
     bin_offset[mag < ref_power**0.5] = 0
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -228,7 +228,8 @@ def test_stft():
                          window=window,
                          center=False)
 
-        assert np.allclose(D, DATA['D'])
+        # conjugate matlab stft to fix the ' vs .' bug
+        assert np.allclose(D, DATA['D'].conj())
 
     for infile in files('data/core-stft-*.mat'):
         yield (__test, infile)


### PR DESCRIPTION
#### Reference Issue
Fixes: #521 


#### What does this implement/fix? Explain your changes.

As mentioned in #521, the stft implementation was originally biult to match the reference matlab version, which conjugated the spectrum in the wrong place.  This PR fixes that, so that we now match `scipy.signal.stft` (up to a constant magnitude scaling dependent on `n_fft` and the window function).

#### Any other comments?

This definitely breaks bitwise compatibility for old stft calculations, though only in the phase.

There may be unintended consequences for things like `cqt`/`icqt`, so I'd like to get this merged prior to finishing #435.

Comments are welcome from @dpwe and @Jonathan-LeRoux

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/634)
<!-- Reviewable:end -->
