### PR TITLE
change mode --> pad_mode in docstrings

### DIFF
--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -71,7 +71,7 @@ def stft(y, n_fft=2048, hop_length=None, win_length=None, window='hann',
     dtype       : numeric type
         Complex numeric type for `D`.  Default is 64-bit complex.
 
-    mode : string
+    pad_mode : string
         If `center=True`, the padding mode to use at the edges of the signal.
         By default, STFT uses reflection padding.
 
@@ -391,7 +391,7 @@ def ifgram(y, sr=22050, n_fft=2048, hop_length=None, win_length=None,
     dtype : numeric type
         Complex numeric type for `D`.  Default is 64-bit complex.
 
-    mode : string
+    pad_mode : string
         If `center=True`, the padding mode to use at the edges of the signal.
         By default, STFT uses reflection padding.
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/master/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
<!-- Example: Fixes #123 -->


#### What does this implement/fix? Explain your changes.

Update 'mode' to 'pad_mode' in the docstrings of `STFT` and `ifgram`.

#### Any other comments?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/684)
<!-- Reviewable:end -->
