### PR TITLE
Add chirp signal generator function

### DIFF
--- a/librosa/core/__init__.py
+++ b/librosa/core/__init__.py
@@ -17,6 +17,7 @@ Audio processing
     zero_crossings
     clicks
     tone
+    chirp
 
 Spectral representations
 ------------------------

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -17,7 +17,7 @@ from .. import util
 from ..util.exceptions import ParameterError
 
 __all__ = ['load', 'to_mono', 'resample', 'get_duration',
-           'autocorrelate', 'zero_crossings', 'clicks', 'tone']
+           'autocorrelate', 'zero_crossings', 'clicks', 'tone', 'chirp']
 
 # Resampling bandwidths as percentage of Nyquist
 BW_BEST = resampy.filters.get_filter('kaiser_best')[2]
@@ -779,3 +779,104 @@ def tone(frequency, sr=22050, length=None, duration=None, phi=None):
 
     step = 1.0 / sr
     return np.cos(2 * np.pi * frequency * (np.arange(step * length, step=step)) + phi)
+
+
+def chirp(fmin, fmax, sr=22050, length=None, duration=None, linear=False, phi=None):
+    """Returns a chirp signal that goes from frequency `fmin` to frequency `fmax`
+
+    Parameters
+    ----------
+    fmin : float > 0
+        initial frequency
+
+    fmax : float > 0
+        final frequency
+
+    sr : number > 0
+        desired sampling rate of the output signal
+
+    length : int > 0
+        desired number of samples in the output signal.
+        When both `duration` and `length` are defined, `length` would take priority.
+
+    duration : float > 0
+        desired duration in seconds.
+        When both `duration` and `length` are defined, `length` would take priority.
+
+    linear : boolean
+        - If `True`, use a linear sweep, i.e., frequency changes linearly with time
+        - If `False`, use a exponential sweep.
+        Default is `False`.
+
+    phi : float or None
+        phase offset, in radians.
+        If unspecified, defaults to `-np.pi * 0.5`.
+
+
+    Returns
+    -------
+    chirp_signal : np.ndarray [shape=(length,), dtype=float64]
+        Synthesized chirp signal
+
+
+    Raises
+    ------
+    ParameterError
+        - If either `fmin` or `fmax` are not provided.
+        - If neither `length` nor `duration` are provided.
+
+
+    See Also
+    --------
+    scipy.signal.chirp
+
+
+    Examples
+    --------
+    >>> # Generate a exponential chirp from A4 to A5
+    >>> exponential_chirp = librosa.chirp(440, 880, duration=1)
+
+    >>> # Or generate the same signal using `length`
+    >>> exponential_chirp = librosa.chirp(440, 880, sr=22050, length=22050)
+
+    >>> # Or generate a linear chirp instead
+    >>> linear_chirp = librosa.chirp(440, 880, duration=1, linear=True)
+
+    Display spectrogram for both exponential and linear chirps
+
+    >>> import matplotlib.pyplot as plt
+    >>> plt.figure()
+    >>> S_exponential = librosa.feature.melspectrogram(y=exponential_chirp)
+    >>> ax = plt.subplot(2,1,1)
+    >>> librosa.display.specshow(librosa.power_to_db(S_exponential, ref=np.max),
+    ...                          x_axis='time', y_axis='mel')
+    >>> plt.subplot(2,1,2, sharex=ax)
+    >>> S_linear = librosa.feature.melspectrogram(y=linear_chirp)
+    >>> librosa.display.specshow(librosa.power_to_db(S_linear, ref=np.max),
+    ...                          x_axis='time', y_axis='mel')
+    >>> plt.tight_layout()
+    """
+
+    if fmin is None or fmax is None:
+        raise ParameterError('both "fmin" and "fmax" must be provided')
+
+    # Compute signal duration
+    period = 1.0 / sr
+    if length is None:
+        if duration is None:
+            raise ParameterError('either "length" or "duration" must be provided')
+    else:
+        duration = period * length
+
+    if phi is None:
+        phi = -np.pi * 0.5
+
+    method = 'linear' if linear else 'logarithmic'
+    return scipy.signal.chirp(
+        np.arange(duration, step=period),
+        fmin,
+        duration,
+        fmax,
+        method=method,
+        phi=phi / np.pi * 180,  # scipy.signal.chirp uses degrees for phase offset
+    )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1034,6 +1034,36 @@ def test_tone():
                     if length is not None or duration is not None:
                         yield __test, 440, sr, length, duration, phi
 
+def test_chirp():
+
+    def __test(fmin, fmax, sr, length, duration, linear, phi):
+
+        y = librosa.chirp(fmin=fmin,
+                          fmax=fmax,
+                          sr=sr,
+                          length=length,
+                          duration=duration,
+                          linear=linear,
+                          phi=phi)
+
+        if length is not None:
+            assert len(y) == length
+        else:
+            assert len(y) == np.ceil(duration * sr)
+
+    # Bad cases
+    yield raises(librosa.ParameterError)(__test), None, None, 22050, 22050, 1, False, None
+    yield raises(librosa.ParameterError)(__test), 440, None, 22050, 22050, 1, False, None
+    yield raises(librosa.ParameterError)(__test), None, 880, 22050, 22050, 1, False, None
+    yield raises(librosa.ParameterError)(__test), 440, 880, 22050, None, None, False, None
+
+    for sr in [11025, 22050]:
+        for length in [None, 11025]:
+            for duration in [None, 0.5]:
+                for phi in [None, np.pi / 2]:
+                    if length is not None or duration is not None:
+                        yield __test, 440, 880, sr, length, duration, False, phi
+                        yield __test, 880, 440, sr, length, duration, True, phi
 
 
 def test_fmt_scale():


### PR DESCRIPTION
#### Reference Issue
Partially fixes #736


#### What does this implement/fix? Explain your changes.
This implements the chirp signal generator as specified in #736. I'll either update this with the tone generator or add that function in a separate pull request.

#### Any other comments?
It takes me an embarrassingly long time to get around to do this :-/
Turns out `scipy` already has a `chirp` function, but it does have a different signature and has a couple small caveats (e.g., by default it doesn't start at 0 which would cause a "pop" sound in the generated .wav file, at least on the machine I am using). This function is just a thin wrapper on top of it - let me know whether this makes sense!

I also see a bunch of warnings from `pytest` that generator tests are going to be deprecated - it seems [parameterize](https://docs.pytest.org/en/latest/parametrize.html#pytest-mark-parametrize) is the replacement - should I use that instead or is `yield` tests still preferred?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/750)
<!-- Reviewable:end -->
