### PR TITLE
Remove asserts

### DIFF
--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -357,6 +357,11 @@ def get_duration(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
     -------
     d : float >= 0
         Duration (in seconds) of the input time series or spectrogram.
+
+    Raises
+    ------
+    ParameterError
+        if none of `y`, `S`, or `filename` are provided.
     """
 
     if filename is not None:
@@ -364,7 +369,8 @@ def get_duration(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
             return fdesc.duration
 
     if y is None:
-        assert S is not None
+        if S is None:
+            raise ParameterError('At least one of (y, sr), S, or filename must be provided')
 
         n_frames = S.shape[1]
         n_samples = n_fft + hop_length * (n_frames - 1)

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -362,6 +362,14 @@ def get_duration(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
     ------
     ParameterError
         if none of `y`, `S`, or `filename` are provided.
+
+    Notes
+    -----
+    `get_duration` can be applied to a file (`filename`), a spectrogram (`S`),
+    or audio buffer (`y, sr`).  Only one of these three options should be
+    provided.  If you do provide multiple options (e.g., `filename` and `S`),
+    then `filename` takes precedence over `S`, and `S` takes precedence over
+    `(y, sr)`.
     """
 
     if filename is not None:

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1264,7 +1264,7 @@ def fmt(y, t_min=0.5, n_fmt=None, kind='cubic', beta=0.5, over_sample=1, axis=-1
     # Make sure that all sample points are unique
     # This should never happen!
     if len(np.unique(x_exp)) != len(x_exp):
-        raise RuntimeError('Redundant sample positions in FMT')
+        raise RuntimeError('Redundant sample positions in Mellin transform')
 
     # Resample the signal
     y_res = f_interp(x_exp)

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1262,7 +1262,9 @@ def fmt(y, t_min=0.5, n_fmt=None, kind='cubic', beta=0.5, over_sample=1, axis=-1
         x_exp = np.clip(x_exp, float(t_min) / n, x[-1])
 
     # Make sure that all sample points are unique
-    assert len(np.unique(x_exp)) == len(x_exp)
+    # This should never happen!
+    if len(np.unique(x_exp)) != len(x_exp):
+        raise RuntimeError('Redundant sample positions in FMT')
 
     # Resample the signal
     y_res = f_interp(x_exp)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -576,6 +576,11 @@ def test_get_duration_filename():
     assert np.allclose(duration_fn, duration_y)
 
 
+@pytest.mark.xfail(raises=librosa.ParameterError)
+def test_get_duration_fail():
+    librosa.get_duration(y=None, S=None, filename=None)
+
+
 def test_autocorrelate():
 
     def __test(y, truth, max_size, axis):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/master/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
Fixes #784 


#### What does this implement/fix? Explain your changes.
This PR replaces runtime assertions by proper exceptions.  No other change to functionality.

#### Any other comments?

The exception in the fast mellin transform code should, I think, never occur in practice.  It's difficult to construct a test case to trigger this, so we'll have a small dip in test coverage for now.

In the future, it might be nice to refactor FMT a bit to make it easier to understand what's going on, but I'll leave that for future work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/785)
<!-- Reviewable:end -->
