### PR TITLE
fix typo in CONTRIBUTING.md: scikit-learn -> librosa

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ following rules before submitting:
    See [Creating and highlighting code blocks](https://help.github.com/articles/creating-and-highlighting-code-blocks).
 
 -  Please include your operating system type and version number, as well
-   as your Python, scikit-learn, numpy, and scipy versions. This information
+   as your Python, librosa, numpy, and scipy versions. This information
    can be found by runnning the following code snippet:
 
   ```python


### PR DESCRIPTION
#### Reference Issue
N/A


#### What does this implement/fix? Explain your changes.
So today I was reading librosa's `CONTRIBUTING.md` which is adapted from the `CONTRIBUTING.md` of scikit-learn.
I noticed an instance in which scikit-learn is not replaced by librosa in the Markdown file.

#### Any other comments?
N/A
