### PR TITLE
Expose stft parameters in all spectral features

### DIFF
--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -199,7 +199,7 @@ def piptrack(y=None, sr=22050, S=None, n_fft=2048, hop_length=None,
     fmax : float > 0 [scalar]
         upper frequency cutoff.
 
-    win_length  : int <= n_fft [scalar]
+    win_length : int <= n_fft [scalar]
         Each frame of audio is windowed by `window()`.
         The window will be of length `win_length` and then padded
         with zeros to match `n_fft`.
@@ -214,7 +214,7 @@ def piptrack(y=None, sr=22050, S=None, n_fft=2048, hop_length=None,
 
         .. see also:: `filters.get_window`
 
-    center      : boolean
+    center : boolean
         - If `True`, the signal `y` is padded so that frame
           `t` is centered at `y[t * hop_length]`.
         - If `False`, then frame `t` begins at `y[t * hop_length]`

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -53,7 +53,7 @@ def stft(y, n_fft=2048, hop_length=None, win_length=None, window='hann',
         number audio of frames between STFT columns.
         If unspecified, defaults `win_length / 4`.
 
-    win_length  : int <= n_fft [scalar]
+    win_length : int <= n_fft [scalar]
         Each frame of audio is windowed by `window()`.
         The window will be of length `win_length` and then padded
         with zeros to match `n_fft`.
@@ -68,12 +68,12 @@ def stft(y, n_fft=2048, hop_length=None, win_length=None, window='hann',
 
         .. see also:: `filters.get_window`
 
-    center      : boolean
+    center : boolean
         - If `True`, the signal `y` is padded so that frame
           `D[:, t]` is centered at `y[t * hop_length]`.
         - If `False`, then `D[:, t]` begins at `y[t * hop_length]`
 
-    dtype       : numeric type
+    dtype : numeric type
         Complex numeric type for `D`.  Default is 64-bit complex.
 
     pad_mode : string
@@ -212,18 +212,18 @@ def istft(stft_matrix, hop_length=None, win_length=None, window='hann',
     stft_matrix : np.ndarray [shape=(1 + n_fft/2, t)]
         STFT matrix from `stft`
 
-    hop_length  : int > 0 [scalar]
+    hop_length : int > 0 [scalar]
         Number of frames between STFT columns.
         If unspecified, defaults to `win_length / 4`.
 
-    win_length  : int <= n_fft = 2 * (stft_matrix.shape[0] - 1)
+    win_length : int <= n_fft = 2 * (stft_matrix.shape[0] - 1)
         When reconstructing the time series, each frame is windowed
         and each sample is normalized by the sum of squared window
         according to the `window` function (see below).
 
         If unspecified, defaults to `n_fft`.
 
-    window      : string, tuple, number, function, np.ndarray [shape=(n_fft,)]
+    window : string, tuple, number, function, np.ndarray [shape=(n_fft,)]
         - a window specification (string, tuple, or number);
           see `scipy.signal.get_window`
         - a window function, such as `scipy.signal.hanning`
@@ -231,11 +231,11 @@ def istft(stft_matrix, hop_length=None, win_length=None, window='hann',
 
         .. see also:: `filters.get_window`
 
-    center      : boolean
+    center : boolean
         - If `True`, `D` is assumed to have centered frames.
         - If `False`, `D` is assumed to have left-aligned frames.
 
-    dtype       : numeric type
+    dtype : numeric type
         Real numeric type for `y`.  Default is 32-bit float.
 
     length : int > 0, optional
@@ -403,7 +403,7 @@ def ifgram(y, sr=22050, n_fft=2048, hop_length=None, win_length=None,
     norm : bool
         Normalize the STFT.
 
-    center      : boolean
+    center : boolean
         - If `True`, the signal `y` is padded so that frame
             `D[:, t]` (and `if_gram`) is centered at `y[t * hop_length]`.
         - If `False`, then `D[:, t]` at `y[t * hop_length]`
@@ -514,7 +514,7 @@ def magphase(D, power=1):
 
     Parameters
     ----------
-    D       : np.ndarray [shape=(d, t), dtype=complex]
+    D : np.ndarray [shape=(d, t), dtype=complex]
         complex-valued spectrogram
     power : float > 0
         Exponent for the magnitude spectrogram,
@@ -523,7 +523,7 @@ def magphase(D, power=1):
 
     Returns
     -------
-    D_mag   : np.ndarray [shape=(d, t), dtype=real]
+    D_mag : np.ndarray [shape=(d, t), dtype=real]
         magnitude of `D`, raised to `power`
     D_phase : np.ndarray [shape=(d, t), dtype=complex]
         `exp(1.j * phi)` where `phi` is the phase of `D`
@@ -608,7 +608,7 @@ def phase_vocoder(D, rate, hop_length=None):
 
     Returns
     -------
-    D_stretched  : np.ndarray [shape=(d, t / rate), dtype=complex]
+    D_stretched : np.ndarray [shape=(d, t / rate), dtype=complex]
         time-stretched STFT
     """
 
@@ -839,7 +839,7 @@ def power_to_db(S, ref=1.0, amin=1e-10, top_db=80.0):
 
     Returns
     -------
-    S_db   : np.ndarray
+    S_db : np.ndarray
         ``S_db ~= 10 * log10(S) - 10 * log10(ref)``
 
     See Also
@@ -1559,7 +1559,7 @@ def _spectrogram(y=None, S=None, n_fft=2048, hop_length=512, power=1,
         Exponent for the magnitude spectrogram,
         e.g., 1 for energy, 2 for power, etc.
 
-    win_length  : int <= n_fft [scalar]
+    win_length : int <= n_fft [scalar]
         Each frame of audio is windowed by `window()`.
         The window will be of length `win_length` and then padded
         with zeros to match `n_fft`.
@@ -1574,7 +1574,7 @@ def _spectrogram(y=None, S=None, n_fft=2048, hop_length=512, power=1,
 
         .. see also:: `filters.get_window`
 
-    center      : boolean
+    center : boolean
         - If `True`, the signal `y` is padded so that frame
           `t` is centered at `y[t * hop_length]`.
         - If `False`, then frame `t` begins at `y[t * hop_length]`

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -38,8 +38,8 @@ __all__ = ['spectral_centroid',
 
 # -- Spectral features -- #
 def spectral_centroid(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
-                      freq=None,
-                      win_length=None, window='hann', center=True, pad_mode='reflect'):
+                      freq=None, win_length=None, window='hann', center=True,
+                      pad_mode='reflect'):
     '''Compute the spectral centroid.
 
     Each frame of a magnitude spectrogram is normalized and treated as a
@@ -70,7 +70,7 @@ def spectral_centroid(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
         or a matrix of center frequencies as constructed by
         `librosa.core.ifgram`
 
-    win_length  : int <= n_fft [scalar]
+    win_length : int <= n_fft [scalar]
         Each frame of audio is windowed by `window()`.
         The window will be of length `win_length` and then padded
         with zeros to match `n_fft`.
@@ -85,7 +85,7 @@ def spectral_centroid(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
 
         .. see also:: `filters.get_window`
 
-    center      : boolean
+    center : boolean
         - If `True`, the signal `y` is padded so that frame
           `t` is centered at `y[t * hop_length]`.
         - If `False`, then frame `t` begins at `y[t * hop_length]`
@@ -194,7 +194,7 @@ def spectral_bandwidth(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
     hop_length : int > 0 [scalar]
         hop length for STFT. See `librosa.core.stft` for details.
 
-    win_length  : int <= n_fft [scalar]
+    win_length : int <= n_fft [scalar]
         Each frame of audio is windowed by `window()`.
         The window will be of length `win_length` and then padded
         with zeros to match `n_fft`.
@@ -209,7 +209,7 @@ def spectral_bandwidth(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
 
         .. see also:: `filters.get_window`
 
-    center      : boolean
+    center : boolean
         - If `True`, the signal `y` is padded so that frame
           `t` is centered at `y[t * hop_length]`.
         - If `False`, then frame `t` begins at `y[t * hop_length]`
@@ -343,7 +343,7 @@ def spectral_contrast(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
     hop_length : int > 0 [scalar]
         hop length for STFT. See `librosa.core.stft` for details.
 
-    win_length  : int <= n_fft [scalar]
+    win_length : int <= n_fft [scalar]
         Each frame of audio is windowed by `window()`.
         The window will be of length `win_length` and then padded
         with zeros to match `n_fft`.
@@ -358,7 +358,7 @@ def spectral_contrast(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
 
         .. see also:: `filters.get_window`
 
-    center      : boolean
+    center : boolean
         - If `True`, the signal `y` is padded so that frame
           `t` is centered at `y[t * hop_length]`.
         - If `False`, then frame `t` begins at `y[t * hop_length]`
@@ -511,7 +511,7 @@ def spectral_rolloff(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
     hop_length : int > 0 [scalar]
         hop length for STFT. See `librosa.core.stft` for details.
 
-    win_length  : int <= n_fft [scalar]
+    win_length : int <= n_fft [scalar]
         Each frame of audio is windowed by `window()`.
         The window will be of length `win_length` and then padded
         with zeros to match `n_fft`.
@@ -526,7 +526,7 @@ def spectral_rolloff(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
 
         .. see also:: `filters.get_window`
 
-    center      : boolean
+    center : boolean
         - If `True`, the signal `y` is padded so that frame
           `t` is centered at `y[t * hop_length]`.
         - If `False`, then frame `t` begins at `y[t * hop_length]`
@@ -654,7 +654,7 @@ def spectral_flatness(y=None, S=None, n_fft=2048, hop_length=512,
     hop_length : int > 0 [scalar]
         hop length for STFT. See `librosa.core.stft` for details.
 
-    win_length  : int <= n_fft [scalar]
+    win_length : int <= n_fft [scalar]
         Each frame of audio is windowed by `window()`.
         The window will be of length `win_length` and then padded
         with zeros to match `n_fft`.
@@ -669,7 +669,7 @@ def spectral_flatness(y=None, S=None, n_fft=2048, hop_length=512,
 
         .. see also:: `filters.get_window`
 
-    center      : boolean
+    center : boolean
         - If `True`, the signal `y` is padded so that frame
           `t` is centered at `y[t * hop_length]`.
         - If `False`, then frame `t` begins at `y[t * hop_length]`
@@ -723,9 +723,8 @@ def spectral_flatness(y=None, S=None, n_fft=2048, hop_length=512,
         raise ParameterError('amin must be strictly positive')
 
     S, n_fft = _spectrogram(y=y, S=S, n_fft=n_fft, hop_length=hop_length,
-                            power=1.,
-                            win_length=win_length, window=window, center=center,
-                            pad_mode=pad_mode)
+                            power=1., win_length=win_length, window=window,
+                            center=center, pad_mode=pad_mode)
 
     if not np.isrealobj(S):
         raise ParameterError('Spectral flatness is only defined '
@@ -857,7 +856,7 @@ def poly_features(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
     hop_length : int > 0 [scalar]
         hop length for STFT. See `librosa.core.stft` for details.
 
-    win_length  : int <= n_fft [scalar]
+    win_length : int <= n_fft [scalar]
         Each frame of audio is windowed by `window()`.
         The window will be of length `win_length` and then padded
         with zeros to match `n_fft`.
@@ -872,7 +871,7 @@ def poly_features(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
 
         .. see also:: `filters.get_window`
 
-    center      : boolean
+    center : boolean
         - If `True`, the signal `y` is padded so that frame
           `t` is centered at `y[t * hop_length]`.
         - If `False`, then frame `t` begins at `y[t * hop_length]`
@@ -1060,7 +1059,7 @@ def chroma_stft(y=None, sr=22050, S=None, norm=np.inf, n_fft=2048,
     hop_length : int > 0 [scalar]
         hop length if provided `y, sr` instead of `S`
 
-    win_length  : int <= n_fft [scalar]
+    win_length : int <= n_fft [scalar]
         Each frame of audio is windowed by `window()`.
         The window will be of length `win_length` and then padded
         with zeros to match `n_fft`.
@@ -1075,7 +1074,7 @@ def chroma_stft(y=None, sr=22050, S=None, norm=np.inf, n_fft=2048,
 
         .. see also:: `filters.get_window`
 
-    center      : boolean
+    center : boolean
         - If `True`, the signal `y` is padded so that frame
           `t` is centered at `y[t * hop_length]`.
         - If `False`, then frame `t` begins at `y[t * hop_length]`
@@ -1095,7 +1094,7 @@ def chroma_stft(y=None, sr=22050, S=None, norm=np.inf, n_fft=2048,
 
     Returns
     -------
-    chromagram  : np.ndarray [shape=(n_chroma, t)]
+    chromagram : np.ndarray [shape=(n_chroma, t)]
         Normalized energy for each chroma bin at each frame.
 
     See Also
@@ -1540,13 +1539,13 @@ def mfcc(y=None, sr=22050, S=None, n_mfcc=20, dct_type=2, norm='ortho', **kwargs
 
     Parameters
     ----------
-    y     : np.ndarray [shape=(n,)] or None
+    y : np.ndarray [shape=(n,)] or None
         audio time series
 
-    sr    : number > 0 [scalar]
+    sr : number > 0 [scalar]
         sampling rate of `y`
 
-    S     : np.ndarray [shape=(d, t)] or None
+    S : np.ndarray [shape=(d, t)] or None
         log-power Mel spectrogram
 
     n_mfcc: int > 0 [scalar]
@@ -1568,7 +1567,7 @@ def mfcc(y=None, sr=22050, S=None, n_mfcc=20, dct_type=2, norm='ortho', **kwargs
 
     Returns
     -------
-    M     : np.ndarray [shape=(n_mfcc, t)]
+    M : np.ndarray [shape=(n_mfcc, t)]
         MFCC sequence
 
     See Also
@@ -1664,7 +1663,7 @@ def melspectrogram(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
         number of samples between successive frames.
         See `librosa.core.stft`
 
-    win_length  : int <= n_fft [scalar]
+    win_length : int <= n_fft [scalar]
         Each frame of audio is windowed by `window()`.
         The window will be of length `win_length` and then padded
         with zeros to match `n_fft`.
@@ -1679,7 +1678,7 @@ def melspectrogram(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
 
         .. see also:: `filters.get_window`
 
-    center      : boolean
+    center : boolean
         - If `True`, the signal `y` is padded so that frame
           `t` is centered at `y[t * hop_length]`.
         - If `False`, then frame `t` begins at `y[t * hop_length]`

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -38,7 +38,8 @@ __all__ = ['spectral_centroid',
 
 # -- Spectral features -- #
 def spectral_centroid(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
-                      freq=None):
+                      freq=None,
+                      win_length=None, window='hann', center=True, pad_mode='reflect'):
     '''Compute the spectral centroid.
 
     Each frame of a magnitude spectrogram is normalized and treated as a
@@ -68,6 +69,31 @@ def spectral_centroid(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
         Otherwise, it can be a single array of `d` center frequencies,
         or a matrix of center frequencies as constructed by
         `librosa.core.ifgram`
+
+    win_length  : int <= n_fft [scalar]
+        Each frame of audio is windowed by `window()`.
+        The window will be of length `win_length` and then padded
+        with zeros to match `n_fft`.
+
+        If unspecified, defaults to ``win_length = n_fft``.
+
+    window : string, tuple, number, function, or np.ndarray [shape=(n_fft,)]
+        - a window specification (string, tuple, or number);
+          see `scipy.signal.get_window`
+        - a window function, such as `scipy.signal.hanning`
+        - a vector or array of length `n_fft`
+
+        .. see also:: `filters.get_window`
+
+    center      : boolean
+        - If `True`, the signal `y` is padded so that frame
+          `t` is centered at `y[t * hop_length]`.
+        - If `False`, then frame `t` begins at `y[t * hop_length]`
+
+    pad_mode : string
+        If `center=True`, the padding mode to use at the edges of the signal.
+        By default, STFT uses reflection padding.
+
 
     Returns
     -------
@@ -121,7 +147,9 @@ def spectral_centroid(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
     >>> plt.tight_layout()
     '''
 
-    S, n_fft = _spectrogram(y=y, S=S, n_fft=n_fft, hop_length=hop_length)
+    S, n_fft = _spectrogram(y=y, S=S, n_fft=n_fft, hop_length=hop_length,
+                            win_length=win_length, window=window, center=center,
+                            pad_mode=pad_mode)
 
     if not np.isrealobj(S):
         raise ParameterError('Spectral centroid is only defined '
@@ -143,6 +171,7 @@ def spectral_centroid(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
 
 
 def spectral_bandwidth(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
+                       win_length=None, window='hann', center=True, pad_mode='reflect',
                        freq=None, centroid=None, norm=True, p=2):
     '''Compute p'th-order spectral bandwidth:
 
@@ -164,6 +193,30 @@ def spectral_bandwidth(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
 
     hop_length : int > 0 [scalar]
         hop length for STFT. See `librosa.core.stft` for details.
+
+    win_length  : int <= n_fft [scalar]
+        Each frame of audio is windowed by `window()`.
+        The window will be of length `win_length` and then padded
+        with zeros to match `n_fft`.
+
+        If unspecified, defaults to ``win_length = n_fft``.
+
+    window : string, tuple, number, function, or np.ndarray [shape=(n_fft,)]
+        - a window specification (string, tuple, or number);
+          see `scipy.signal.get_window`
+        - a window function, such as `scipy.signal.hanning`
+        - a vector or array of length `n_fft`
+
+        .. see also:: `filters.get_window`
+
+    center      : boolean
+        - If `True`, the signal `y` is padded so that frame
+          `t` is centered at `y[t * hop_length]`.
+        - If `False`, then frame `t` begins at `y[t * hop_length]`
+
+    pad_mode : string
+        If `center=True`, the padding mode to use at the edges of the signal.
+        By default, STFT uses reflection padding.
 
     freq : None or np.ndarray [shape=(d,) or shape=(d, t)]
         Center frequencies for spectrogram bins.
@@ -227,7 +280,9 @@ def spectral_bandwidth(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
 
     '''
 
-    S, n_fft = _spectrogram(y=y, S=S, n_fft=n_fft, hop_length=hop_length)
+    S, n_fft = _spectrogram(y=y, S=S, n_fft=n_fft, hop_length=hop_length,
+                            win_length=win_length, window=window, center=center,
+                            pad_mode=pad_mode)
 
     if not np.isrealobj(S):
         raise ParameterError('Spectral bandwidth is only defined '
@@ -259,6 +314,7 @@ def spectral_bandwidth(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
 
 
 def spectral_contrast(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
+                      win_length=None, window='hann', center=True, pad_mode='reflect',
                       freq=None, fmin=200.0, n_bands=6, quantile=0.02,
                       linear=False):
     '''Compute spectral contrast [1]_
@@ -286,6 +342,30 @@ def spectral_contrast(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
 
     hop_length : int > 0 [scalar]
         hop length for STFT. See `librosa.core.stft` for details.
+
+    win_length  : int <= n_fft [scalar]
+        Each frame of audio is windowed by `window()`.
+        The window will be of length `win_length` and then padded
+        with zeros to match `n_fft`.
+
+        If unspecified, defaults to ``win_length = n_fft``.
+
+    window : string, tuple, number, function, or np.ndarray [shape=(n_fft,)]
+        - a window specification (string, tuple, or number);
+          see `scipy.signal.get_window`
+        - a window function, such as `scipy.signal.hanning`
+        - a vector or array of length `n_fft`
+
+        .. see also:: `filters.get_window`
+
+    center      : boolean
+        - If `True`, the signal `y` is padded so that frame
+          `t` is centered at `y[t * hop_length]`.
+        - If `False`, then frame `t` begins at `y[t * hop_length]`
+
+    pad_mode : string
+        If `center=True`, the padding mode to use at the edges of the signal.
+        By default, STFT uses reflection padding.
 
     freq : None or np.ndarray [shape=(d,)]
         Center frequencies for spectrogram bins.
@@ -339,7 +419,9 @@ def spectral_contrast(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
     >>> plt.tight_layout()
     '''
 
-    S, n_fft = _spectrogram(y=y, S=S, n_fft=n_fft, hop_length=hop_length)
+    S, n_fft = _spectrogram(y=y, S=S, n_fft=n_fft, hop_length=hop_length,
+                            win_length=win_length, window=window, center=center,
+                            pad_mode=pad_mode)
 
     # Compute the center frequencies of each bin
     if freq is None:
@@ -402,6 +484,7 @@ def spectral_contrast(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
 
 
 def spectral_rolloff(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
+                     win_length=None, window='hann', center=True, pad_mode='reflect',
                      freq=None, roll_percent=0.85):
     '''Compute roll-off frequency.
 
@@ -427,6 +510,30 @@ def spectral_rolloff(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
 
     hop_length : int > 0 [scalar]
         hop length for STFT. See `librosa.core.stft` for details.
+
+    win_length  : int <= n_fft [scalar]
+        Each frame of audio is windowed by `window()`.
+        The window will be of length `win_length` and then padded
+        with zeros to match `n_fft`.
+
+        If unspecified, defaults to ``win_length = n_fft``.
+
+    window : string, tuple, number, function, or np.ndarray [shape=(n_fft,)]
+        - a window specification (string, tuple, or number);
+          see `scipy.signal.get_window`
+        - a window function, such as `scipy.signal.hanning`
+        - a vector or array of length `n_fft`
+
+        .. see also:: `filters.get_window`
+
+    center      : boolean
+        - If `True`, the signal `y` is padded so that frame
+          `t` is centered at `y[t * hop_length]`.
+        - If `False`, then frame `t` begins at `y[t * hop_length]`
+
+    pad_mode : string
+        If `center=True`, the padding mode to use at the edges of the signal.
+        By default, STFT uses reflection padding.
 
     freq : None or np.ndarray [shape=(d,) or shape=(d, t)]
         Center frequencies for spectrogram bins.
@@ -490,7 +597,9 @@ def spectral_rolloff(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
     if not 0.0 < roll_percent < 1.0:
         raise ParameterError('roll_percent must lie in the range (0, 1)')
 
-    S, n_fft = _spectrogram(y=y, S=S, n_fft=n_fft, hop_length=hop_length)
+    S, n_fft = _spectrogram(y=y, S=S, n_fft=n_fft, hop_length=hop_length,
+                            win_length=win_length, window=window, center=center,
+                            pad_mode=pad_mode)
 
     if not np.isrealobj(S):
         raise ParameterError('Spectral rolloff is only defined '
@@ -517,6 +626,7 @@ def spectral_rolloff(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
 
 
 def spectral_flatness(y=None, S=None, n_fft=2048, hop_length=512,
+                      win_length=None, window='hann', center=True, pad_mode='reflect',
                       amin=1e-10, power=2.0):
     '''Compute spectral flatness
 
@@ -543,6 +653,30 @@ def spectral_flatness(y=None, S=None, n_fft=2048, hop_length=512,
 
     hop_length : int > 0 [scalar]
         hop length for STFT. See `librosa.core.stft` for details.
+
+    win_length  : int <= n_fft [scalar]
+        Each frame of audio is windowed by `window()`.
+        The window will be of length `win_length` and then padded
+        with zeros to match `n_fft`.
+
+        If unspecified, defaults to ``win_length = n_fft``.
+
+    window : string, tuple, number, function, or np.ndarray [shape=(n_fft,)]
+        - a window specification (string, tuple, or number);
+          see `scipy.signal.get_window`
+        - a window function, such as `scipy.signal.hanning`
+        - a vector or array of length `n_fft`
+
+        .. see also:: `filters.get_window`
+
+    center      : boolean
+        - If `True`, the signal `y` is padded so that frame
+          `t` is centered at `y[t * hop_length]`.
+        - If `False`, then frame `t` begins at `y[t * hop_length]`
+
+    pad_mode : string
+        If `center=True`, the padding mode to use at the edges of the signal.
+        By default, STFT uses reflection padding.
 
     amin : float > 0 [scalar]
         minimum threshold for `S` (=added noise floor for numerical stability)
@@ -589,7 +723,9 @@ def spectral_flatness(y=None, S=None, n_fft=2048, hop_length=512,
         raise ParameterError('amin must be strictly positive')
 
     S, n_fft = _spectrogram(y=y, S=S, n_fft=n_fft, hop_length=hop_length,
-                            power=1.)
+                            power=1.,
+                            win_length=win_length, window=window, center=center,
+                            pad_mode=pad_mode)
 
     if not np.isrealobj(S):
         raise ParameterError('Spectral flatness is only defined '
@@ -699,6 +835,7 @@ rmse = moved('librosa.feature.rmse', '0.6.3', '0.7.0')(rms)
 
 
 def poly_features(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
+                  win_length=None, window='hann', center=True, pad_mode='reflect',
                   order=1, freq=None):
     '''Get coefficients of fitting an nth-order polynomial to the columns
     of a spectrogram.
@@ -719,6 +856,30 @@ def poly_features(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
 
     hop_length : int > 0 [scalar]
         hop length for STFT. See `librosa.core.stft` for details.
+
+    win_length  : int <= n_fft [scalar]
+        Each frame of audio is windowed by `window()`.
+        The window will be of length `win_length` and then padded
+        with zeros to match `n_fft`.
+
+        If unspecified, defaults to ``win_length = n_fft``.
+
+    window : string, tuple, number, function, or np.ndarray [shape=(n_fft,)]
+        - a window specification (string, tuple, or number);
+          see `scipy.signal.get_window`
+        - a window function, such as `scipy.signal.hanning`
+        - a vector or array of length `n_fft`
+
+        .. see also:: `filters.get_window`
+
+    center      : boolean
+        - If `True`, the signal `y` is padded so that frame
+          `t` is centered at `y[t * hop_length]`.
+        - If `False`, then frame `t` begins at `y[t * hop_length]`
+
+    pad_mode : string
+        If `center=True`, the padding mode to use at the edges of the signal.
+        By default, STFT uses reflection padding.
 
     order : int > 0
         order of the polynomial to fit
@@ -784,7 +945,9 @@ def poly_features(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
     >>> plt.tight_layout()
     '''
 
-    S, n_fft = _spectrogram(y=y, S=S, n_fft=n_fft, hop_length=hop_length)
+    S, n_fft = _spectrogram(y=y, S=S, n_fft=n_fft, hop_length=hop_length,
+                            win_length=win_length, window=window, center=center,
+                            pad_mode=pad_mode)
 
     # Compute the center frequencies of each bin
     if freq is None:
@@ -864,7 +1027,8 @@ def zero_crossing_rate(y, frame_length=2048, hop_length=512, center=True,
 
 # -- Chroma --#
 def chroma_stft(y=None, sr=22050, S=None, norm=np.inf, n_fft=2048,
-                hop_length=512, tuning=None, **kwargs):
+                hop_length=512, win_length=None, window='hann', center=True,
+                pad_mode='reflect', tuning=None, **kwargs):
     """Compute a chromagram from a waveform or power spectrogram.
 
     This implementation is derived from `chromagram_E` [1]_
@@ -895,6 +1059,31 @@ def chroma_stft(y=None, sr=22050, S=None, norm=np.inf, n_fft=2048,
 
     hop_length : int > 0 [scalar]
         hop length if provided `y, sr` instead of `S`
+
+    win_length  : int <= n_fft [scalar]
+        Each frame of audio is windowed by `window()`.
+        The window will be of length `win_length` and then padded
+        with zeros to match `n_fft`.
+
+        If unspecified, defaults to ``win_length = n_fft``.
+
+    window : string, tuple, number, function, or np.ndarray [shape=(n_fft,)]
+        - a window specification (string, tuple, or number);
+          see `scipy.signal.get_window`
+        - a window function, such as `scipy.signal.hanning`
+        - a vector or array of length `n_fft`
+
+        .. see also:: `filters.get_window`
+
+    center      : boolean
+        - If `True`, the signal `y` is padded so that frame
+          `t` is centered at `y[t * hop_length]`.
+        - If `False`, then frame `t` begins at `y[t * hop_length]`
+
+    pad_mode : string
+        If `center=True`, the padding mode to use at the edges of the signal.
+        By default, STFT uses reflection padding.
+
 
     tuning : float in `[-0.5, 0.5)` [scalar] or None.
         Deviation from A440 tuning in fractional bins (cents).
@@ -957,8 +1146,9 @@ def chroma_stft(y=None, sr=22050, S=None, norm=np.inf, n_fft=2048,
 
     """
 
-    S, n_fft = _spectrogram(y=y, S=S, n_fft=n_fft, hop_length=hop_length,
-                            power=2)
+    S, n_fft = _spectrogram(y=y, S=S, n_fft=n_fft, hop_length=hop_length, power=2,
+                            win_length=win_length, window=window, center=center,
+                            pad_mode=pad_mode)
 
     n_chroma = kwargs.get('n_chroma', 12)
 
@@ -1445,6 +1635,7 @@ def mfcc(y=None, sr=22050, S=None, n_mfcc=20, dct_type=2, norm='ortho', **kwargs
 
 
 def melspectrogram(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
+                   win_length=None, window='hann', center=True, pad_mode='reflect',
                    power=2.0, **kwargs):
     """Compute a mel-scaled spectrogram.
 
@@ -1472,6 +1663,30 @@ def melspectrogram(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
     hop_length : int > 0 [scalar]
         number of samples between successive frames.
         See `librosa.core.stft`
+
+    win_length  : int <= n_fft [scalar]
+        Each frame of audio is windowed by `window()`.
+        The window will be of length `win_length` and then padded
+        with zeros to match `n_fft`.
+
+        If unspecified, defaults to ``win_length = n_fft``.
+
+    window : string, tuple, number, function, or np.ndarray [shape=(n_fft,)]
+        - a window specification (string, tuple, or number);
+          see `scipy.signal.get_window`
+        - a window function, such as `scipy.signal.hanning`
+        - a vector or array of length `n_fft`
+
+        .. see also:: `filters.get_window`
+
+    center      : boolean
+        - If `True`, the signal `y` is padded so that frame
+          `t` is centered at `y[t * hop_length]`.
+        - If `False`, then frame `t` begins at `y[t * hop_length]`
+
+    pad_mode : string
+        If `center=True`, the padding mode to use at the edges of the signal.
+        By default, STFT uses reflection padding.
 
     power : float > 0 [scalar]
         Exponent for the magnitude melspectrogram.
@@ -1523,12 +1738,11 @@ def melspectrogram(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
     >>> plt.colorbar(format='%+2.0f dB')
     >>> plt.title('Mel spectrogram')
     >>> plt.tight_layout()
-
-
     """
 
-    S, n_fft = _spectrogram(y=y, S=S, n_fft=n_fft, hop_length=hop_length,
-                            power=power)
+    S, n_fft = _spectrogram(y=y, S=S, n_fft=n_fft, hop_length=hop_length, power=power,
+                            win_length=win_length, window=window, center=center,
+                            pad_mode=pad_mode)
 
     # Build a Mel filter
     mel_basis = filters.mel(sr, n_fft, **kwargs)


### PR DESCRIPTION
#### Reference Issue
Fixes #767 ; facilitates #804 


#### What does this implement/fix? Explain your changes.

This PR extends the `_spectrogram` helper function to expose almost all stft parameters, as described in comments of #767.

All functions which use the helper now expose these new parameters: `win_length`, `window`, `center`, and `pad_mode`.

#### Any other comments?

The odd one out here is `rms`: there's no situation in which the additional parameters would be used, since time-domain input does not generate a spectrogram, and spectral-domain input would not be recomputed.

I did not extend the unit tests here, but I did lint everything to make sure all parameters are being passed through properly.  I think this one should be good to go.

As a side-effect, it will make documentation like #804 a bit simpler, since reproducing alternate configurations (eg HTK) no longer requires separate intermediate steps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/834)
<!-- Reviewable:end -->
