### PR TITLE
Fix a typo in time_frequency.py

### DIFF
--- a/librosa/core/time_frequency.py
+++ b/librosa/core/time_frequency.py
@@ -756,7 +756,7 @@ def octs_to_hz(octs, A440=440.0):
 
 
 def fft_frequencies(sr=22050, n_fft=2048):
-    '''Alternative implementation of `np.fft.fftfreqs`
+    '''Alternative implementation of `np.fft.fftfreq`
 
     Parameters
     ----------


### PR DESCRIPTION
The `np.fft.fftfreqs` function seems nonexistent - maybe this should be `np.fft.fftfreq`?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/731)
<!-- Reviewable:end -->
