### PR TITLE
Include LICENSE.md in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include AUTHORS.md
+include CONTRIBUTING.md
+include LICENSE.md


### PR DESCRIPTION
The ISC license requires that the license be included in all copies of the code.  Also include the AUTHORS.md and CONTRIBUTING.md files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/777)
<!-- Reviewable:end -->
