### PR TITLE
made smoothing optional, allowed overriding smoothing window function

### DIFF
--- a/docs/examples/plot_chroma.py
+++ b/docs/examples/plot_chroma.py
@@ -1,21 +1,26 @@
 # coding: utf-8
 """
-===============
-Enhanced chroma
-===============
+===================================
+Enhanced chroma and chroma variants
+===================================
 
-This notebook demonstrates a variety of techniques for enhancing chroma features.
-
-Beyond the default parameter settings of librosa's chroma functions, we apply the following
-enhancements:
-
-    1. Over-sampling the frequency axis to reduce sensitivity to tuning deviations
-    2. Harmonic-percussive-residual source separation to eliminate transients.
-    3. Nearest-neighbor smoothing to eliminate passing tones and sparse noise.  This is inspired by the
-       recurrence-based smoothing technique of
-       `Cho and Bello, 2011 <http://ismir2011.ismir.net/papers/OS8-4.pdf>`_.
-    4. Local median filtering to suppress remaining discontinuities.
+This notebook demonstrates a variety of techniques for enhancing chroma features and 
+also, introduces chroma variants implemented in librosa.
 """
+
+
+###############################################################################################
+#  
+# Enhanced chroma
+# ^^^^^^^^^^^^^^^
+# Beyond the default parameter settings of librosa's chroma functions, we apply the following 
+# enhancements:
+#    1. Over-sampling the frequency axis to reduce sensitivity to tuning deviations
+#    2. Harmonic-percussive-residual source separation to eliminate transients.
+#    3. Nearest-neighbor smoothing to eliminate passing tones and sparse noise.  This is inspired by the
+#       recurrence-based smoothing technique of
+#       `Cho and Bello, 2011 <http://ismir2011.ismir.net/papers/OS8-4.pdf>`_.
+#    4. Local median filtering to suppress remaining discontinuities.
 
 # Code source: Brian McFee
 # License: ISC
@@ -164,3 +169,63 @@ plt.ylabel('Processed')
 plt.colorbar()
 plt.tight_layout()
 plt.show()
+
+
+#################################################################################################
+#   
+# Chroma variants
+# ^^^^^^^^^^^^^^^
+# There are three chroma variants implemented in librosa: `chroma_stft`, `chroma_cqt`, and `chroma_cens`.
+# `chroma_stft` and `chroma_cqt` are two alternative ways of plotting chroma.    
+# 
+# `chroma_stft` performs short-time fourier transform of an audio input and maps each STFT bin to chroma, while `chroma_cqt` uses constant-Q transform and maps each cq-bin to chroma.      
+# 
+# A comparison between the STFT and the CQT methods for chromagram. 
+chromagram_stft = librosa.feature.chroma_stft(y=y, sr=sr)
+chromagram_cqt = librosa.feature.chroma_cqt(y=y, sr=sr)
+
+
+plt.figure(figsize=(12, 4))
+
+plt.subplot(2, 1, 1)
+librosa.display.specshow(chromagram_stft[idx], y_axis='chroma')
+plt.colorbar()
+plt.ylabel('STFT')
+
+plt.subplot(2, 1, 2)
+librosa.display.specshow(chromagram_cqt[idx], y_axis='chroma', x_axis='time')
+plt.colorbar()
+plt.ylabel('CQT')
+plt.tight_layout()
+
+
+###################################################################################################
+# CENS features (`chroma_cens`) are variants of chroma features introduced in 
+# `Müller and Ewart, 2011 <http://ismir2011.ismir.net/papers/PS2-8.pdf>`_, in which 
+# additional post processing steps are performed on the constant-Q chromagram to obtain features 
+# that are invariant to dynamics and timbre.     
+# 
+# Thus, the CENS features are useful for applications, such as audio matching and retrieval.
+#  
+# Following steps are additional processing done on the chromagram, and are implemented in `chroma_cens`:  
+#   1. L1-Normalization across each chroma vector
+#   2. Quantization of the amplitudes based on "log-like" amplitude thresholds
+#   3. Smoothing with sliding window (optional parameter) 
+#   4. Downsampling (not implemented)
+#
+# A comparison between the original constant-Q chromagram and the CENS features.  
+chromagram_cens = librosa.feature.chroma_cens(y=y, sr=sr)
+
+
+plt.figure(figsize=(12, 4))
+
+plt.subplot(2, 1, 1)
+librosa.display.specshow(chromagram_cqt[idx], y_axis='chroma')
+plt.colorbar()
+plt.ylabel('Orig')
+
+plt.subplot(2, 1, 2)
+librosa.display.specshow(chromagram_cens[idx], y_axis='chroma', x_axis='time')
+plt.colorbar()
+plt.ylabel('CENS')
+plt.tight_layout()

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -1097,8 +1097,16 @@ def chroma_cens(y=None, sr=22050, C=None, hop_length=512, fmin=None,
                 norm=2, win_len_smooth=41, smoothing_window='hann'):
     r'''Computes the chroma variant "Chroma Energy Normalized" (CENS), following [1]_.
 
+    To compute CENS features, following steps are taken after obtaining chroma vectors using `chroma_cqt`:  
+    1. L-1 normalization of each chroma vector
+    2. Quantization of amplitude based on "log-like" amplitude thresholds
+    3. (optional) Smoothing with sliding window. Default window length = 41 frames 
+    4. (not implemented) Downsampling   
+
+    CENS features are robust to dynamics, timbre and articulation, thus these are commonly used in audio matching and retrieval applications.   
+
     .. [1] Meinard Müller and Sebastian Ewert
-           Chroma Toolbox: MATLAB implementations for extracting variants of chroma-based audio features
+           "Chroma Toolbox: MATLAB implementations for extracting variants of chroma-based audio features" 
            In Proceedings of the International Conference on Music Information Retrieval (ISMIR), 2011.
 
     Parameters

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -1150,11 +1150,11 @@ def chroma_cens(y=None, sr=22050, C=None, hop_length=512, fmin=None,
         Constant-Q transform mode
 
     win_len_smooth : int > 0 or None
-        Length of temporal smoothing window.
+        Length of temporal smoothing window. `None` disables temporal smoothing. 
         Default: 41
 
     smoothing_window : str, float or tuple
-        Type of window function for temporal smoothing. See `scipy.signal.get_window` for possible inputs.
+        Type of window function for temporal smoothing. See `filters.get_window` for possible inputs.
         Default: 'hann'
 
     Returns
@@ -1169,6 +1169,9 @@ def chroma_cens(y=None, sr=22050, C=None, hop_length=512, fmin=None,
 
     chroma_stft
         Compute a chromagram from an STFT spectrogram or waveform.
+
+    filters.get_window
+        Compute a window function. 
 
     Examples
     --------
@@ -1192,6 +1195,9 @@ def chroma_cens(y=None, sr=22050, C=None, hop_length=512, fmin=None,
     >>> plt.colorbar()
     >>> plt.tight_layout()
     '''
+    if not ((win_len_smooth is None) or (isinstance(win_len_smooth, int) and win_len_smooth > 0)):
+        raise ParameterError('win_len_smooth={} must be a positive integer or None'.format(win_len_smooth))
+
     chroma = chroma_cqt(y=y, C=C, sr=sr,
                         hop_length=hop_length,
                         fmin=fmin,
@@ -1222,7 +1228,7 @@ def chroma_cens(y=None, sr=22050, C=None, hop_length=512, fmin=None,
         win = np.atleast_2d(win)
 
         cens = scipy.signal.convolve2d(chroma_quant, win,
-                                     mode='same', boundary='fill')
+                                       mode='same', boundary='fill')
     else:
         cens = chroma_quant
 


### PR DESCRIPTION
#### Reference Issue
Fixes #728: "make smoothing optional in chroma_cens"


#### What does this implement/fix? Explain your changes.
Current chroma_cens assumes the smoothing as a default, but here, I added an option to not use smoothing at all. Also, allowing the user to choose the window function other than 'hann' window by adding a new parameter `smoothing_window='hann'`. 

#### Any other comments?
Regarding coverage, I see that it decreased a bit on the spectral features. I guess I should be adding the test for the `win_len_smooth=None`, but it looks like the baseline is from the chroma toolbox result (I see 3 `.mat` files with example parameters). Any tips on creating one like `'features-CT-CENS_None-1.mat'`? Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/766)
<!-- Reviewable:end -->
