### PR TITLE
Fix FutureWarning from NumPy

### DIFF
--- a/librosa/display.py
+++ b/librosa/display.py
@@ -653,7 +653,7 @@ def specshow(data, x_coords=None, y_coords=None,
     >>> plt.tight_layout()
     '''
 
-    if np.issubdtype(data.dtype, np.complex):
+    if np.issubdtype(data.dtype, np.complexfloating):
         warnings.warn('Trying to display complex-valued input. '
                       'Showing magnitude instead.')
         data = np.abs(data)

--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -287,7 +287,7 @@ def pitch_shift(y, sr, n_steps, bins_per_octave=12):
     ...                                          bins_per_octave=24)
     '''
 
-    if bins_per_octave < 1 or not np.issubdtype(type(bins_per_octave), np.int):
+    if bins_per_octave < 1 or not np.issubdtype(type(bins_per_octave), np.integer):
         raise ParameterError('bins_per_octave must be a positive integer.')
 
     rate = 2.0 ** (-float(n_steps) / bins_per_octave)

--- a/librosa/output.py
+++ b/librosa/output.py
@@ -216,7 +216,7 @@ def write_wav(path, y, sr, norm=False):
     util.valid_audio(y, mono=False)
 
     # normalize
-    if norm and np.issubdtype(y.dtype, np.float):
+    if norm and np.issubdtype(y.dtype, np.floating):
         wav = util.normalize(y, norm=np.inf, axis=None)
     else:
         wav = y

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -1736,7 +1736,7 @@ def tiny(x):
     x = np.asarray(x)
 
     # Only floating types generate a tiny
-    if np.issubdtype(x.dtype, np.dtype(float).type) or np.issubdtype(x.dtype, np.dtype(complex).type):
+    if np.issubdtype(x.dtype, np.floating) or np.issubdtype(x.dtype, np.complexfloating):
         dtype = x.dtype
     else:
         dtype = np.float32

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -1736,7 +1736,7 @@ def tiny(x):
     x = np.asarray(x)
 
     # Only floating types generate a tiny
-    if np.issubdtype(x.dtype, float) or np.issubdtype(x.dtype, complex):
+    if np.issubdtype(x.dtype, np.dtype(float).type) or np.issubdtype(x.dtype, np.dtype(complex).type):
         dtype = x.dtype
     else:
         dtype = np.float32

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -155,7 +155,7 @@ def valid_audio(y, mono=True):
     if not isinstance(y, np.ndarray):
         raise ParameterError('data must be of type numpy.ndarray')
 
-    if not np.issubdtype(y.dtype, np.float):
+    if not np.issubdtype(y.dtype, np.floating):
         raise ParameterError('data must be floating-point')
 
     if mono and y.ndim != 1:
@@ -1537,7 +1537,7 @@ def sync(data, idx, aggregate=None, pad=True, axis=-1):
 
     if np.all([isinstance(_, slice) for _ in idx]):
         slices = idx
-    elif np.all([np.issubdtype(type(_), np.int) for _ in idx]):
+    elif np.all([np.issubdtype(type(_), np.integer) for _ in idx]):
         slices = index_to_slice(np.asarray(idx), 0, shape[axis], pad=pad)
     else:
         raise ParameterError('Invalid index set: {}'.format(idx))
@@ -1651,7 +1651,7 @@ def softmask(X, X_ref, power=1, split_zeros=False):
 
     # We're working with ints, cast to float.
     dtype = X.dtype
-    if not np.issubdtype(dtype, float):
+    if not np.issubdtype(dtype, np.floating):
         dtype = np.float32
 
     # Re-scale the input arrays relative to the larger value


### PR DESCRIPTION
Fix NumPy warnings:

>FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.

>FutureWarning: Conversion of the second argument of issubdtype from `complex` to `np.complexfloating` is deprecated. In future, it will be treated as `np.complex128 == np.dtype(complex).type`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/656)
<!-- Reviewable:end -->
