### PR TITLE
util.normalize preserves dtype

### DIFF
--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -751,23 +751,24 @@ def normalize(S, norm=np.inf, axis=0, threshold=None, fill=None):
     # indices where norm is below the threshold
     small_idx = length < threshold
 
+    Snorm = np.empty_like(S)
     if fill is None:
         # Leave small indices un-normalized
         length[small_idx] = 1.0
-        Snorm = S / length
+        Snorm[:] = S / length
 
     elif fill:
         # If we have a non-zero fill value, we locate those entries by
         # doing a nan-divide.
         # If S was finite, then length is finite (except for small positions)
         length[small_idx] = np.nan
-        Snorm = S / length
+        Snorm[:] = S / length
         Snorm[np.isnan(Snorm)] = fill_norm
     else:
         # Set small values to zero by doing an inf-divide.
         # This is safe (by IEEE-754) as long as S is finite.
         length[small_idx] = np.inf
-        Snorm = S / length
+        Snorm[:] = S / length
 
     return Snorm
 

--- a/tests/test_decompose.py
+++ b/tests/test_decompose.py
@@ -133,12 +133,12 @@ def test_nn_filter_mean():
     X = np.random.randn(10, 100)
 
     # Build a recurrence matrix, just for testing purposes
-    rec = librosa.segment.recurrence_matrix(X).astype(np.float)
+    rec = librosa.segment.recurrence_matrix(X)
 
     X_filtered = librosa.decompose.nn_filter(X)
 
     # Normalize the recurrence matrix so dotting computes an average
-    rec = librosa.util.normalize(rec, axis=1, norm=1)
+    rec = librosa.util.normalize(rec.astype(np.float), axis=1, norm=1)
 
     assert np.allclose(X_filtered, X.dot(rec.T))
 
@@ -149,10 +149,10 @@ def test_nn_filter_mean_rec():
     X = np.random.randn(10, 100)
 
     # Build a recurrence matrix, just for testing purposes
-    rec = librosa.segment.recurrence_matrix(X).astype(np.float)
+    rec = librosa.segment.recurrence_matrix(X)
 
     # Knock out the first three rows of links
-    rec[:3] = 0
+    rec[:3] = False
 
     X_filtered = librosa.decompose.nn_filter(X, rec=rec)
 
@@ -160,7 +160,7 @@ def test_nn_filter_mean_rec():
         assert np.allclose(X_filtered[:, i], X[:, i])
 
     # Normalize the recurrence matrix
-    rec = librosa.util.normalize(rec, axis=1, norm=1)
+    rec = librosa.util.normalize(rec.astype(np.float), axis=1, norm=1)
     assert np.allclose(X_filtered[:, 3:], (X.dot(rec.T))[:, 3:])
 
 
@@ -170,12 +170,12 @@ def test_nn_filter_mean_rec_sparse():
     X = np.random.randn(10, 100)
 
     # Build a recurrence matrix, just for testing purposes
-    rec = librosa.segment.recurrence_matrix(X, sparse=True).astype(np.float)
+    rec = librosa.segment.recurrence_matrix(X, sparse=True)
 
     X_filtered = librosa.decompose.nn_filter(X, rec=rec)
 
     # Normalize the recurrence matrix
-    rec = librosa.util.normalize(rec.toarray(), axis=1, norm=1)
+    rec = librosa.util.normalize(rec.toarray().astype(np.float), axis=1, norm=1)
     assert np.allclose(X_filtered, (X.dot(rec.T)))
 
 

--- a/tests/test_decompose.py
+++ b/tests/test_decompose.py
@@ -133,7 +133,7 @@ def test_nn_filter_mean():
     X = np.random.randn(10, 100)
 
     # Build a recurrence matrix, just for testing purposes
-    rec = librosa.segment.recurrence_matrix(X)
+    rec = librosa.segment.recurrence_matrix(X).astype(np.float)
 
     X_filtered = librosa.decompose.nn_filter(X)
 
@@ -149,7 +149,7 @@ def test_nn_filter_mean_rec():
     X = np.random.randn(10, 100)
 
     # Build a recurrence matrix, just for testing purposes
-    rec = librosa.segment.recurrence_matrix(X)
+    rec = librosa.segment.recurrence_matrix(X).astype(np.float)
 
     # Knock out the first three rows of links
     rec[:3] = 0
@@ -170,7 +170,7 @@ def test_nn_filter_mean_rec_sparse():
     X = np.random.randn(10, 100)
 
     # Build a recurrence matrix, just for testing purposes
-    rec = librosa.segment.recurrence_matrix(X, sparse=True)
+    rec = librosa.segment.recurrence_matrix(X, sparse=True).astype(np.float)
 
     X_filtered = librosa.decompose.nn_filter(X, rec=rec)
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -162,6 +162,10 @@ def test_normalize():
     def __test_pass(X, norm, axis):
         X_norm = librosa.util.normalize(X, norm=norm, axis=axis)
 
+        # Shape and dtype checks
+        assert X_norm.dtype == X.dtype
+        assert X_norm.shape == X.shape
+
         if norm is None:
             assert np.allclose(X, X_norm)
             return
@@ -225,7 +229,8 @@ def test_normalize_threshold():
 def test_normalize_fill():
 
     def __test(fill, norm, threshold, axis, x, result):
-        xn = librosa.util.normalize(x, axis=axis,
+        xn = librosa.util.normalize(x,
+                                    axis=axis,
                                     fill=fill,
                                     threshold=threshold,
                                     norm=norm)
@@ -274,7 +279,8 @@ def test_normalize_fill():
     axis = None
     threshold = None
     norm = 2
-    yield __test, None, norm, threshold, axis, np.asarray([[3, 0], [0, 4]]), np.asarray([[0.6, 0], [0, 0.8]])
+    yield __test, None, norm, threshold, axis, np.asarray([[3, 0], [0, 4]]), np.asarray([[0, 0], [0, 0]])
+    yield __test, None, norm, threshold, axis, np.asarray([[3., 0], [0, 4]]), np.asarray([[0.6, 0], [0, 0.8]])
 
 
 def test_axis_sort():


### PR DESCRIPTION
#### Reference Issue
Implements #580 


#### What does this implement/fix? Explain your changes.

This PR changes `util.normalize` so that the output matches the dtype of the input array.

#### Any other comments?

There might be some side-effects if we were implicitly assuming `int->float` conversion when calling this function.  I'll do an audit of the code base for calls to normalize before merging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/636)
<!-- Reviewable:end -->
