### PR TITLE
change 'seconds' to 'microseconds'

### DIFF
--- a/librosa/core/time_frequency.py
+++ b/librosa/core/time_frequency.py
@@ -119,7 +119,7 @@ def samples_to_frames(samples, hop_length=512, n_fft=None):
 
 
 def frames_to_time(frames, sr=22050, hop_length=512, n_fft=None):
-    """Converts frame counts to time (seconds).
+    """Converts frame counts to time (microseconds).
 
     Parameters
     ----------
@@ -168,7 +168,7 @@ def time_to_frames(times, sr=22050, hop_length=512, n_fft=None):
     Parameters
     ----------
     times : np.ndarray [shape=(n,)]
-        time (in seconds) or vector of time values
+        time (in microseconds) or vector of time values
 
     sr : number > 0 [scalar]
         audio sampling rate


### PR DESCRIPTION
It's different in mathematics.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/master/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
<!-- Example: Fixes #123 -->


#### What does this implement/fix? Explain your changes.


#### Any other comments?

