### PR TITLE
Isolated matplotlib.pyplot dependencies; fixes #690

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,10 +2,10 @@ build: false
 
 environment:
   matrix:
-    - PYTHON_VERSION: 3.6
-      MINICONDA: C:\Miniconda3
     - PYTHON_VERSION: 2.7
       MINICONDA: C:\Miniconda
+    - PYTHON_VERSION: 3.6
+      MINICONDA: C:\Miniconda3
 
 cache:
     - "%MINICONDA%\\envs -> appveyor.yml"

--- a/librosa/display.py
+++ b/librosa/display.py
@@ -20,7 +20,8 @@ Display
 import warnings
 
 import numpy as np
-import matplotlib.pyplot as plt
+from matplotlib.cm import get_cmap
+from matplotlib.axes import Axes
 from matplotlib.ticker import Formatter, ScalarFormatter
 from matplotlib.ticker import LogLocator, FixedLocator, MaxNLocator
 from matplotlib.ticker import SymmetricalLogLocator
@@ -303,7 +304,7 @@ def cmap(data, robust=True, cmap_seq='magma', cmap_bool='gray_r', cmap_div='cool
     data = np.atleast_1d(data)
 
     if data.dtype == 'bool':
-        return plt.get_cmap(cmap_bool)
+        return get_cmap(cmap_bool)
 
     data = data[np.isfinite(data)]
 
@@ -316,9 +317,9 @@ def cmap(data, robust=True, cmap_seq='magma', cmap_bool='gray_r', cmap_div='cool
     min_val = np.percentile(data, min_p)
 
     if min_val >= 0 or max_val <= 0:
-        return plt.get_cmap(cmap_seq)
+        return get_cmap(cmap_seq)
 
-    return plt.get_cmap(cmap_div)
+    return get_cmap(cmap_div)
 
 
 def __envelope(x, hop):
@@ -683,8 +684,7 @@ def specshow(data, x_coords=None, y_coords=None,
 
     axes = __check_axes(ax)
     out = axes.pcolormesh(x_coords, y_coords, data, **kwargs)
-    if ax is None:
-        plt.sci(out)
+    __set_current_image(ax, out)
 
     axes.set_xlim(x_coords.min(), x_coords.max())
     axes.set_ylim(y_coords.min(), y_coords.max())
@@ -698,6 +698,18 @@ def specshow(data, x_coords=None, y_coords=None,
     __decorate_axis(axes.yaxis, y_axis)
 
     return axes
+
+
+def __set_current_image(ax, img):
+    '''Helper to set the current image in pyplot mode.
+
+    If the provided `ax` is not `None`, then we assume that the user is using the object API.
+    In this case, the pyplot current image is not set.
+    '''
+
+    if ax is None:
+        import matplotlib.pyplot as plt
+        plt.sci(img)
 
 
 def __mesh_coords(ax_type, coords, n, **kwargs):
@@ -734,10 +746,11 @@ def __mesh_coords(ax_type, coords, n, **kwargs):
 def __check_axes(axes):
     '''Check if "axes" is an instance of an axis object. If not, use `gca`.'''
     if axes is None:
+        import matplotlib.pyplot as plt
         axes = plt.gca()
-    if not isinstance(axes, plt.Axes):
-        raise ValueError("`axes` must be an instance of plt.Axes. "
-                         "Found type {}".format(type(axes)))
+    elif not isinstance(axes, Axes):
+        raise ValueError("`axes` must be an instance of matplotlib.axes.Axes. "
+                         "Found type(axes)={}".format(type(axes)))
     return axes
 
 


### PR DESCRIPTION
#### Reference Issue
Fixes #690 


#### What does this implement/fix? Explain your changes.
This PR isolates all dependencies on `matplotlib.pyplot` to avoid import side-effects.

As noted in #690, the issue here is that `librosa.display` should be compatible with matplotlib's stateful (`pyplot`) and objective APIs.  Compatibility with `pyplot` requires accessing the `matplotlib.pyplot` module for managing state (getting current axes, setting current images, etc), but importing this module incurs side-effects.  If the user is only using the object interface, then we shouldn't import pyplot.

Otherwise, there should be no externally visible changes to the API or functionality.

#### Any other comments?

Is it worth revisiting the dynamic import issue for `display` #343 , now that the side effect issue should be neutralized?  On the one hand, dynamic submodule imports are ugly.  On the other hand, it would turn an optional dependency (matplotlib) back into a hard dependency.  It's mainly a trade-off between dependency simplicity and (space/memory) efficiency at runtime.

What do folks think?  I'm inclined to leave it as is (optional), since it's been that way for a couple of years and people should be used to it by now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/704)
<!-- Reviewable:end -->
