### PR TITLE
Add warnings when phase is lost

### DIFF
--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -850,6 +850,8 @@ def power_to_db(S, ref=1.0, amin=1e-10, top_db=80.0):
 
     """
 
+    S = np.array(S)
+
     if amin <= 0:
         raise ParameterError('amin must be strictly positive')
 
@@ -943,6 +945,9 @@ def amplitude_to_db(S, ref=1.0, amin=1e-5, top_db=80.0):
     -----
     This function caches at level 30.
     '''
+
+    S = np.array(S)
+
     if np.issubdtype(S.dtype, np.complexfloating):
         warnings.warn('Input was complex. Phase information will be discarded.'
                       'Only input magnitudes to avoid this warning (e.g. `np.abs(S)`).')

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -537,7 +537,8 @@ def magphase(D, power=1):
 
     """
 
-    mag = np.pow(np.abs(D), power)
+    mag = np.abs(D)
+    mag **= power
     phase = np.exp(1.j * np.angle(D))
 
     return mag, phase

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -861,7 +861,7 @@ def power_to_db(S, ref=1.0, amin=1e-10, top_db=80.0):
     if np.issubdtype(S.dtype, np.complexfloating):
         warnings.warn('power_to_db was called on complex input so phase '
                       'information will be discarded. To suppress this warning, '
-                      'call power_to_db(magphase(S, power=2)[0]) instead.')
+                      'call power_to_db(magphase(D, power=2)[0]) instead.')
         magnitude = np.abs(S)
     else:
         magnitude = S
@@ -956,7 +956,7 @@ def amplitude_to_db(S, ref=1.0, amin=1e-5, top_db=80.0):
     if np.issubdtype(S.dtype, np.complexfloating):
         warnings.warn('amplitude_to_db was called on complex input so phase '
                       'information will be discarded. To suppress this warning, '
-                      'call amplitude_to_db(magphase(S)[0]) instead.')
+                      'call amplitude_to_db(magphase(D)[0]) instead.')
 
     magnitude = np.abs(S)
 

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -850,7 +850,7 @@ def power_to_db(S, ref=1.0, amin=1e-10, top_db=80.0):
 
     """
 
-    S = np.array(S)
+    S = np.asarray(S)
 
     if amin <= 0:
         raise ParameterError('amin must be strictly positive')
@@ -946,7 +946,7 @@ def amplitude_to_db(S, ref=1.0, amin=1e-5, top_db=80.0):
     This function caches at level 30.
     '''
 
-    S = np.array(S)
+    S = np.asarray(S)
 
     if np.issubdtype(S.dtype, np.complexfloating):
         warnings.warn('Input was complex. Phase information will be discarded.'

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 '''Utilities for spectral processing'''
+import warnings
 
 import numpy as np
 import scipy.fftpack as fft
@@ -852,6 +853,10 @@ def power_to_db(S, ref=1.0, amin=1e-10, top_db=80.0):
     if amin <= 0:
         raise ParameterError('amin must be strictly positive')
 
+    if np.issubdtype(S.dtype, np.complexfloating):
+        warnings.warn('Input was complex. Phase information will be discarded.'
+                      'Only input magnitudes to avoid this warning (e.g. `np.abs(S)`).')
+
     magnitude = np.abs(S)
 
     if six.callable(ref):
@@ -938,6 +943,10 @@ def amplitude_to_db(S, ref=1.0, amin=1e-5, top_db=80.0):
     -----
     This function caches at level 30.
     '''
+    if np.issubdtype(S.dtype, np.complexfloating):
+        warnings.warn('Input was complex. Phase information will be discarded.'
+                      'Only input magnitudes to avoid this warning (e.g. `np.abs(S)`).')
+
     magnitude = np.abs(S)
 
     if six.callable(ref):
@@ -946,8 +955,8 @@ def amplitude_to_db(S, ref=1.0, amin=1e-5, top_db=80.0):
     else:
         ref_value = np.abs(ref)
 
-    magnitude **= 2
-    return power_to_db(magnitude, ref=ref_value**2, amin=amin**2,
+    power = magnitude**2
+    return power_to_db(power, ref=ref_value**2, amin=amin**2,
                        top_db=top_db)
 
 

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -960,7 +960,7 @@ def amplitude_to_db(S, ref=1.0, amin=1e-5, top_db=80.0):
     else:
         ref_value = np.abs(ref)
 
-    power = magnitude**2
+    power = np.square(magnitude, out=magnitude)
     return power_to_db(power, ref=ref_value**2, amin=amin**2,
                        top_db=top_db)
 


### PR DESCRIPTION
Fixes my own confusion in https://github.com/librosa/librosa/issues/662

I don't think there's an easy way of not duplicating the warning in both `power_to_db` and `amplitude_to_db` but would gladly fix that if possible.

I'm also unsure if there's a non-complex time-frequency representation of amplitudes that are not magnitudes? I guess it would be something like `np.sign(S)*np.abs(S)` but that feels somewhat exotic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/671)
<!-- Reviewable:end -->
