### PR TITLE
Dropped imp for importlib

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -165,8 +165,10 @@ copyright = u'2013--2018, librosa development team'
 # built documents.
 #
 
-import imp
-librosa_version = imp.load_source('librosa.version', '../librosa/version.py')
+from importlib.machinery import SourceFileLoader
+
+librosa_version = SourceFileLoader('librosa.version',
+                                   '../librosa/version.py').load_module()
 # The short X.Y version.
 version = librosa_version.short_version
 # The full version, including alpha/beta/rc tags.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -165,10 +165,16 @@ copyright = u'2013--2018, librosa development team'
 # built documents.
 #
 
-from importlib.machinery import SourceFileLoader
+if sys.version_info.major == 2:
+    import imp
 
-librosa_version = SourceFileLoader('librosa.version',
-                                   '../librosa/version.py').load_module()
+    librosa_version = imp.load_source('librosa.version', 'librosa/version.py')
+else:
+    from importlib.machinery import SourceFileLoader
+
+    librosa_version = SourceFileLoader('librosa.version',
+                                       'librosa/version.py').load_module()
+
 # The short X.Y version.
 version = librosa_version.short_version
 # The full version, including alpha/beta/rc tags.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -168,12 +168,13 @@ copyright = u'2013--2018, librosa development team'
 if sys.version_info.major == 2:
     import imp
 
-    librosa_version = imp.load_source('librosa.version', 'librosa/version.py')
+    librosa_version = imp.load_source('librosa.version',
+                                      '../librosa/version.py')
 else:
     from importlib.machinery import SourceFileLoader
 
     librosa_version = SourceFileLoader('librosa.version',
-                                       'librosa/version.py').load_module()
+                                       '../librosa/version.py').load_module()
 
 # The short X.Y version.
 version = librosa_version.short_version

--- a/librosa/version.py
+++ b/librosa/version.py
@@ -35,14 +35,18 @@ def show_versions():
                  'joblib',
                  'decorator',
                  'six',
-                 'resampy']
+                 'resampy',
+                 'numba']
 
     extra_deps = ['numpydoc',
                   'sphinx',
                   'sphinx_rtd_theme',
                   'sphinxcontrib.versioning',
-                  'matplotlib',
-                  'numba']
+                  'sphinx-gallery',
+                  'pytest',
+                  'pytest-mpl',
+                  'pytest-cov',
+                  'matplotlib']
 
     print('INSTALLED VERSIONS')
     print('------------------')

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 from setuptools import setup, find_packages
 
-import imp
+from importlib.machinery import SourceFileLoader
 
-version = imp.load_source('librosa.version', 'librosa/version.py')
+version = SourceFileLoader('librosa.version',
+                           'librosa/version.py').load_module()
 
 with open('README.md', 'r') as fdesc:
     long_description = fdesc.read()

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,16 @@
 from setuptools import setup, find_packages
+import sys
 
-from importlib.machinery import SourceFileLoader
 
-version = SourceFileLoader('librosa.version',
-                           'librosa/version.py').load_module()
+if sys.version_info.major == 2:
+    import imp
+
+    version = imp.load_source('librosa.version', 'librosa/version.py')
+else:
+    from importlib.machinery import SourceFileLoader
+
+    version = SourceFileLoader('librosa.version',
+                               'librosa/version.py').load_module()
 
 with open('README.md', 'r') as fdesc:
     long_description = fdesc.read()


### PR DESCRIPTION

#### Reference Issue
Fixes #788 


#### What does this implement/fix? Explain your changes.
Removed deprecated `imp` dependencies in favor of `importlib`.

#### Any other comments?
I also took the opportunity to revise some of the dependency checks in `show_versions()` to reflect some recent changes.  Nothing major here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/790)
<!-- Reviewable:end -->
