### PR TITLE
Cache refactor

### DIFF
--- a/docs/cache.rst
+++ b/docs/cache.rst
@@ -43,6 +43,9 @@ Please refer to the `joblib.Memory` `documentation
 <https://pythonhosted.org/joblib/memory.html#memory-reference>`_ for a detailed explanation of these
 parameters.
 
+As of 0.7, librosa's cache wraps (rather than extends) the `joblib.Memory` object.
+The memory object can be directly accessed by `librosa.cache.memory`.
+
 
 Cache levels
 ------------

--- a/librosa/__init__.py
+++ b/librosa/__init__.py
@@ -8,7 +8,7 @@ from .version import version as __version__
 from .version import show_versions
 
 # And all the librosa sub-modules
-from . import cache
+from ._cache import cache
 from . import core
 from . import beat
 from . import decompose

--- a/librosa/_cache.py
+++ b/librosa/_cache.py
@@ -3,7 +3,6 @@
 """Function caching"""
 
 import os
-import sys
 from joblib import Memory
 
 
@@ -55,11 +54,8 @@ class CacheManager(Memory):
 
 
 # Instantiate the cache from the environment
-CACHE = CacheManager(os.environ.get('LIBROSA_CACHE_DIR', None),
+cache = CacheManager(os.environ.get('LIBROSA_CACHE_DIR', None),
                      mmap_mode=os.environ.get('LIBROSA_CACHE_MMAP', None),
                      compress=os.environ.get('LIBROSA_CACHE_COMPRESS', False),
                      verbose=int(os.environ.get('LIBROSA_CACHE_VERBOSE', 0)),
                      level=int(os.environ.get('LIBROSA_CACHE_LEVEL', 10)))
-
-# Override the module's __call__ attribute
-sys.modules[__name__] = CACHE

--- a/librosa/_cache.py
+++ b/librosa/_cache.py
@@ -6,16 +6,21 @@ import os
 from joblib import Memory
 
 
-class CacheManager(Memory):
-    '''The librosa cache manager class extends joblib.Memory
+class CacheManager(object):
+    '''The librosa cache manager class wraps joblib.Memory
     with a __call__ attribute, so that it may act as a function.
 
-    This allows us to override the librosa.cache module's __call__
-    field, thereby allowing librosa.cache to act as a decorator function.
+    Additionally, it provides a caching level filter, so that
+    different functions can be cached or not depending on the user's
+    preference for speed vs. storage usage.
     '''
 
-    def __init__(self, location, level=10, **kwargs):
-        super(CacheManager, self).__init__(location, **kwargs)
+    def __init__(self, *args, **kwargs):
+
+        level = kwargs.pop('level', 10)
+
+        # Initialize the memory object
+        self.memory = Memory(*args, **kwargs)
         # The level parameter controls which data we cache
         # smaller numbers mean less caching
         self.level = level
@@ -45,12 +50,27 @@ class CacheManager(Memory):
                     func, 'return decorated(%(signature)s)',
                     dict(decorated=dec(func)), __wrapped__=func)
 
-            if self.location is not None and self.level >= level:
-                return decorator_apply(self.cache, function)
+            if self.memory.location is not None and self.level >= level:
+                return decorator_apply(self.memory.cache, function)
 
             else:
                 return function
         return wrapper
+
+    def clear(self, *args, **kwargs):
+        return self.memory.clear(*args, **kwargs)
+
+    def eval(self, *args, **kwargs):
+        return self.memory.eval(*args, **kwargs)
+
+    def format(self, *args, **kwargs):
+        return self.memory.format(*args, **kwargs)
+
+    def reduce_size(self, *args, **kwargs):
+        return self.memory.reduce_size(*args, **kwargs)
+
+    def warn(self, *args, **kwargs):
+        return self.memory.warn(*args, **kwargs)
 
 
 # Instantiate the cache from the environment

--- a/librosa/beat.py
+++ b/librosa/beat.py
@@ -13,7 +13,7 @@ Beat and tempo
 import numpy as np
 import scipy
 
-from . import cache
+from ._cache import cache
 from . import core
 from . import onset
 from . import util

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -12,7 +12,7 @@ import resampy
 
 from .fft import get_fftlib
 from .time_frequency import frames_to_samples, time_to_samples
-from .. import cache
+from .._cache import cache
 from .. import util
 from ..util.exceptions import ParameterError
 

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -12,7 +12,7 @@ from .fft import get_fftlib
 from .time_frequency import cqt_frequencies, note_to_hz
 from .spectrum import stft
 from .pitch import estimate_tuning
-from .. import cache
+from .._cache import cache
 from .. import filters
 from .. import util
 from ..util.exceptions import ParameterError

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from .spectrum import _spectrogram
 from . import time_frequency
-from .. import cache
+from .._cache import cache
 from .. import util
 
 __all__ = ['estimate_tuning', 'pitch_tuning', 'piptrack']

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -15,7 +15,7 @@ from numba import jit
 from . import time_frequency
 from .fft import get_fftlib
 from .audio import resample
-from .. import cache
+from .._cache import cache
 from .. import util
 from ..util.exceptions import ParameterError
 from ..filters import get_window, semitone_filterbank

--- a/librosa/decompose.py
+++ b/librosa/decompose.py
@@ -19,7 +19,7 @@ from scipy.ndimage import median_filter
 import sklearn.decomposition
 
 from . import core
-from . import cache
+from ._cache import cache
 from . import segment
 from . import util
 from .util.exceptions import ParameterError

--- a/librosa/feature/utils.py
+++ b/librosa/feature/utils.py
@@ -6,7 +6,7 @@ from warnings import warn
 import numpy as np
 import scipy.signal
 
-from .. import cache
+from .._cache import cache
 from ..util.exceptions import ParameterError
 from ..util.deprecation import Deprecated
 __all__ = ['delta', 'stack_memory']

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -50,7 +50,7 @@ import six
 
 from numba import jit
 
-from . import cache
+from ._cache import cache
 from . import util
 from .util.exceptions import ParameterError
 from .util.decorators import deprecated

--- a/librosa/onset.py
+++ b/librosa/onset.py
@@ -15,7 +15,7 @@ Onset detection
 import numpy as np
 import scipy
 
-from . import cache
+from ._cache import cache
 from . import core
 from . import util
 from .util.exceptions import ParameterError

--- a/librosa/segment.py
+++ b/librosa/segment.py
@@ -692,7 +692,7 @@ def agglomerative(data, k, clusterer=None, axis=-1):
         # Instantiate the clustering object
         clusterer = sklearn.cluster.AgglomerativeClustering(n_clusters=k,
                                                             connectivity=grid,
-                                                            memory=cache)
+                                                            memory=cache.memory)
 
     # Fit the model
     clusterer.fit(data)

--- a/librosa/segment.py
+++ b/librosa/segment.py
@@ -34,7 +34,7 @@ import sklearn.cluster
 import sklearn.feature_extraction
 import sklearn.neighbors
 
-from . import cache
+from ._cache import cache
 from . import util
 from .util.exceptions import ParameterError
 

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -9,7 +9,7 @@ import six
 import numpy as np
 from numpy.lib.stride_tricks import as_strided
 
-from .. import cache
+from .._cache import cache
 from .exceptions import ParameterError
 
 # Constrain STFT block sizes to 256 KB

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -11,6 +11,7 @@ import shutil
 import numpy as np
 
 import pytest
+import librosa._cache
 
 
 # Disable any initial cache settings
@@ -24,9 +25,8 @@ for key in ['DIR', 'MMAP', 'COMPRESS', 'VERBOSE', 'LEVEL']:
 @pytest.fixture
 def local_cache():
     cache_dir = tempfile.mkdtemp()
-    os.environ['LIBROSA_CACHE_DIR'] = cache_dir
-    yield
-    os.environ.pop('LIBROSA_CACHE_DIR')
+    cache = librosa._cache.CacheManager(cache_dir, verbose=0, level=10)
+    yield cache
     shutil.rmtree(cache_dir)
 
 
@@ -37,26 +37,21 @@ def func(x):
 
 def test_cache_disabled():
 
-    os.environ.pop('LIBROSA_CACHE_DIR', None)
-    sys.modules.pop('librosa.cache', None)
-    import librosa.cache
-
-    func_cache = librosa.cache(level=-10)(func)
-
     # When there's no cache directory in the environment,
     # librosa.cache is a no-op.
+    cache = librosa._cache.CacheManager(None, verbose=0, level=10)
+    func_cache = cache(level=-10)(func)
+
     assert func == func_cache
 
 
 def test_cache_enabled(local_cache):
 
-    sys.modules.pop('librosa.cache', None)
-    import librosa.cache
-    librosa.cache.clear()
+    local_cache.clear()
 
-    func_cache = librosa.cache(level=-10)(func)
+    func_cache = local_cache(level=-10)(func)
 
-    # The cache should be active now
+    # The cache should be active now, so func_cache should be a different object from func
     assert func_cache != func
 
     # issue three calls to func


### PR DESCRIPTION
#### Reference Issue
Fixes #795 


#### What does this implement/fix? Explain your changes.

This PR restructures the cache class (and submodule) in two ways:

- The `cache` module has been moved to `_cache`, and the singleton object no longer overrides the module in the system namespace.
- The `cache` class no longer extends from `joblib.Memory`, which should save us from future API compatibility issues like #729 

#### Any other comments?

This should have no apparent effects to 99% of users.  The only users who may experience problems are those who depend on `librosa.cache` being an instance of `joblib.Memory`; in those cases, the memory object can be accessed directly by `librosa.cache.memory`.

I've tested locally, and all the timing examples from the documentation still work as expected.  As long as CI passes, I see no need for CR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/829)
<!-- Reviewable:end -->
