### PR TITLE
fixed #672 by making delta width message more explicit

### DIFF
--- a/librosa/feature/utils.py
+++ b/librosa/feature/utils.py
@@ -105,7 +105,11 @@ def delta(data, width=9, order=1, axis=-1, trim=Deprecated(), mode='interp', **k
 
     data = np.atleast_1d(data)
 
-    if width < 3 or np.mod(width, 2) != 1 or (mode=='interp' and width > data.shape[axis]):
+    if mode == 'interp' and width > data.shape[axis]:
+        raise ParameterError("when mode='interp', width={} "
+                             "cannot exceed data.shape[axis]={}".format(width, data.shape[axis]))
+
+    if width < 3 or np.mod(width, 2) != 1:
         raise ParameterError('width must be an odd integer >= 3')
 
     if order <= 0 or not isinstance(order, int):


### PR DESCRIPTION
#### Reference Issue
#672 


#### What does this implement/fix? Explain your changes.
`delta` will now provide a more useful error message when the `width` is too large for `mode='interp'` to handle.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/673)
<!-- Reviewable:end -->
