### PR TITLE
Trimming should work for zero-only signals as well

### DIFF
--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -473,11 +473,15 @@ def trim(y, top_db=60, ref=np.max, frame_length=2048, hop_length=512):
 
     nonzero = np.flatnonzero(non_silent)
 
-    # Compute the start and end positions
-    # End position goes one frame past the last non-zero
-    start = int(core.frames_to_samples(nonzero[0], hop_length))
-    end = min(y.shape[-1],
-              int(core.frames_to_samples(nonzero[-1] + 1, hop_length)))
+    if nonzero.size > 0:
+        # Compute the start and end positions
+        # End position goes one frame past the last non-zero
+        start = int(core.frames_to_samples(nonzero[0], hop_length))
+        end = min(y.shape[-1],
+                int(core.frames_to_samples(nonzero[-1] + 1, hop_length)))
+    else:
+        # The signal only contains zeros
+        start, end = 0, 0
 
     # Build the mono/stereo index
     full_index = [slice(None)] * y.ndim

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -188,6 +188,17 @@ def test_trim():
             yield __test, y[0], top_db, ref, trim_duration
 
 
+def test_trim_empty():
+
+    y = np.zeros(1)
+
+    yt, idx = librosa.effects.trim(y, ref=1)
+
+    assert yt.size == 0
+    assert idx[0] == 0
+    assert idx[1] == 0
+
+
 def test_split():
 
     def __test(hop_length, frame_length, top_db):


### PR DESCRIPTION
#### Reference Issue
Fixes #645 

#### What does this implement/fix? Explain your changes.
Special handling of start and end position calculation for zero-only signals

#### Any other comments?
N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/646)
<!-- Reviewable:end -->
