### PR TITLE
added target axes to pcen. fixes #703

### DIFF
--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1453,6 +1453,8 @@ def pcen(S, sr=22050, hop_length=512, gain=0.98, bias=2, power=0.5,
 
     if max_size == 1:
         ref_spec = S
+    elif S.ndim == 1:
+        raise ParameterError('Max-filtering cannot be applied to 1-dimensional input')
     else:
         if max_axis is None:
             if S.ndim != 2:

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1466,6 +1466,8 @@ def pcen(S, sr=22050, hop_length=512, gain=0.98, bias=2, power=0.5,
                 if S.ndim != 2:
                     raise ParameterError('Max-filtering a {:d}-dimensional spectrogram '
                                          'requires you to specify max_axis'.format(S.ndim))
+                # if axis = 0, max_axis=1
+                # if axis = +- 1, max_axis = 0
                 max_axis = np.mod(1 - axis, 2)
 
             ref = scipy.ndimage.maximum_filter1d(S, max_size, axis=max_axis)

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1284,7 +1284,7 @@ def fmt(y, t_min=0.5, n_fmt=None, kind='cubic', beta=0.5, over_sample=1, axis=-1
 
 @cache(level=30)
 def pcen(S, sr=22050, hop_length=512, gain=0.98, bias=2, power=0.5,
-         time_constant=0.395, eps=1e-6, b=None, max_size=1, ref=None,
+         time_constant=0.400, eps=1e-6, b=None, max_size=1, ref=None,
          axis=-1, max_axis=None):
     '''Per-channel energy normalization (PCEN) [1]_
 
@@ -1300,7 +1300,9 @@ def pcen(S, sr=22050, hop_length=512, gain=0.98, bias=2, power=0.5,
 
     If `b` is not provided, it is calculated as:
 
-        b = 1 - exp(-hop_length / (sr * time_constant))
+        b = (sqrt(1 + 4* T**2) - 1) / (2 * T**2)
+
+    where `T = time_constant * sr / hop_length`.
 
     This normalization is designed to suppress background noise and
     emphasize foreground signals, and can be used as an alternative to
@@ -1445,7 +1447,9 @@ def pcen(S, sr=22050, hop_length=512, gain=0.98, bias=2, power=0.5,
         raise ParameterError('max_size={} must be a positive integer'.format(max_size))
 
     if b is None:
-        b = 1 - np.exp(- float(hop_length) / (time_constant * sr))
+        t_frames = time_constant * sr / float(hop_length)
+
+        b = (np.sqrt(1 + 4 * t_frames**2) - 1) / (2 * t_frames**2)
 
     if not 0 <= b <= 1:
         raise ParameterError('b={} must be between 0 and 1'.format(b))

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1457,7 +1457,7 @@ def pcen(S, sr=22050, hop_length=512, gain=0.98, bias=2, power=0.5,
     if np.issubdtype(S.dtype, np.complexfloating):
         warnings.warn('pcen was called on complex input so phase '
                       'information will be discarded. To suppress this warning, '
-                      'call pcen(magphase(D)[0]) instead.')
+                      'call pcen(np.abs(D)) instead.')
         S = np.abs(S)
 
     if ref is None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1354,3 +1354,54 @@ def test_pcen():
     Z = np.zeros_like(S)
     yield __test, 0.98, 2.0, 0.5, None, 0.395, 1e-6, 1, Z, Z
     yield __test, 0.98, 2.0, 0.5, None, 0.395, 1e-6, 3, Z, Z
+
+
+def test_pcen_axes():
+
+    srand()
+    # Make a power spectrogram
+    X = np.random.randn(3, 100, 50)**2
+
+    # First, test that axis setting works
+    P1 = librosa.pcen(X[0])
+    P1a = librosa.pcen(X[0], axis=-1)
+    P2 = librosa.pcen(X[0].T, axis=0).T
+
+    assert np.array_equal(P1, P2)
+    assert np.array_equal(P1, P1a)
+
+    # Test that it works with max-filtering
+    P1 = librosa.pcen(X[0], max_size=3)
+    P1a = librosa.pcen(X[0], axis=-1, max_size=3)
+    P2 = librosa.pcen(X[0].T, axis=0, max_size=3).T
+
+    assert np.array_equal(P1, P2)
+    assert np.array_equal(P1, P1a)
+
+    # Test that it works with multi-dimensional input, no filtering
+    P0 = librosa.pcen(X[0])
+    P1 = librosa.pcen(X[1])
+    P2 = librosa.pcen(X[2])
+    Pa = librosa.pcen(X)
+
+    assert np.array_equal(P0, Pa[0])
+    assert np.array_equal(P1, Pa[1])
+    assert np.array_equal(P2, Pa[2])
+
+    # Test that it works with multi-dimensional input, max-filtering
+    P0 = librosa.pcen(X[0], max_size=3)
+    P1 = librosa.pcen(X[1], max_size=3)
+    P2 = librosa.pcen(X[2], max_size=3)
+    Pa = librosa.pcen(X, max_size=3, max_axis=1)
+
+    assert np.array_equal(P0, Pa[0])
+    assert np.array_equal(P1, Pa[1])
+    assert np.array_equal(P2, Pa[2])
+
+@raises(librosa.ParameterError)
+def test_pcen_axes_nomax():
+    srand()
+    # Make a power spectrogram
+    X = np.random.randn(3, 100, 50)**2
+
+    librosa.pcen(X, max_size=3)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1410,3 +1410,21 @@ def test_pcen_axes_nomax():
 def test_pcen_max1():
 
     librosa.pcen(np.arange(100), max_size=3)
+
+
+def test_pcen_ref():
+
+    srand()
+    # Make a power spectrogram
+    X = np.random.randn(100, 50)**2
+
+    # Edge cases:
+    #   gain=1, bias=0, power=1, b=1 => ones
+    ones = np.ones_like(X)
+
+    Y = librosa.pcen(X, gain=1, bias=0, power=1, b=1, eps=1e-20)
+    assert np.allclose(Y, ones)
+
+    # with ref=ones, we should get X / (eps + ones) == X
+    Y2 = librosa.pcen(X, gain=1, bias=0, power=1, b=1, ref=ones, eps=1e-20)
+    assert np.allclose(Y2, X)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1405,3 +1405,8 @@ def test_pcen_axes_nomax():
     X = np.random.randn(3, 100, 50)**2
 
     librosa.pcen(X, max_size=3)
+
+@raises(librosa.ParameterError)
+def test_pcen_max1():
+
+    librosa.pcen(np.arange(100), max_size=3)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1367,16 +1367,16 @@ def test_pcen_axes():
     P1a = librosa.pcen(X[0], axis=-1)
     P2 = librosa.pcen(X[0].T, axis=0).T
 
-    assert np.array_equal(P1, P2)
-    assert np.array_equal(P1, P1a)
+    assert np.allclose(P1, P2)
+    assert np.allclose(P1, P1a)
 
     # Test that it works with max-filtering
     P1 = librosa.pcen(X[0], max_size=3)
     P1a = librosa.pcen(X[0], axis=-1, max_size=3)
     P2 = librosa.pcen(X[0].T, axis=0, max_size=3).T
 
-    assert np.array_equal(P1, P2)
-    assert np.array_equal(P1, P1a)
+    assert np.allclose(P1, P2)
+    assert np.allclose(P1, P1a)
 
     # Test that it works with multi-dimensional input, no filtering
     P0 = librosa.pcen(X[0])
@@ -1384,9 +1384,9 @@ def test_pcen_axes():
     P2 = librosa.pcen(X[2])
     Pa = librosa.pcen(X)
 
-    assert np.array_equal(P0, Pa[0])
-    assert np.array_equal(P1, Pa[1])
-    assert np.array_equal(P2, Pa[2])
+    assert np.allclose(P0, Pa[0])
+    assert np.allclose(P1, Pa[1])
+    assert np.allclose(P2, Pa[2])
 
     # Test that it works with multi-dimensional input, max-filtering
     P0 = librosa.pcen(X[0], max_size=3)
@@ -1394,9 +1394,9 @@ def test_pcen_axes():
     P2 = librosa.pcen(X[2], max_size=3)
     Pa = librosa.pcen(X, max_size=3, max_axis=1)
 
-    assert np.array_equal(P0, Pa[0])
-    assert np.array_equal(P1, Pa[1])
-    assert np.array_equal(P2, Pa[2])
+    assert np.allclose(P0, Pa[0])
+    assert np.allclose(P1, Pa[1])
+    assert np.allclose(P2, Pa[2])
 
 @raises(librosa.ParameterError)
 def test_pcen_axes_nomax():


### PR DESCRIPTION
#### Reference Issue
Fixes #703 


#### What does this implement/fix? Explain your changes.
This PR adds target axis support for PCEN.

It also extends PCEN to support multi-dimensional spectrogram input, and throw an exception if max-filtering is attempted on 1-d input.

#### Any other comments?

Should we add support for pre-computed reference spectra to the onset detector as well?  @lostanlen ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/708)
<!-- Reviewable:end -->
