### PR TITLE
add display to __init__.py

### DIFF
--- a/librosa/__init__.py
+++ b/librosa/__init__.py
@@ -12,6 +12,7 @@ from . import cache
 from . import core
 from . import beat
 from . import decompose
+from . import display
 from . import effects
 from . import feature
 from . import filters


### PR DESCRIPTION
to fix module 'librosa' has no attribute 'display'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/700)
<!-- Reviewable:end -->
