### PR TITLE
implemented PCEN. fixes #615. needs tests

### DIFF
--- a/librosa/core/__init__.py
+++ b/librosa/core/__init__.py
@@ -51,6 +51,8 @@ Magnitude scaling
     perceptual_weighting
     A_weighting
 
+    pcen
+
 Time and frequency conversion
 -----------------------------
 .. autosummary::

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1439,8 +1439,7 @@ def pcen(S, sr=22050, hop_length=512, gain=0.98, bias=2, power=0.5,
         warnings.warn('pcen was called on complex input so phase '
                       'information will be discarded. To suppress this warning, '
                       'call pcen(magphase(D)[0]) instead.')
-
-    S = np.abs(S)
+        S = np.abs(S)
 
     if max_size == 1:
         ref_spec = S

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1426,7 +1426,7 @@ def pcen(S, sr=22050, hop_length=512, gain=0.98, bias=2, power=0.5,
     if time_constant <= 0:
         raise ParameterError('time_constant={} must be strictly positive'.format(time_constant))
 
-    if max_size <= 0 or not isinstance(max_size, int):
+    if max_size < 1 or not isinstance(max_size, int):
         raise ParameterError('max_size={} must be a positive integer'.format(max_size))
 
     if b is None:

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1288,7 +1288,7 @@ def pcen(S, sr=22050, hop_length=512, gain=0.98, bias=2, power=0.5,
     '''Per-channel energy normalization (PCEN) [1]_
 
     This function normalizes a time-frequency representation `S` by
-    performing automatic gain control, followed by non-linear compression:
+    performing automatic gain control, followed by nonlinear compression:
 
         P = (S / (eps + M)**gain + bias)**power - bias**power
 

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1447,9 +1447,11 @@ def pcen(S, sr=22050, hop_length=512, gain=0.98, bias=2, power=0.5,
     else:
         ref_spec = scipy.ndimage.maximum_filter1d(S, max_size, axis=0)
 
-    smooth = (eps + scipy.signal.lfilter([b], [1, b - 1], ref_spec))**gain
+    S_smooth = scipy.signal.lfilter([b], [1, b - 1], ref_spec)
 
-    return (S / smooth + bias)**power - bias**power
+    # Working in log-space gives us some stability, and a slight speedup
+    smooth = np.exp(-gain * (np.log(eps) + np.log1p(S_smooth / eps)))
+    return (S * smooth + bias)**power - bias**power
 
 
 def _spectrogram(y=None, S=None, n_fft=2048, hop_length=512, power=1):

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1314,7 +1314,7 @@ def pcen(S, sr=22050, hop_length=512, gain=0.98, bias=2, power=0.5,
     where `R` has been max-filtered along the frequency axis, similar to
     the SuperFlux algorithm implemented in `onset.onset_strength`:
 
-        R[f, t] = max(R[f - max_size//2: f + max_size//2, t])
+        R[f, t] = max(S[f - max_size//2: f + max_size//2, t])
 
     This can be used to perform automatic gain control on signals that cross
     or span multiple frequency bans, which may be desirable for spectrograms

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1297,12 +1297,13 @@ def test_pcen():
         assert np.all(P >= 0)
         assert np.all(np.isfinite(P))
 
-        assert np.allclose(P, Pexp)
+        if Pexp is not None:
+            assert np.allclose(P, Pexp)
 
     tf = raises(librosa.ParameterError)(__test)
 
     srand()
-    S = np.abs(np.random.randn(10, 50))
+    S = np.abs(np.random.randn(9, 30))
 
     # Bounds tests (failures):
     #   gain < 0
@@ -1337,4 +1338,7 @@ def test_pcen():
     #   gain=1, bias=0, power=1, b=1, eps=1e-20 => ones
     yield __test, 1, 0, 1, 1.0, 0.5, 1e-20, 1, S, np.ones_like(S)
 
+    #   zeros to zeros
+    Z = np.zeros_like(S)
+    yield __test, 0.98, 2.0, 0.5, None, 0.395, 1e-6, 1, Z, Z
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1283,3 +1283,58 @@ def test_iirt():
     mut = librosa.iirt(y, hop_length=2205, win_length=4410)
 
     assert np.allclose(mut, gt[23:108, :mut.shape[1]], atol=1.8)
+
+
+def test_pcen():
+
+    def __test(gain, bias, power, b, time_constant, eps, ms, S, Pexp):
+
+        P = librosa.pcen(S, gain=gain, bias=bias, power=power,
+                         time_constant=time_constant, eps=eps, b=b,
+                         max_size=ms)
+
+        assert P.shape == S.shape
+        assert np.all(P >= 0)
+        assert np.all(np.isfinite(P))
+
+        assert np.allclose(P, Pexp)
+
+    tf = raises(librosa.ParameterError)(__test)
+
+    srand()
+    S = np.abs(np.random.randn(10, 50))
+
+    # Bounds tests (failures):
+    #   gain < 0
+    yield tf, -1, 1, 1, 0.5, 0.5, 1e-6, 1, S, S
+
+    #   bias < 0
+    yield tf, 1, -1, 1, 0.5, 0.5, 1e-6, 1, S, S
+
+    #   power <= 0
+    yield tf, 1, 1, 0, 0.5, 0.5, 1e-6, 1, S, S
+
+    #   b < 0
+    yield tf, 1, 1, 1, -2, 0.5, 1e-6, 1, S, S
+
+    #   b > 1
+    yield tf, 1, 1, 1, 2, 0.5, 1e-6, 1, S, S
+
+    #   time_constant <= 0
+    yield tf, 1, 1, 1, 0.5, -2, 1e-6, 1, S, S
+
+    #   eps <= 0
+    yield tf, 1, 1, 1, 0.5, 0.5, 0, 1, S, S
+    #   max_size not int, < 1
+    yield tf, 1, 1, 1, 0.5, 0.5, 0, 1.5, S, S
+    yield tf, 1, 1, 1, 0.5, 0.5, 0, 0, S, S
+
+    # Edge cases:
+    #   gain=0, bias=0, power=p, b=1 => S**p
+    for p in [0.5, 1, 2]:
+        yield __test, 0, 0, p, 1.0, 0.5, 1e-6, 1, S, S**p
+
+    #   gain=1, bias=0, power=1, b=1, eps=1e-20 => ones
+    yield __test, 1, 0, 1, 1.0, 0.5, 1e-20, 1, S, np.ones_like(S)
+
+


### PR DESCRIPTION
#### Reference Issue
#615 


#### What does this implement/fix? Explain your changes.

This PR adds the PCEN method of [Wang et al.](https://arxiv.org/pdf/1607.05666)

The default parameters are set to correspond (as closely as possible) to those reported in the paper.

The API allows the user to specify the IIR smoothing filter either by setting a time constant (from which the filter coefficient is derived), or explicitly setting the parameter.

#### Any other comments?

This PR also adds a superflux-style extension that allows for vibrato-sensitive automatic gain control.  This is disabled by default, and enabled by setting `max_size` to an integer greater than 1.

It still needs tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/679)
<!-- Reviewable:end -->
