### PR TITLE
Fix appveyor test failure

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,8 @@ build: false
 environment:
   matrix:
     - PYTHON_VERSION: 3.6
-      MINICONDA: C:\Miniconda3
+      PYTHON_ARCH: "64"
+      MINICONDA: C:\Miniconda36-x64
 
 cache:
     - "%MINICONDA%\\envs -> appveyor.yml"
@@ -15,6 +16,7 @@ install:
   - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
+  - conda install -n root _license
   - conda info -a
   - "IF NOT EXIST %MINICONDA%\\envs\\test-environment-%PYTHON_VERSION% conda create -q -n test-environment-%PYTHON_VERSION% python=%PYTHON_VERSION% numpy scipy nose coverage scikit-learn!=0.19.0 numba"
   - "activate test-environment-%PYTHON_VERSION%"


### PR DESCRIPTION
- Use explicit PYTHON_ARCH and MINICONDA path. Sym links may not exist after `conda update -q conda`
- Fix WARNING: could not import _license.show_info

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/master/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
<!-- Example: Fixes #123 -->


#### What does this implement/fix? Explain your changes.

Fixes recent tests failure on AppVeyor. e.g., https://ci.appveyor.com/project/bmcfee/librosa/build/1.0.130

```
conda info -a
'conda' is not recognized as an internal or external command,
operable program or batch file.
```

I was seeing the same error with very similar situation while working on https://github.com/r9y9/deepvoice3_pytorch/pull/83. In my case it turned out that `C:\Miniconda3-x64` no longer exists after `conda update -q conda`, resulting `conda` not found error. I was able to fix it to use explicit path (`C:\Miniconda36-x64`) rather than symlinks. 

I feel it's odd `C:\Miniconda3` doesn't exist after upgrading, but I think using explicit path should be safe and hopefully this fixes the issue for librosa.

`conda install -n root _license` is just a minor fix to suppress warning.

#### Any other comments?

Removing `conda update -q conda` also worked. I can change if you prefer this approach.