### PR TITLE
Mpl display test fix

### DIFF
--- a/.travis_dependencies.sh
+++ b/.travis_dependencies.sh
@@ -11,7 +11,7 @@ conda_create ()
     conda update -q conda
     conda config --add channels pypi
     conda info -a
-    deps='pip numpy scipy nose coverage scikit-learn!=0.19.0 matplotlib numba'
+    deps='pip numpy scipy nose coverage scikit-learn!=0.19.0 matplotlib==2.0 numba'
 
     conda create -q -n $ENV_NAME "python=$TRAVIS_PYTHON_VERSION" $deps
     conda update --all

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         'docs': ['numpydoc', 'sphinx!=1.3.1', 'sphinx_rtd_theme',
                  'matplotlib >= 2.0.0',
                  'sphinxcontrib-versioning >= 2.2.1'],
-        'tests': ['matplotlib >= 2.0.0'],
+        'tests': ['matplotlib == 2.0'],
         'display': ['matplotlib >= 1.5'],
     }
 )


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Matplotlib 2.1 switched to pytest from nosetests, which breaks the unit tests for the display module.

This PR is a short-term fix to pin the mpl version to 2.0.  The long-term solution will be to migrate to pytest as well, but that's a much bigger job than we can realistically accomplish before 0.6.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/643)
<!-- Reviewable:end -->
