### PR TITLE
Don't use the deprecated cachedir property of joblib Memory

### DIFF
--- a/librosa/cache.py
+++ b/librosa/cache.py
@@ -46,7 +46,7 @@ class CacheManager(Memory):
                     func, 'return decorated(%(signature)s)',
                     dict(decorated=dec(func)), __wrapped__=func)
 
-            if self.cachedir is not None and self.level >= level:
+            if self.location is not None and self.level >= level:
                 return decorator_apply(self.cache, function)
 
             else:

--- a/librosa/cache.py
+++ b/librosa/cache.py
@@ -15,8 +15,8 @@ class CacheManager(Memory):
     field, thereby allowing librosa.cache to act as a decorator function.
     '''
 
-    def __init__(self, cachedir, level=10, **kwargs):
-        super(CacheManager, self).__init__(cachedir, **kwargs)
+    def __init__(self, location, level=10, **kwargs):
+        super(CacheManager, self).__init__(location, **kwargs)
         # The level parameter controls which data we cache
         # smaller numbers mean less caching
         self.level = level

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         'numpy >= 1.8.0',
         'scipy >= 0.14.0',
         'scikit-learn >= 0.14.0, != 0.19.0',
-        'joblib >= 0.7.0',
+        'joblib >= 0.12',
         'decorator >= 3.0.0',
         'six >= 1.3',
         'resampy >= 0.2.0',


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/master/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
#729 


#### What does this implement/fix? Explain your changes.
The `Memory.cachedir` deprecation warning in joblib 0.12 is broken causing a `TypeError` when importing librosa.  Using the `location` attribute gets the same results.

#### Any other comments?
We still use `cachedir` in the constructor, but this is not broken yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/730)
<!-- Reviewable:end -->
