### PR TITLE
Fixed #754 to avoid futurewarnings in index sequences

### DIFF
--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -447,7 +447,7 @@ def autocorrelate(y, max_size=None, axis=-1):
     subslice = [slice(None)] * autocorr.ndim
     subslice[axis] = slice(max_size)
 
-    autocorr = autocorr[subslice]
+    autocorr = autocorr[tuple(subslice)]
 
     if not np.iscomplexobj(y):
         autocorr = autocorr.real
@@ -574,7 +574,7 @@ def zero_crossings(y, threshold=1e-10, ref_magnitude=None, pad=True,
     padding = [(0, 0)] * y.ndim
     padding[axis] = (1, 0)
 
-    return np.pad((y_sign[slice_post] != y_sign[slice_pre]),
+    return np.pad((y_sign[tuple(slice_post)] != y_sign[tuple(slice_pre)]),
                   padding,
                   mode='constant',
                   constant_values=pad)

--- a/librosa/core/harmonic.py
+++ b/librosa/core/harmonic.py
@@ -377,6 +377,6 @@ def harmonics_2d(harmonic_out, x, freqs, h_range, kind='linear', fill_value=0,
         idx_freq[ni_axis] = i
         idx_out[1 + ni_axis] = idx_in[ni_axis]
 
-        harmonics_1d(harmonic_out[idx_out], x[idx_in], freqs[idx_freq],
+        harmonics_1d(harmonic_out[tuple(idx_out)], x[tuple(idx_in)], freqs[tuple(idx_freq)],
                      h_range, kind=kind, fill_value=fill_value,
                      axis=axis)

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1280,7 +1280,7 @@ def fmt(y, t_min=0.5, n_fmt=None, kind='cubic', beta=0.5, over_sample=1, axis=-1
     idx[axis] = slice(0, 1 + n_fmt//2)
 
     # Truncate and length-normalize
-    return result[idx] * np.sqrt(n) / n_fmt
+    return result[tuple(idx)] * np.sqrt(n) / n_fmt
 
 
 @cache(level=30)

--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -374,7 +374,7 @@ def remix(y, intervals, align_zeros=True):
 
         clip[-1] = slice(interval[0], interval[1])
 
-        y_out.append(y[clip])
+        y_out.append(y[tuple(clip)])
 
     return np.concatenate(y_out, axis=-1)
 
@@ -487,7 +487,7 @@ def trim(y, top_db=60, ref=np.max, frame_length=2048, hop_length=512):
     full_index = [slice(None)] * y.ndim
     full_index[-1] = slice(start, end)
 
-    return y[full_index], np.asarray([start, end])
+    return y[tuple(full_index)], np.asarray([start, end])
 
 
 def split(y, top_db=60, ref=np.max, frame_length=2048, hop_length=512):

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -823,7 +823,7 @@ def localmax(x, axis=0):
     inds2 = [slice(None)] * x.ndim
     inds2[axis] = slice(2, x_pad.shape[axis])
 
-    return (x > x_pad[inds1]) & (x >= x_pad[inds2])
+    return (x > x_pad[tuple(inds1)]) & (x >= x_pad[tuple(inds2)])
 
 
 def peak_pick(x, pre_max, post_max, pre_avg, post_avg, delta, wait):
@@ -1374,7 +1374,7 @@ def sync(data, idx, aggregate=None, pad=True, axis=-1):
     for (i, segment) in enumerate(slices):
         idx_in[axis] = segment
         idx_agg[axis] = i
-        data_agg[idx_agg] = aggregate(data[idx_in], axis=axis)
+        data_agg[idx_agg] = aggregate(data[tuple(idx_in)], axis=axis)
 
     return data_agg
 

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -357,7 +357,7 @@ def fix_length(data, size, axis=-1, **kwargs):
     if n > size:
         slices = [slice(None)] * data.ndim
         slices[axis] = slice(0, size)
-        return data[slices]
+        return data[tuple(slices)]
 
     elif n < size:
         lengths = [(0, 0)] * data.ndim

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -1374,7 +1374,7 @@ def sync(data, idx, aggregate=None, pad=True, axis=-1):
     for (i, segment) in enumerate(slices):
         idx_in[axis] = segment
         idx_agg[axis] = i
-        data_agg[idx_agg] = aggregate(data[tuple(idx_in)], axis=axis)
+        data_agg[tuple(idx_agg)] = aggregate(data[tuple(idx_in)], axis=axis)
 
     return data_agg
 

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -544,9 +544,9 @@ def axis_sort(S, axis=-1, index=False, value=None):
     sort_slice[axis] = idx
 
     if index:
-        return S[sort_slice], idx
+        return S[tuple(sort_slice)], idx
     else:
-        return S[sort_slice]
+        return S[tuple(sort_slice)]
 
 
 @cache(level=40)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -593,7 +593,7 @@ def test_autocorrelate():
         if not np.iscomplexobj(y):
             assert not np.iscomplexobj(ac)
 
-        assert np.allclose(ac, truth[my_slice])
+        assert np.allclose(ac, truth[tuple(my_slice)])
 
     srand()
     # test with both real and complex signals

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -151,7 +151,7 @@ def test_trim():
         # Test for index position
         fidx = [slice(None)] * y.ndim
         fidx[-1] = slice(*idx.tolist())
-        assert np.allclose(yt, y[fidx])
+        assert np.allclose(yt, y[tuple(fidx)])
 
         # Verify logamp
         rms = librosa.feature.rmse(y=librosa.to_mono(yt), center=False)

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -42,7 +42,7 @@ def test_delta():
         slice_out = [slice(None)] * delta.ndim
         slice_orig[axis] = slice(width//2 + 1, -width//2 + 1)
         slice_out[axis] = slice(width//2, -width//2)
-        assert np.allclose((x + delta)[slice_out], x[slice_orig])
+        assert np.allclose((x + delta)[tuple(slice_out)], x[tuple(slice_orig)])
 
     x = np.vstack([np.arange(100.0)] * 3)
 


### PR DESCRIPTION
#### Reference Issue
Fixes #754 


#### What does this implement/fix? Explain your changes.

Numpy 1.15 added `FutureWarning` for using lists as ndarray indexes.  This PR tuple-izes all of the offending cases to avoid the warnings going forward.

#### Any other comments?

I don't anticipate any problems with this change.  As long as the tests pass and the warnings are gone, I think we can merge without CR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/755)
<!-- Reviewable:end -->
