### PR TITLE
Pitch tuning fix 806

### DIFF
--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -154,7 +154,7 @@ def pitch_tuning(frequencies, resolution=0.01, bins_per_octave=12):
     # from the next tone up.
     residual[residual >= 0.5] -= 1.0
 
-    bins = np.linspace(-0.5, 0.5, int(np.ceil(1./resolution))+1)
+    bins = np.linspace(-0.5, 0.5, int(np.ceil(1. / resolution)) + 1)
 
     counts, tuning = np.histogram(residual, bins)
 

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -154,7 +154,7 @@ def pitch_tuning(frequencies, resolution=0.01, bins_per_octave=12):
     # from the next tone up.
     residual[residual >= 0.5] -= 1.0
 
-    bins = np.linspace(-0.5, 0.5, int(np.ceil(1./resolution)), endpoint=False)
+    bins = np.linspace(-0.5, 0.5, int(np.ceil(1./resolution))+1)
 
     counts, tuning = np.histogram(residual, bins)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -769,11 +769,13 @@ def test_estimate_tuning():
                                              fmax=librosa.note_to_hz('G#9'))
 
         # Round to the proper number of decimals
-        deviation = np.around(np.abs(tuning - tuning_est),
-                              int(-np.log10(resolution)))
+        deviation = np.around(tuning - tuning_est, int(-np.log10(resolution)))
+
+        # Take the minimum floating point for positive and negative deviations 
+        max_dev = np.min([np.mod(deviation, 1.0), np.mod(-deviation, 1.0)])
 
         # We'll accept an answer within three bins of the resolution
-        assert deviation <= 3 * resolution
+        assert max_dev <= 3 * resolution
 
     for sr in [11025, 22050]:
         duration = 5.0


### PR DESCRIPTION
#### Reference Issue
This PR builds on #807 to fix #806 


#### What does this implement/fix? Explain your changes.

This PR fixes the tuning deviation estimation in the unit tests for `estimate_tuning` to properly handle circular errors.

#### Any other comments?

This ought to close out #806 .  Since there are no additional changes to the code, I'll merge this and close #807 once the CI passes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/824)
<!-- Reviewable:end -->
