### PR TITLE
added 3.7 to travis tests and setup supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ python:
     - 2.7
     - 3.5
     - 3.6
+    - 3.7
 
 before_install:
     - bash .travis_dependencies.sh
@@ -28,8 +29,6 @@ install:
 
 script:
     - python --version
-    # - nosetests --with-coverage --cover-erase --cover-package=librosa -v -w tests/
-    # - nosetests --with-coverage --cover-erase --cover-package=librosa -w tests/
     - pytest 
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 
+dist: xenial
+
 cache:
   directories:
   - $HOME/env

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
     keywords='audio music sound',
     license='ISC',


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This PR adds python 3.7 to the travis build matrix.  We had this a while back, but removed it because of problems in the conda dependency chain.  These should be resolved now, so i'm adding it back in.

The supported python versions field in setup.py has also been extended.

There are no changes to the code.  I'll merge without CR once this passes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/836)
<!-- Reviewable:end -->
