### PR TITLE
convert slices to tuple in test_valid_intervals

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -677,7 +677,7 @@ def test_valid_intervals():
         for n in range(1, 4):
             ivals = np.ones(d * [n])
             for m in range(1, 3):
-                slices = [slice(m)] * d
+                slices = tuple([slice(m)] * d)
                 if m == 2 and d == 2 and n > 1:
                     yield __test, ivals[slices]
                 else:


### PR DESCRIPTION
#### Reference Issue
```
./home/travis/build/librosa/librosa/tests/test_util.py:684: FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result.
  yield raises(librosa.ParameterError)(__test), ivals[slices]
```


#### What does this implement/fix? Explain your changes.
replacing
`slices = [slice(m)] * d`
by 
`slices = tuple([slice(m)] * d)`
fixes the following Travis deprecation warning.

It's an explicit conversion from list to tuple.


#### Any other comments?
found while investigating a Travis build failure in Python 3.X

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/779)
<!-- Reviewable:end -->
