### PR TITLE
Remove confusing reference to "DPWE code".

### DIFF
--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -179,7 +179,6 @@ def stft(y, n_fft=2048, hop_length=None, win_length=None, window='hann',
     for bl_s in range(0, stft_matrix.shape[1], n_columns):
         bl_t = min(bl_s + n_columns, stft_matrix.shape[1])
 
-        # RFFT and Conjugate here to match phase from DPWE code
         stft_matrix[:, bl_s:bl_t] = fft.fft(fft_window *
                                             y_frames[:, bl_s:bl_t],
                                             axis=0)[:stft_matrix.shape[0]]


### PR DESCRIPTION
Remove obsolete explanation for why the FFT output is being conjugated - it's not any more.

The .conj() on the output of fft.fft was removed in 0.6.0; this comment should have been deleted then.  Not sure what RFFT refers to, as the call seems to have always been fft.fft.

Obsolete comments?  In my code base?

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/master/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
<!-- Example: Fixes #123 -->


#### What does this implement/fix? Explain your changes.
Removes an outdated comment that could only confuse readers.

#### Any other comments?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/793)
<!-- Reviewable:end -->
