### PR TITLE
Document mel_frequencies

### DIFF
--- a/librosa/core/time_frequency.py
+++ b/librosa/core/time_frequency.py
@@ -834,11 +834,14 @@ def mel_frequencies(n_mels=128, fmin=0.0, fmax=11025.0, htk=False):
     
     Because the definition of the mel scale is conditioned by a finite number
     of subjective psychoaoustical experiments, several implementations coexist
-    in the audio signal processing literature [1]. By default, librosa replicates
-    the behavior of the well-established MATLAB Auditory Toolbox of Slaney [2],
-    in the conversion from Hertz to mel is linear below 1 kHz and logarithmic above
-    1 kHz. Another available implementation replicates the Hidden Markov Toolkit [3]
-    (HTK) according to the following formula: mel = 2595.0 * np.log10(1.0 + f / 700.0).
+    in the audio signal processing literature [1]_. By default, librosa replicates
+    the behavior of the well-established MATLAB Auditory Toolbox of Slaney [2]_.
+    According to this default implementation,  the conversion from Hertz to mel is
+    linear below 1 kHz and logarithmic above 1 kHz. Another available implementation
+    replicates the Hidden Markov Toolkit [3]_ (HTK) according to the following formula:
+    mel = 2595.0 * np.log10(1.0 + f / 700.0). The choice of implementation is determined
+    by the `htk` keyword argument: setting `htk=False` leads to the Auditory toolbox
+    implementation, whereas setting it `htk=True` leads to the HTK implementation.
     
     .. [1] Umesh, S., Cohen, L., & Nelson, D. Fitting the mel scale.
     In Proc. International Conference on Acoustics, Speech, and Signal Processing
@@ -863,21 +866,22 @@ def mel_frequencies(n_mels=128, fmin=0.0, fmax=11025.0, htk=False):
     Parameters
     ----------
     n_mels    : int > 0 [scalar]
-        number of mel bins
+        Number of mel bins.
 
     fmin      : float >= 0 [scalar]
-        minimum frequency (Hz)
+        Minimum frequency (Hz).
 
     fmax      : float >= 0 [scalar]
-        maximum frequency (Hz)
+        Maximum frequency (Hz).
 
     htk       : bool
-        use HTK formula instead of Slaney's Auditory Toolbox (see references).
+        If True, use HTK formula to convert Hz to mel.
+        Otherwise (False), use Slaney's Auditory Toolbox.
 
     Returns
     -------
     bin_frequencies : ndarray [shape=(n_mels,)]
-        vector of n_mels frequencies in Hz which are uniformly spaced on the Mel
+        Vector of n_mels frequencies in Hz which are uniformly spaced on the Mel
         axis.
 
     Examples

--- a/librosa/core/time_frequency.py
+++ b/librosa/core/time_frequency.py
@@ -826,12 +826,44 @@ def cqt_frequencies(n_bins, fmin, bins_per_octave=12, tuning=0.0):
 
 
 def mel_frequencies(n_mels=128, fmin=0.0, fmax=11025.0, htk=False):
-    """Compute the center frequencies of mel bands.
+    """Compute an array of acoustic frequencies tuned to the mel scale.
+    
+    The mel scale is a quasi-logarithmic function of acoustic frequency
+    designed such that perceptually similar pitch intervals (e.g. octaves)
+    appear equal in width over the full hearing range.
+    
+    Because the definition of the mel scale is conditioned by a finite number
+    of subjective psychoaoustical experiments, several implementations coexist
+    in the audio signal processing literature [1]. By default, librosa replicates
+    the behavior of the well-established MATLAB Auditory Toolbox of Slaney [2],
+    in the conversion from Hertz to mel is linear below 1 kHz and logarithmic above
+    1 kHz. Another available implementation replicates the Hidden Markov Toolkit [3]
+    (HTK) according to the following formula: mel = 2595.0 * np.log10(1.0 + f / 700.0).
+    
+    .. [1] Umesh, S., Cohen, L., & Nelson, D. Fitting the mel scale.
+    In Proc. International Conference on Acoustics, Speech, and Signal Processing
+    (ICASSP), vol. 1, pp. 217-220, 1998.
+    
+    .. [2] Slaney, M. Auditory Toolbox: A MATLAB Toolbox for Auditory
+    Modeling Work. Technical Report, version 2, Interval Research Corporation, 1998.
+    
+    .. [3] Young, S., Evermann, G., Gales, M., Hain, T., Kershaw, D., Liu, X.,
+    Moore, G., Odell, J., Ollason, D., Povey, D., Valtchev, V., & Woodland, P.
+    The HTK book, version 3.4. Cambridge University, March 2009.
+    
+    
+    See Also
+    --------
+    hz_to_mel
+    mel_to_hz
+    librosa.feature.melspectrogram
+    librosa.feature.mfcc
+    
 
     Parameters
     ----------
     n_mels    : int > 0 [scalar]
-        number of Mel bins
+        number of mel bins
 
     fmin      : float >= 0 [scalar]
         minimum frequency (Hz)
@@ -840,7 +872,7 @@ def mel_frequencies(n_mels=128, fmin=0.0, fmax=11025.0, htk=False):
         maximum frequency (Hz)
 
     htk       : bool
-        use HTK formula instead of Slaney
+        use HTK formula instead of Slaney's Auditory Toolbox (see references).
 
     Returns
     -------


### PR DESCRIPTION
#### Reference Issue
As @stefan-balke pointed out in #642, our documentation of the mel scale is rather lapidary, and lacks references to the toolboxes it replicates, namely Slaney's MATLAB Auditory Toolbox and Cambridge's Hidden Markov Toolkit.

#### What does this implement/fix? Explain your changes.
I wrote two paragraphs explaining what the mel scale is in layperson's terms, and explaining the difference between Auditory toolbox (our default) and HTK, so that the user is informed of the choice.
NB: some of the wording in this commit is from my ISMIR 2016 paper (CC BY 4.0), but I hereby declare that I don't need attribution for it, and am happy to make it part of librosa (ISC license).


#### Any other comments?
I decided to document `mel_frequencies` rather than lower functions in the call chain (`hz_to_mel` and `mel_to_hz`) or higher functions in the call chain (`mel_filterbank`, `melspectrogram`, `mfcc`) because I feel like this is the function where we'd expect some explanation. This function is essentially a vectorized form of `hz_to_mel`. In practice I use this one much more often than `hz_to_mel`. Same for `mel_filterbank` which is rarely called by the user themself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/701)
<!-- Reviewable:end -->
