### PR TITLE
Expanded MFCC options

### DIFF
--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -1305,7 +1305,7 @@ def tonnetz(y=None, sr=22050, chroma=None):
 
 
 # -- Mel spectrogram and MFCCs -- #
-def mfcc(y=None, sr=22050, S=None, n_mfcc=20, dct_type=None, norm=None, **kwargs):
+def mfcc(y=None, sr=22050, S=None, n_mfcc=20, dct_type=2, norm='ortho', **kwargs):
     """Mel-frequency cepstral coefficients (MFCCs)
 
     Parameters
@@ -1324,21 +1324,17 @@ def mfcc(y=None, sr=22050, S=None, n_mfcc=20, dct_type=None, norm=None, **kwargs
 
     dct_type : None, or {1, 2, 3}
         Discrete cosine transform (DCT) type.
-        By default (None), the reference implementation from RASTAMAT [1]_ is used.
+        By default, DCT type-2 is used.
 
     norm : None or 'ortho'
         If `dct_type` is `2 or 3`, setting `norm='ortho'` uses an ortho-normal
         DCT basis.
 
-        If `dct_type=None`, this parameter is ignored.
+        Normalization is not supported for `dct_type=1`.
 
     kwargs : additional keyword arguments
         Arguments to `melspectrogram`, if operating
         on time series input
-
-    .. [1] Ellis, D. (2006). PLP and RASTA (and MFCC, and inversion)
-        in MATLAB using melfcc.m and invmelfcc.m.
-        https://labrosa.ee.columbia.edu/matlab/rastamat/
 
     Returns
     -------
@@ -1388,19 +1384,14 @@ def mfcc(y=None, sr=22050, S=None, n_mfcc=20, dct_type=None, norm=None, **kwargs
 
     Compare different DCT bases
 
-    >>> m_rasta = librosa.feature.mfcc(y=y, sr=sr)
     >>> m_slaney = librosa.feature.mfcc(y=y, sr=sr, dct_type=2)
     >>> m_htk = librosa.feature.mfcc(y=y, sr=sr, dct_type=3)
-    >>> plt.figure(figsize=(10, 8))
-    >>> plt.subplot(3, 1, 1)
-    >>> librosa.display.specshow(m_rasta, x_axis='time')
-    >>> plt.title('RASTAMAT')
-    >>> plt.colorbar()
-    >>> plt.subplot(3, 1, 2)
+    >>> plt.figure(figsize=(10, 6))
+    >>> plt.subplot(2, 1, 1)
     >>> librosa.display.specshow(m_slaney, x_axis='time')
-    >>> plt.title('Slaney Auditory toolbox-style (dct_type=2)')
+    >>> plt.title('RASTAMAT / Auditory toolbox (dct_type=2)')
     >>> plt.colorbar()
-    >>> plt.subplot(3, 1, 3)
+    >>> plt.subplot(2, 1, 2)
     >>> librosa.display.specshow(m_htk, x_axis='time')
     >>> plt.title('HTK-style (dct_type=3)')
     >>> plt.colorbar()
@@ -1410,10 +1401,7 @@ def mfcc(y=None, sr=22050, S=None, n_mfcc=20, dct_type=None, norm=None, **kwargs
     if S is None:
         S = power_to_db(melspectrogram(y=y, sr=sr, **kwargs))
 
-    if dct_type is None:
-        return np.dot(filters.dct(n_mfcc, S.shape[0]), S)
-
-    return scipy.fftpack.dct(S, axis=0, n=n_mfcc, type=dct_type, norm=norm)
+    return scipy.fftpack.dct(S, axis=0, type=dct_type, norm=norm)[:n_mfcc]
 
 
 def melspectrogram(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -9,7 +9,6 @@ Filter bank construction
 .. autosummary::
     :toctree: generated/
 
-    dct
     mel
     chroma
     constant_q
@@ -35,6 +34,12 @@ Miscellaneous
     mr_frequencies
     window_sumsquare
 
+Deprecated
+----------
+.. autosummary::
+    :toctree: generated/
+
+    dct
 """
 import warnings
 
@@ -48,6 +53,7 @@ from numba import jit
 from . import cache
 from . import util
 from .util.exceptions import ParameterError
+from .util.decorators import deprecated
 
 from .core.time_frequency import note_to_hz, hz_to_midi, midi_to_hz, hz_to_octs
 from .core.time_frequency import fft_frequencies, mel_frequencies
@@ -109,11 +115,14 @@ WINDOW_BANDWIDTHS = {'bart': 1.3334961334912805,
                      'triangle': 1.3331706523555851}
 
 
-@cache(level=10)
+@deprecated('0.6.1', '0.7.0')
 def dct(n_filters, n_input):
-    """Discrete cosine transform (DCT type-III) basis.
+    """Discrete cosine transform (DCT type-II, normalized) basis.
 
     .. [1] http://en.wikipedia.org/wiki/Discrete_cosine_transform
+
+    .. warning:: This function is deprecated in librosa 0.6.1. It will
+        be removed in 0.7.0.
 
     Parameters
     ----------
@@ -126,11 +135,15 @@ def dct(n_filters, n_input):
     Returns
     -------
     dct_basis: np.ndarray [shape=(n_filters, n_input)]
-        DCT (type-III) basis vectors [1]_
+        DCT (type-II) basis vectors [1]_
 
     Notes
     -----
     This function caches at level 10.
+
+    See Also
+    --------
+    scipy.fftpack.dct
 
     Examples
     --------


### PR DESCRIPTION
#### Reference Issue
#437 
#573 


#### What does this implement/fix? Explain your changes.
This expands the mfcc interface to allow the user to use scipy's dct implementation.  This may better approximate alternative mfcc implementations, such as Slaney's auditory toolbox (uses type-II dct) or HTK (type-III + liftering).

#### Any other comments?

Maybe we should roll liftering into this PR as well?  It probably wouldn't hurt.

As it currently stands, there are no regression tests for mfcc.  This is largely due to the integrated implementation in rastamat being hard to factor out for component-wise testing.  I'm curious if anyone has thoughts on how sanely test this though.

~~~Side note: the rastamat (and by inheritance, librosa) type-III dct does not match with scipy's, with or without normalization.  The differences are pretty stark, and I'm not 100% sure I understand why this should be the case.  That said, I think I prefer librosa's dct because for a constant signal (say, all ones), it provides an MFCC output that closely resembles an impulse; scipy's dct does not.~~ Disregard -- I was using `fftpack.dct` incorrectly.  It does turn out that the librosa docs are wrong though: the dct basis used is Type-II (normalized), not Type-III.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/682)
<!-- Reviewable:end -->
