### PR TITLE
removed realpath from load, fixes #768

### DIFF
--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -116,7 +116,7 @@ def load(path, sr=22050, mono=True, offset=0.0, duration=None,
     """
 
     y = []
-    with audioread.audio_open(os.path.realpath(path)) as input_file:
+    with audioread.audio_open(path) as input_file:
         sr_native = input_file.samplerate
         n_channels = input_file.channels
 


### PR DESCRIPTION
#### Reference Issue
Fixes #768 by removing call to realpath in load.


#### What does this implement/fix? Explain your changes.

This PR addresses a minor quirk in the load function where file paths were implicitly and unnecessarily converted to realpaths.  This isn't necessary, and could break things down the line.  However, it doesn't address the core concern of #768, which is out of scope for librosa.

This PR is more of a future-proofing than anything else; if audioread eventually supports virtual file paths or bytes arrays, then it will automatically work here as well.

This ought to pass CI, and I see no need for CR here otherwise.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/841)
<!-- Reviewable:end -->
