### PR TITLE
Modified random fake audio generation

### DIFF
--- a/docs/ioformats.rst
+++ b/docs/ioformats.rst
@@ -121,7 +121,7 @@ convert to a given PCM subtype and additionally support several compressed forma
     import soundfile as sf
 
     rate = 44100
-    data = np.random.randn(rate * 10, 2)
+    data = np.random.uniform(-1, 1, size = (rate * 10, 2))
 
     # Write out audio as 24bit PCM WAV
     sf.write('stereo_file.wav', data, samplerate, subtype='PCM_24')

--- a/docs/ioformats.rst
+++ b/docs/ioformats.rst
@@ -104,7 +104,7 @@ Write out audio files
     import librosa
 
     rate = 44100
-    data = np.random.randn(rate * 10, 2)
+    audio = np.random.uniform(-1, 1, size = (rate * 10, 2))
 
     maxv = np.iinfo(np.int16).max
     librosa.output.write_wav(


### PR DESCRIPTION
Fixes [#635](https://github.com/librosa/librosa/issues/635).
Modified random audio generation to restrict it to the range of [-1, 1]. Changed data -> audio

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/637)
<!-- Reviewable:end -->
