### PR TITLE
improve audio quality processed by effects.time_stretch() and effects…

### DIFF
--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -22,7 +22,7 @@ def test_time_stretch():
 
     def __test(infile, rate):
         y, sr = librosa.load(infile, duration=4.0)
-        ys = librosa.effects.time_stretch(y, rate)
+        ys = librosa.effects.time_stretch(y, sr, rate)
 
         orig_duration = librosa.get_duration(y, sr=sr)
         new_duration = librosa.get_duration(ys, sr=sr)


### PR DESCRIPTION
….pitch_shift()

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/master/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
<!-- Example: Fixes #123 -->


#### What does this implement/fix? Explain your changes.
The origin effects.time_stretch( ) contain a stft operations. **n_fft** of stft is set to 2048 (default), but it's too large in most situation, and it causes some background **noise** in processed audio.
This issus also affects the performance of effects.pitch_shift( ), because pitch_shift( ) relay on time_stretch( ).

I fix it in this way:
Fixed frame-length 40ms is used and **n_fft** is computed by (frame-length * sample_rate / 1000).
The experiments show that my implementation decreases the "noise" in processed audio.
[sample.zip](https://github.com/librosa/librosa/files/2767035/sample.zip)


#### Any other comments?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/820)
<!-- Reviewable:end -->
