### PR TITLE
fixed #827 by limiting width to at most the length of the data in rec…

### DIFF
--- a/librosa/segment.py
+++ b/librosa/segment.py
@@ -72,6 +72,8 @@ def recurrence_matrix(data, k=None, width=1, metric='euclidean',
         only link neighbors `(data[:, i], data[:, j])`
         if `|i - j| >= width`
 
+        `width` cannot exceed the length of the data.
+
     metric : str
         Distance metric to use for nearest-neighbor calculation.
 
@@ -171,8 +173,8 @@ def recurrence_matrix(data, k=None, width=1, metric='euclidean',
     t = data.shape[0]
     data = data.reshape((t, -1))
 
-    if width < 1:
-        raise ParameterError('width must be at least 1')
+    if width < 1 or width > t:
+        raise ParameterError('width={} must be at least 1 and at most data.shape[{}]={}'.format(width, axis, t))
 
     if mode not in ['connectivity', 'distance', 'affinity']:
         raise ParameterError(("Invalid mode='{}'. Must be one of "

--- a/tests/test_segment.py
+++ b/tests/test_segment.py
@@ -58,10 +58,10 @@ def test_recurrence_matrix():
     for n in [20, 250]:
         for k in [None, n//4]:
             for sym in [False, True]:
-                for width in [-1, 0, 1, 3, 5]:
+                for width in [-1, 0, 1, 3, 5, 5000]:
                     for metric in ['l2', 'cosine']:
                         tester = __test
-                        if width < 1:
+                        if width < 1 or width > n:
                             tester = pytest.mark.xfail(__test, raises=librosa.ParameterError)
 
                         yield tester, n, k, width, sym, metric


### PR DESCRIPTION
#### Reference Issue
#827 


#### What does this implement/fix? Explain your changes.

This PR adds an upper bound check on the `width` parameter of `segment.recurrence_matrix`.

Left unchecked, a `width > data.shape[axis]` results in an opaque error when we call `setdiag` on the sparse neighbor graph.  There's no reason to allow width to exceed the duration anyway (this will always produce an all-zeros matrix).

#### Any other comments?

There's functionally no change here, but the exception that gets raised in this scenario is more user-friendly and should be easier to debug with.  Assuming it passes CI, I see no need for CR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/833)
<!-- Reviewable:end -->
