### PR TITLE
Iir sos

### DIFF
--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -690,6 +690,7 @@ def iirt(y, sr=22050, win_length=2048, hop_length=None, center=True,
           Can be unstable for high-order filters.
         - If `sos`, a series of second-order filters is used for filtering with `scipy.signal.sosfiltfilt`.
           Minimizes numerical precision errors for high-order filters, but is slower.
+        - Raises a `ParameterError` for any other string.
 
     kwargs : additional keyword arguments
         Additional arguments for `librosa.filters.semitone_filterbank()`

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -772,7 +772,7 @@ def iirt(y, sr=22050, win_length=2048, hop_length=None, center=True,
         if flayout == 'ba':
             cur_filter_output = scipy.signal.filtfilt(cur_filter[0], cur_filter[1],
                                                       y_resampled[cur_sr_idx])
-        else:
+        elif flayout == 'sos':
             cur_filter_output = scipy.signal.sosfiltfilt(cur_filter,
                                                          y_resampled[cur_sr_idx])
 

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -634,7 +634,7 @@ def phase_vocoder(D, rate, hop_length=None):
 
 @cache(level=20)
 def iirt(y, sr=22050, win_length=2048, hop_length=None, center=True,
-         tuning=0.0, pad_mode='reflect', flayout='ba', **kwargs):
+         tuning=0.0, pad_mode='reflect', flayout=None, **kwargs):
     r'''Time-frequency representation using IIR filters [1]_.
 
     This function will return a time-frequency representation
@@ -720,6 +720,11 @@ def iirt(y, sr=22050, win_length=2048, hop_length=None, center=True,
     >>> plt.colorbar(format='%+2.0f dB')
     >>> plt.tight_layout()
     '''
+
+    if flayout is None:
+        warnings.warn('Default filter layout for `iirt` is `ba`, but will be `sos` in 0.7.',
+                      FutureWarning)
+        flayout = 'ba'
 
     # check audio input
     util.valid_audio(y)

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -634,7 +634,7 @@ def phase_vocoder(D, rate, hop_length=None):
 
 @cache(level=20)
 def iirt(y, sr=22050, win_length=2048, hop_length=None, center=True,
-         tuning=0.0, pad_mode='reflect', **kwargs):
+         tuning=0.0, pad_mode='reflect', flayout='ba', **kwargs):
     r'''Time-frequency representation using IIR filters [1]_.
 
     This function will return a time-frequency representation
@@ -642,7 +642,7 @@ def iirt(y, sr=22050, win_length=2048, hop_length=None, center=True,
     First, `y` is resampled as needed according to the provided `sample_rates`.
     Then, a filterbank with with `n` band-pass filters is designed.
     The resampled input signals are processed by the filterbank as a whole.
-    (`scipy.signal.sosfiltfilt` is used to make the phase linear.)
+    (`scipy.signal.filtfilt` resp. `sosfiltfilt` is used to make the phase linear.)
     The output of the filterbank is cut into frames.
     For each band, the short-time mean-square power (STMSP) is calculated by
     summing `win_length` subsequent filtered time samples.
@@ -685,6 +685,12 @@ def iirt(y, sr=22050, win_length=2048, hop_length=None, center=True,
         If `center=True`, the padding mode to use at the edges of the signal.
         By default, this function uses reflection padding.
 
+    flayout : string
+        - If `ba`, the standard difference equation is used for filtering with `scipy.signal.filtfilt`.
+          Can be unstable for high-order filters.
+        - If `sos`, a series of second-order filters is used for filtering with `scipy.signal.sosfiltfilt`.
+          Minimizes numerical precision errors for high-order filters, but is slower.
+
     kwargs : additional keyword arguments
         Additional arguments for `librosa.filters.semitone_filterbank()`
         (e.g., could be used to provide another set of `center_freqs` and `sample_rates`).
@@ -700,6 +706,7 @@ def iirt(y, sr=22050, win_length=2048, hop_length=None, center=True,
     librosa.filters._multirate_fb
     librosa.filters.mr_frequencies
     librosa.core.cqt
+    scipy.signal.filtfilt
     scipy.signal.sosfiltfilt
 
     Examples
@@ -726,7 +733,7 @@ def iirt(y, sr=22050, win_length=2048, hop_length=None, center=True,
         y = np.pad(y, int(hop_length), mode=pad_mode)
 
     # get the semitone filterbank
-    filterbank_ct, sample_rates = semitone_filterbank(tuning=tuning, **kwargs)
+    filterbank_ct, sample_rates = semitone_filterbank(tuning=tuning, flayout=flayout, **kwargs)
 
     # create three downsampled versions of the audio signal
     y_resampled = []
@@ -749,8 +756,12 @@ def iirt(y, sr=22050, win_length=2048, hop_length=None, center=True,
         # filter the signal
         cur_sr_idx = np.flatnonzero(y_srs == cur_sr)[0]
 
-        cur_filter_output = scipy.signal.sosfiltfilt(cur_filter,
-                                                     y_resampled[cur_sr_idx])
+        if flayout == 'ba':
+            cur_filter_output = scipy.signal.filtfilt(cur_filter[0], cur_filter[1],
+                                                      y_resampled[cur_sr_idx])
+        else:
+            cur_filter_output = scipy.signal.sosfiltfilt(cur_filter,
+                                                         y_resampled[cur_sr_idx])
 
         # frame the current filter output
         cur_frames = util.frame(np.ascontiguousarray(cur_filter_output),

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -726,6 +726,9 @@ def iirt(y, sr=22050, win_length=2048, hop_length=None, center=True,
                       FutureWarning)
         flayout = 'ba'
 
+    elif flayout not in ('ba', 'sos'):
+        raise ParameterError('Unsupported flayout={}'.format(flayout))
+
     # check audio input
     util.valid_audio(y)
 

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -749,8 +749,8 @@ def iirt(y, sr=22050, win_length=2048, hop_length=None, center=True,
         # filter the signal
         cur_sr_idx = np.flatnonzero(y_srs == cur_sr)[0]
 
-        cur_filter_output = scipy.signal.filtfilt(cur_filter[0], cur_filter[1],
-                                                  y_resampled[cur_sr_idx])
+        cur_filter_output = scipy.signal.sosfiltfilt(cur_filter,
+                                                     y_resampled[cur_sr_idx])
 
         # frame the current filter output
         cur_frames = util.frame(np.ascontiguousarray(cur_filter_output),

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -690,7 +690,6 @@ def iirt(y, sr=22050, win_length=2048, hop_length=None, center=True,
           Can be unstable for high-order filters.
         - If `sos`, a series of second-order filters is used for filtering with `scipy.signal.sosfiltfilt`.
           Minimizes numerical precision errors for high-order filters, but is slower.
-        - Raises a `ParameterError` for any other string.
 
     kwargs : additional keyword arguments
         Additional arguments for `librosa.filters.semitone_filterbank()`
@@ -700,6 +699,11 @@ def iirt(y, sr=22050, win_length=2048, hop_length=None, center=True,
     -------
     bands_power : np.ndarray [shape=(n, t), dtype=dtype]
         Short-time mean-square power for the input signal.
+
+    Raises
+    ------
+    ParameterError
+        If `flayout` is not None, `ba`, or `sos`.
 
     See Also
     --------

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -642,7 +642,7 @@ def iirt(y, sr=22050, win_length=2048, hop_length=None, center=True,
     First, `y` is resampled as needed according to the provided `sample_rates`.
     Then, a filterbank with with `n` band-pass filters is designed.
     The resampled input signals are processed by the filterbank as a whole.
-    (`scipy.signal.filtfilt` is used to make the phase linear.)
+    (`scipy.signal.sosfiltfilt` is used to make the phase linear.)
     The output of the filterbank is cut into frames.
     For each band, the short-time mean-square power (STMSP) is calculated by
     summing `win_length` subsequent filtered time samples.
@@ -700,7 +700,7 @@ def iirt(y, sr=22050, win_length=2048, hop_length=None, center=True,
     librosa.filters._multirate_fb
     librosa.filters.mr_frequencies
     librosa.core.cqt
-    scipy.signal.filtfilt
+    scipy.signal.sosfiltfilt
 
     Examples
     --------

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -909,7 +909,7 @@ def get_window(window, Nx, fftbins=True):
 
 @cache(level=10)
 def _multirate_fb(center_freqs=None, sample_rates=None, Q=25.0,
-                  passband_ripple=1, stopband_attenuation=50, ftype='ellip'):
+                  passband_ripple=1, stopband_attenuation=50, ftype='ellip', flayout='ba'):
     r'''Helper function to construct a multirate filterbank.
 
      A filter bank consists of multiple band-pass filters which divide the input signal
@@ -943,6 +943,12 @@ def _multirate_fb(center_freqs=None, sample_rates=None, Q=25.0,
     ftype : str
         The type of IIR filter to design
         See `scipy.signal.iirdesign` for details.
+
+    flayout : string
+        - If `ba`, the standard difference equation is used for filtering with `scipy.signal.filtfilt`.
+          Can be unstable for high-order filters.
+        - If `sos`, a series of second-order filters is used for filtering with `scipy.signal.sosfiltfilt`.
+          Minimizes numerical precision errors for high-order filters, but is slower.
 
     Returns
     -------
@@ -986,12 +992,17 @@ def _multirate_fb(center_freqs=None, sample_rates=None, Q=25.0,
         passband_freqs = [cur_center_freq - 0.5 * cur_bw, cur_center_freq + 0.5 * cur_bw] / cur_nyquist
         stopband_freqs = [cur_center_freq - cur_bw, cur_center_freq + cur_bw] / cur_nyquist
 
-        cur_filter_zpk = scipy.signal.iirdesign(passband_freqs, stopband_freqs,
+        if flayout == 'ba':
+            cur_filter = scipy.signal.iirdesign(passband_freqs, stopband_freqs,
                                                 passband_ripple, stopband_attenuation,
-                                                analog=False, ftype=ftype, output='zpk')
-        cur_filter_sos = scipy.signal.zpk2sos(*cur_filter_zpk)
+                                                analog=False, ftype=ftype, output='ba')
+        elif flayout == 'sos':
+            cur_filter_zpk = scipy.signal.iirdesign(passband_freqs, stopband_freqs,
+                                                    passband_ripple, stopband_attenuation,
+                                                    analog=False, ftype=ftype, output='zpk')
+            cur_filter = scipy.signal.zpk2sos(*cur_filter_zpk)
 
-        filterbank.append(cur_filter_sos)
+        filterbank.append(cur_filter)
 
     return filterbank, sample_rates
 
@@ -1044,7 +1055,7 @@ def mr_frequencies(tuning):
     return center_freqs, sample_rates
 
 
-def semitone_filterbank(center_freqs=None, tuning=0.0, sample_rates=None, **kwargs):
+def semitone_filterbank(center_freqs=None, tuning=0.0, sample_rates=None, flayout='ba', **kwargs):
     r'''Constructs a multirate filterbank of infinite-impulse response (IIR)
     band-pass filters at user-defined center frequencies and sample rates.
 
@@ -1078,6 +1089,12 @@ def semitone_filterbank(center_freqs=None, tuning=0.0, sample_rates=None, **kwar
 
     sample_rates : np.ndarray [shape=(n,), dtype=float]
         Sample rates of each filter in the multirate filterbank.
+
+    flayout : string
+        - If `ba`, the standard difference equation is used for filtering with `scipy.signal.filtfilt`.
+          Can be unstable for high-order filters.
+        - If `sos`, a series of second-order filters is used for filtering with `scipy.signal.sosfiltfilt`.
+          Minimizes numerical precision errors for high-order filters, but is slower.
 
     kwargs : additional keyword arguments
         Additional arguments to the private function `_multirate_fb()`.
@@ -1120,7 +1137,8 @@ def semitone_filterbank(center_freqs=None, tuning=0.0, sample_rates=None, **kwar
     if (center_freqs is None) and (sample_rates is None):
         center_freqs, sample_rates = mr_frequencies(tuning)
 
-    filterbank, fb_sample_rates = _multirate_fb(center_freqs=center_freqs, sample_rates=sample_rates, **kwargs)
+    filterbank, fb_sample_rates = _multirate_fb(center_freqs=center_freqs, sample_rates=sample_rates,
+                                                flayout=flayout, **kwargs)
 
     return filterbank, fb_sample_rates
 

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -992,15 +992,9 @@ def _multirate_fb(center_freqs=None, sample_rates=None, Q=25.0,
         passband_freqs = [cur_center_freq - 0.5 * cur_bw, cur_center_freq + 0.5 * cur_bw] / cur_nyquist
         stopband_freqs = [cur_center_freq - cur_bw, cur_center_freq + cur_bw] / cur_nyquist
 
-        if flayout == 'ba':
-            cur_filter = scipy.signal.iirdesign(passband_freqs, stopband_freqs,
-                                                passband_ripple, stopband_attenuation,
-                                                analog=False, ftype=ftype, output='ba')
-        elif flayout == 'sos':
-            cur_filter_zpk = scipy.signal.iirdesign(passband_freqs, stopband_freqs,
-                                                    passband_ripple, stopband_attenuation,
-                                                    analog=False, ftype=ftype, output='zpk')
-            cur_filter = scipy.signal.zpk2sos(*cur_filter_zpk)
+        cur_filter = scipy.signal.iirdesign(passband_freqs, stopband_freqs,
+                                            passband_ripple, stopband_attenuation,
+                                            analog=False, ftype=ftype, output=flayout)
 
         filterbank.append(cur_filter)
 

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -986,11 +986,12 @@ def _multirate_fb(center_freqs=None, sample_rates=None, Q=25.0,
         passband_freqs = [cur_center_freq - 0.5 * cur_bw, cur_center_freq + 0.5 * cur_bw] / cur_nyquist
         stopband_freqs = [cur_center_freq - cur_bw, cur_center_freq + cur_bw] / cur_nyquist
 
-        cur_filter = scipy.signal.iirdesign(passband_freqs, stopband_freqs,
-                                            passband_ripple, stopband_attenuation,
-                                            analog=False, ftype=ftype, output='ba')
+        cur_filter_zpk = scipy.signal.iirdesign(passband_freqs, stopband_freqs,
+                                                passband_ripple, stopband_attenuation,
+                                                analog=False, ftype=ftype, output='zpk')
+        cur_filter_sos = scipy.signal.zpk2sos(*cur_filter_zpk)
 
-        filterbank.append(cur_filter)
+        filterbank.append(cur_filter_sos)
 
     return filterbank, sample_rates
 

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -945,10 +945,14 @@ def _multirate_fb(center_freqs=None, sample_rates=None, Q=25.0,
         See `scipy.signal.iirdesign` for details.
 
     flayout : string
-        - If `ba`, the standard difference equation is used for filtering with `scipy.signal.filtfilt`.
+        Valid `output` argument for `scipy.signal.iirdesign`.
+        - If `ba`, returns numerators/denominators of the transfer functions,
+          used for filtering with `scipy.signal.filtfilt`.
           Can be unstable for high-order filters.
-        - If `sos`, a series of second-order filters is used for filtering with `scipy.signal.sosfiltfilt`.
+        - If `sos`, returns a series of second-order filters,
+          used for filtering with `scipy.signal.sosfiltfilt`.
           Minimizes numerical precision errors for high-order filters, but is slower.
+        - If `zpk`, returns zeros, poles, and system gains of the transfer functions.
 
     Returns
     -------

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     install_requires=[
         'audioread >= 2.0.0',
         'numpy >= 1.8.0',
-        'scipy >= 0.14.0',
+        'scipy >= 1.0.0',
         'scikit-learn >= 0.14.0, != 0.19.0',
         'joblib >= 0.12',
         'decorator >= 3.0.0',

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1347,6 +1347,18 @@ def test_iirt():
     assert np.allclose(mut, gt[23:108, :mut.shape[1]], atol=1.8)
 
 
+@pytest.mark.xfail(raises=librosa.ParameterError)
+def test_iirt_flayout1():
+    y, sr = librosa.load(os.path.join('tests', 'data', 'test1_44100.wav'))
+    librosa.iirt(y, hop_length=2205, win_length=4410, flayout='foo')
+
+
+def test_iirt_flayout2():
+    y, sr = librosa.load(os.path.join('tests', 'data', 'test1_44100.wav'))
+    with pytest.warns(FutureWarning):
+        librosa.iirt(y, hop_length=2205, win_length=4410)
+
+
 def test_pcen():
 
     def __test(gain, bias, power, b, time_constant, eps, ms, S, Pexp):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1342,9 +1342,13 @@ def test_iirt():
     gt = scipy.io.loadmat(os.path.join('tests', 'data', 'features-CT-cqt'), squeeze_me=True)['f_cqt']
 
     y, sr = librosa.load(os.path.join('tests', 'data', 'test1_44100.wav'))
-    mut = librosa.iirt(y, hop_length=2205, win_length=4410)
+    mut1 = librosa.iirt(y, hop_length=2205, win_length=4410, flayout='ba')
 
-    assert np.allclose(mut, gt[23:108, :mut.shape[1]], atol=1.8)
+    assert np.allclose(mut1, gt[23:108, :mut1.shape[1]], atol=1.8)
+
+    mut2 = librosa.iirt(y, hop_length=2205, win_length=4410, flayout='sos')
+
+    assert np.allclose(mut2, gt[23:108, :mut2.shape[1]], atol=1.8)
 
 
 @pytest.mark.xfail(raises=librosa.ParameterError)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -393,19 +393,26 @@ def test_semitone_filterbank():
                              squeeze_me=True)['h']
 
     # standard parameters reproduce settings from chroma toolbox
-    mut_ft, mut_srs = librosa.filters.semitone_filterbank(flayout='ba')
+    mut_ft_ba, mut_srs_ba = librosa.filters.semitone_filterbank(flayout='ba')
+    mut_ft_sos, mut_srs_sos = librosa.filters.semitone_filterbank(flayout='sos')
 
-    for cur_filter_id in range(len(mut_ft)):
+    for cur_filter_id in range(len(mut_ft_ba)):
         cur_filter_gt = gt_fb[cur_filter_id + 23]
-        cur_filter_mut = mut_ft[cur_filter_id]
+        cur_filter_mut = mut_ft_ba[cur_filter_id]
+        cur_filter_mut_sos = scipy.signal.sos2tf(mut_ft_sos[cur_filter_id])
 
         cur_a_gt = cur_filter_gt[0]
         cur_b_gt = cur_filter_gt[1]
         cur_a_mut = cur_filter_mut[1]
         cur_b_mut = cur_filter_mut[0]
+        cur_a_mut_sos = cur_filter_mut_sos[1]
+        cur_b_mut_sos = cur_filter_mut_sos[0]
 
         # we deviate from the chroma toolboxes for pitches 94 and 95
         # (filters 70 and 71) by processing them with a higher samplerate
         if (cur_filter_id != 70) and (cur_filter_id != 71):
             assert np.allclose(cur_a_gt, cur_a_mut)
             assert np.allclose(cur_b_gt, cur_b_mut, atol=1e-4)
+
+            assert np.allclose(cur_a_gt, cur_a_mut_sos)
+            assert np.allclose(cur_b_gt, cur_b_mut_sos, atol=1e-4)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -21,6 +21,7 @@ except KeyError:
 import glob
 import numpy as np
 import scipy.io
+import scipy.signal
 
 import pytest
 
@@ -393,16 +394,17 @@ def test_semitone_filterbank():
                              squeeze_me=True)['h']
 
     # standard parameters reproduce settings from chroma toolbox
-    mut_ft, mut_srs = librosa.filters.semitone_filterbank()
+    mut_ft_sos, mut_srs = librosa.filters.semitone_filterbank()
 
-    for cur_filter_id in range(len(mut_ft)):
+    for cur_filter_id in range(len(mut_ft_sos)):
         cur_filter_gt = gt_fb[cur_filter_id + 23]
-        cur_filter_mut = mut_ft[cur_filter_id]
+        cur_filter_mut_sos = mut_ft_sos[cur_filter_id]
+        cur_filter_mut_ba = scipy.signal.sos2tf(cur_filter_mut_sos)
 
         cur_a_gt = cur_filter_gt[0]
         cur_b_gt = cur_filter_gt[1]
-        cur_a_mut = cur_filter_mut[1]
-        cur_b_mut = cur_filter_mut[0]
+        cur_a_mut = cur_filter_mut_ba[1]
+        cur_b_mut = cur_filter_mut_ba[0]
 
         # we deviate from the chroma toolboxes for pitches 94 and 95
         # (filters 70 and 71) by processing them with a higher samplerate

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -21,7 +21,6 @@ except KeyError:
 import glob
 import numpy as np
 import scipy.io
-import scipy.signal
 
 import pytest
 
@@ -394,17 +393,16 @@ def test_semitone_filterbank():
                              squeeze_me=True)['h']
 
     # standard parameters reproduce settings from chroma toolbox
-    mut_ft_sos, mut_srs = librosa.filters.semitone_filterbank()
+    mut_ft, mut_srs = librosa.filters.semitone_filterbank(flayout='ba')
 
-    for cur_filter_id in range(len(mut_ft_sos)):
+    for cur_filter_id in range(len(mut_ft)):
         cur_filter_gt = gt_fb[cur_filter_id + 23]
-        cur_filter_mut_sos = mut_ft_sos[cur_filter_id]
-        cur_filter_mut_ba = scipy.signal.sos2tf(cur_filter_mut_sos)
+        cur_filter_mut = mut_ft[cur_filter_id]
 
         cur_a_gt = cur_filter_gt[0]
         cur_b_gt = cur_filter_gt[1]
-        cur_a_mut = cur_filter_mut_ba[1]
-        cur_b_mut = cur_filter_mut_ba[0]
+        cur_a_mut = cur_filter_mut[1]
+        cur_b_mut = cur_filter_mut[0]
 
         # we deviate from the chroma toolboxes for pitches 94 and 95
         # (filters 70 and 71) by processing them with a higher samplerate


### PR DESCRIPTION
So far, `librosa.core.iirt` is doing iir filtering with [`scipy.signal.filtfilt`](https://docs.scipy.org/doc/scipy-0.18.1/reference/generated/scipy.signal.filtfilt.html) (using the standard difference equation). It is known that higher order filters can be instable due to numerical imprecisions of floating point numbers. A standard solution is to to use a series of second-order filters instead. Analytically, they are equivalent, but they are more robust against numerical imprecisions. Therefore, I propose to use [`scipy.signal.sosfiltfilt`](https://docs.scipy.org/doc/scipy-0.18.1/reference/generated/scipy.signal.sosfiltfilt.html).

A motivating example is shown in the documentation of [`scipy.signal.sosfilt`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.sosfilt.html). I came across this when reading the [Introduction to Digital Filters](https://ccrma.stanford.edu/~jos/filters/) of Julius O. Smith III.

What does this mean for `librosa.core.iirt`? For the standard settings, the improvements are insignificant. See the comparison of the magnitude responses, created with [this gist](https://gist.github.com/fzalkow/793dfeb0f6e7ce588889592ef286da46) (upper: magnitude response in db with old approach; middle: magnitude response in db with proposed approach; below: difference between the upper two):

![plot1](https://user-images.githubusercontent.com/5499717/49155328-f3d01600-f31a-11e8-9473-393fcd785004.png)
 
However, if we change the standard settings, e.g. by decreasing the passband ripple from 1 to 0.2 dB and increasing the stopband attenuation from 50 to 100 dB, the instability of the previous approach becomes obvious:

![plot2](https://user-images.githubusercontent.com/5499717/49155394-1eba6a00-f31b-11e8-9171-0cbe2d3ac55d.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/799)
<!-- Reviewable:end -->
