### PR TITLE
[CR needed] Path enhancement

### DIFF
--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -1256,7 +1256,7 @@ def diagonal_filter(window, n, slope=1.0, angle=None, zero_mean=False):
     window : string, tuple, number, callable, or list-like
         The window function to use for the filter.
 
-        See get_window for details.
+        See `get_window` for details.
 
         Note that the window used here should be non-negative.
 
@@ -1267,9 +1267,9 @@ def diagonal_filter(window, n, slope=1.0, angle=None, zero_mean=False):
         The slope of the diagonal filter to produce
 
     angle : float or None
-        If given, the slope parameter is ignored, 
+        If given, the slope parameter is ignored,
         and angle directly sets the orientation of the filter (in radians).
-        Otherwise, angle is inferred as arctan(slope).
+        Otherwise, angle is inferred as `arctan(slope)`.
 
     zero_mean : bool
         If True, a zero-mean filter is used.

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -23,7 +23,6 @@ Window functions
     window_bandwidth
     get_window
 
-
 Miscellaneous
 -------------
 .. autosummary::
@@ -33,6 +32,7 @@ Miscellaneous
     cq_to_chroma
     mr_frequencies
     window_sumsquare
+    diagonal_filter
 
 Deprecated
 ----------
@@ -46,6 +46,7 @@ import warnings
 import numpy as np
 import scipy
 import scipy.signal
+import scipy.ndimage
 import six
 
 from numba import jit
@@ -68,7 +69,8 @@ __all__ = ['dct',
            'get_window',
            'mr_frequencies',
            'semitone_filterbank',
-           'window_sumsquare']
+           'window_sumsquare',
+           'diagonal_filter']
 
 
 # Dictionary of window function bandwidths
@@ -1241,3 +1243,65 @@ def window_sumsquare(window, n_frames, hop_length=512, win_length=None, n_fft=20
     __window_ss_fill(x, win_sq, n_frames, hop_length)
 
     return x
+
+
+@cache(level=10)
+def diagonal_filter(window, n, slope=1.0, angle=None, zero_mean=False):
+    '''Build a two-dimensional diagonal filter.
+
+    This is primarily used for smoothing recurrence or self-similarity matrices.
+
+    Parameters
+    ----------
+    window : string, tuple, number, callable, or list-like
+        The window function to use for the filter.
+
+        See get_window for details.
+
+    n : int > 0
+        the length of the filter
+
+    slope : float
+        The slope of the diagonal filter to produce
+
+    angle : float or None
+        If given, the slope parameter is ignored, 
+        and angle directly sets the orientation of the filter (in radians).
+        Otherwise, angle is inferred as arctan(slope).
+
+    zero_mean : bool
+        If True, a zero-mean filter is used.
+        Otherwise, a non-negative averaging filter is used.
+
+        This should be enabled if you want to enhance paths and suppress
+        blocks.
+
+
+    Returns
+    -------
+    kernel : np.ndarray, shape=[(m, m)]
+        The 2-dimensional filter kernel
+
+
+    Notes
+    -----
+    This function caches at level 10.
+
+    '''
+
+    if angle is None:
+        angle = np.arctan(slope)
+
+    win = np.diag(get_window(n, window, fftbins=False))
+
+    if not np.isclose(angle, np.pi/4):
+        win = scipy.ndimage.rotate(win, 45 - angle * 180 / np.pi,
+                                   order=5, prefilter=False)
+
+    np.clip(win, 0, None, out=win)
+    win /= win.sum()
+
+    if zero_mean:
+        win -= win.mean()
+
+    return win

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -1258,6 +1258,8 @@ def diagonal_filter(window, n, slope=1.0, angle=None, zero_mean=False):
 
         See get_window for details.
 
+        Note that the window used here should be non-negative.
+
     n : int > 0
         the length of the filter
 
@@ -1286,13 +1288,12 @@ def diagonal_filter(window, n, slope=1.0, angle=None, zero_mean=False):
     Notes
     -----
     This function caches at level 10.
-
     '''
 
     if angle is None:
         angle = np.arctan(slope)
 
-    win = np.diag(get_window(n, window, fftbins=False))
+    win = np.diag(get_window(window, n, fftbins=False))
 
     if not np.isclose(angle, np.pi/4):
         win = scipy.ndimage.rotate(win, 45 - angle * 180 / np.pi,

--- a/librosa/segment.py
+++ b/librosa/segment.py
@@ -238,10 +238,6 @@ def recurrence_matrix(data, k=None, width=1, metric='euclidean',
         # Everything past the kth closest gets squashed
         rec[i, idx[k:]] = 0
 
-    # symmetrize
-    if sym:
-        rec = rec.minimum(rec.T)
-
     if self:
         if mode == 'connectivity':
             rec.setdiag(1)
@@ -252,6 +248,12 @@ def recurrence_matrix(data, k=None, width=1, metric='euclidean',
             # using negative distances here preserves the structure without changing
             # the statistics of the data
             rec.setdiag(-1)
+
+    # symmetrize
+    if sym:
+        # Note: this operation produces a CSR matrix!
+        # This is why we have to do it after filling the diagonal in self-mode
+        rec = rec.minimum(rec.T)
 
     rec = rec.tocsr()
     rec.eliminate_zeros()

--- a/librosa/segment.py
+++ b/librosa/segment.py
@@ -56,9 +56,21 @@ def recurrence_matrix(data, k=None, width=1, metric='euclidean',
                       bandwidth=None, self=False, axis=-1):
     '''Compute a recurrence matrix from a data matrix.
 
-
     `rec[i, j]` is non-zero if (`data[:, i]`, `data[:, j]`) are
     k-nearest-neighbors and `|i - j| >= width`
+
+    The specific value of `rec[i, j]` can have several forms, governed
+    by the `mode` parameter below:
+
+        - Connectivity: `rec[i, j] = 1 or 0` indicates that frames `i` and `j` are repetitions
+
+        - Affinity: `rec[i, j] > 0` measures how similar frames `i` and `j` are.  This is also
+          known as a (sparse) self-similarity matrix.
+
+        - Distance: `rec[, j] > 0` measures how distant frames `i` and `j` are.  This is also
+          known as a (sparse) self-distance matrix.
+
+    The general term *recurrence matrix* can refer to any of the three forms above.
 
 
     Parameters

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -425,10 +425,16 @@ def test_semitone_filterbank():
 @pytest.mark.parametrize('zero_mean', [False, True])
 def test_diagonal_filter(n, window, angle, slope, zero_mean):
 
-    kernel = librosa.filters.diagonal_filter(n, window,
+    kernel = librosa.filters.diagonal_filter(window, n,
                                              slope=slope,
                                              angle=angle,
                                              zero_mean=zero_mean)
+
+    # In the no-rotation case, check that the filter is shaped correctly
+    if angle == np.pi / 4 and not zero_mean:
+        win_unnorm = librosa.filters.get_window(window, n, fftbins=False)
+        win_unnorm /= win_unnorm.sum()
+        assert np.allclose(np.diag(kernel), win_unnorm)
 
     # First check: zero-mean
     if zero_mean:
@@ -440,14 +446,14 @@ def test_diagonal_filter(n, window, angle, slope, zero_mean):
     if angle is None:
         # If we're using the slope API, then the transposed kernel
         # will have slope 1/slope
-        k2 = librosa.filters.diagonal_filter(n, window,
+        k2 = librosa.filters.diagonal_filter(window, n,
                                              slope=1./slope,
                                              angle=angle,
                                              zero_mean=zero_mean)
     else:
         # If we're using the angle API, then the transposed kernel
         # will have angle pi/2 - angle
-        k2 = librosa.filters.diagonal_filter(n, window,
+        k2 = librosa.filters.diagonal_filter(window, n,
                                              slope=slope,
                                              angle=np.pi/2 - angle,
                                              zero_mean=zero_mean)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -416,3 +416,40 @@ def test_semitone_filterbank():
 
             assert np.allclose(cur_a_gt, cur_a_mut_sos)
             assert np.allclose(cur_b_gt, cur_b_mut_sos, atol=1e-4)
+
+
+@pytest.mark.parametrize('n', [9, 17])
+@pytest.mark.parametrize('window', ['hann', 'rect'])
+@pytest.mark.parametrize('angle', [None, np.pi/4, np.pi/6])
+@pytest.mark.parametrize('slope', [1, 2, 0.5])
+@pytest.mark.parametrize('zero_mean', [False, True])
+def test_diagonal_filter(n, window, angle, slope, zero_mean):
+
+    kernel = librosa.filters.diagonal_filter(n, window,
+                                             slope=slope,
+                                             angle=angle,
+                                             zero_mean=zero_mean)
+
+    # First check: zero-mean
+    if zero_mean:
+        assert np.isclose(kernel.sum(), 0)
+    else:
+        assert np.isclose(kernel.sum(), 1) and np.all(kernel >= 0)
+
+    # Now check if the angle transposes correctly
+    if angle is None:
+        # If we're using the slope API, then the transposed kernel
+        # will have slope 1/slope
+        k2 = librosa.filters.diagonal_filter(n, window,
+                                             slope=1./slope,
+                                             angle=angle,
+                                             zero_mean=zero_mean)
+    else:
+        # If we're using the angle API, then the transposed kernel
+        # will have angle pi/2 - angle
+        k2 = librosa.filters.diagonal_filter(n, window,
+                                             slope=slope,
+                                             angle=np.pi/2 - angle,
+                                             zero_mean=zero_mean)
+
+    assert np.allclose(k2, kernel.T)

--- a/tests/test_segment.py
+++ b/tests/test_segment.py
@@ -313,3 +313,39 @@ def test_subsegment():
         else:
             tf = __test
         yield tf, n_segments
+
+
+
+
+@pytest.fixture
+def R_input():
+    X = np.random.randn(30, 5)
+
+    return X.dot(X.T)
+
+
+@pytest.mark.parametrize('window', ['rect', 'hann'])
+@pytest.mark.parametrize('n', [5, 9])
+@pytest.mark.parametrize('max_ratio', [1.0, 1.5, 2.0])
+@pytest.mark.parametrize('min_ratio', [None, 1.0,
+                                       pytest.mark.xfail(3.0, raises=librosa.ParameterError)])
+@pytest.mark.parametrize('n_filters', [1, 2, 5])
+@pytest.mark.parametrize('zero_mean', [False, True])
+@pytest.mark.parametrize('clip', [False, True])
+@pytest.mark.parametrize('kwargs', [dict(), dict(mode='reflect')])
+def test_path_enhance(R_input, window, n, max_ratio, min_ratio,
+                      n_filters, zero_mean, clip, kwargs):
+
+    R_smooth = librosa.segment.path_enhance(R_input, window=window,
+                                            n=n, max_ratio=max_ratio,
+                                            min_ratio=min_ratio,
+                                            n_filters=n_filters,
+                                            zero_mean=zero_mean,
+                                            clip=clip, **kwargs)
+
+    assert R_smooth.shape == R_input.shape
+    assert np.all(np.isfinite(R_smooth))
+    assert R_smooth.dtype == R_input.dtype
+
+    if clip:
+        assert np.min(R_smooth) >= 0

--- a/tests/test_segment.py
+++ b/tests/test_segment.py
@@ -24,13 +24,13 @@ __EXAMPLE_FILE = os.path.join('tests', 'data', 'test1_22050.wav')
 
 def test_recurrence_matrix():
 
-    def __test(n, k, width, sym, metric):
+    def __test(n, k, width, sym, metric, self):
         srand()
         # Make a data matrix
         data = np.random.randn(3, n)
 
         D = librosa.segment.recurrence_matrix(data, k=k, width=width, sym=sym,
-                                              axis=-1, metric=metric)
+                                              axis=-1, metric=metric, self=self)
 
         # First test for symmetry
         if sym:
@@ -39,13 +39,18 @@ def test_recurrence_matrix():
         # Test for target-axis invariance
         D_trans = librosa.segment.recurrence_matrix(data.T, k=k, width=width,
                                                     sym=sym, axis=0,
-                                                    metric=metric)
+                                                    metric=metric, self=self)
         assert np.allclose(D, D_trans)
 
         # If not symmetric, test for correct number of links
         if not sym and k is not None:
             real_k = min(k, n - width)
+            if self:
+                real_k += 1
             assert not np.any(D.sum(axis=1) != real_k)
+
+        if self:
+            assert np.allclose(np.diag(D), True)
 
         # Make sure the +- width diagonal is hollow
         # It's easier to test if zeroing out the triangles leaves nothing
@@ -55,52 +60,68 @@ def test_recurrence_matrix():
         D.T[idx] = False
         assert not np.any(D)
 
+
     for n in [20, 250]:
         for k in [None, n//4]:
             for sym in [False, True]:
                 for width in [-1, 0, 1, 3, 5, 5000]:
                     for metric in ['l2', 'cosine']:
-                        tester = __test
-                        if width < 1 or width > n:
-                            tester = pytest.mark.xfail(__test, raises=librosa.ParameterError)
+                        for self in [False, True]:
+                            tester = __test
+                            if width < 1 or width > n:
+                                tester = pytest.mark.xfail(__test, raises=librosa.ParameterError)
 
-                        yield tester, n, k, width, sym, metric
+                        yield tester, n, k, width, sym, metric, self
 
 
-def test_recurrence_sparse():
+@pytest.mark.parametrize('self', [False, True])
+def test_recurrence_sparse(self):
 
     srand()
     data = np.random.randn(3, 100)
-    D_sparse = librosa.segment.recurrence_matrix(data, sparse=True)
-    D_dense = librosa.segment.recurrence_matrix(data, sparse=False)
+    D_sparse = librosa.segment.recurrence_matrix(data, sparse=True, self=self)
+    D_dense = librosa.segment.recurrence_matrix(data, sparse=False, self=self)
 
     assert scipy.sparse.isspmatrix(D_sparse)
     assert np.allclose(D_sparse.todense(), D_dense)
 
+    if self:
+        assert np.allclose(D_sparse.diagonal(), True)
+    else:
+        assert np.allclose(D_sparse.diagonal(), False)
 
-def test_recurrence_distance():
+
+@pytest.mark.parametrize('self', [False, True])
+def test_recurrence_distance(self):
 
     srand()
     data = np.random.randn(3, 100)
     distance = squareform(pdist(data.T, metric='sqeuclidean'))
     rec = librosa.segment.recurrence_matrix(data, mode='distance',
                                             metric='sqeuclidean',
-                                            sparse=True)
+                                            sparse=True, self=self)
 
     i, j, vals = scipy.sparse.find(rec)
     assert np.allclose(vals, distance[i, j])
+    assert np.allclose(rec.diagonal(), 0.0)
 
 
 def test_recurrence_affinity():
 
-    def __test(metric, bandwidth):
+    def __test(metric, bandwidth, self):
         srand()
         data = np.random.randn(3, 100)
         distance = squareform(pdist(data.T, metric=metric))
         rec = librosa.segment.recurrence_matrix(data, mode='affinity',
                                                 metric=metric,
                                                 sparse=True,
-                                                bandwidth=bandwidth)
+                                                bandwidth=bandwidth,
+                                                self=self)
+
+        if self:
+            assert np.allclose(rec.diagonal(), 1.0)
+        else:
+            assert np.allclose(rec.diagonal(), 0.0)
 
         i, j, vals = scipy.sparse.find(rec)
         logvals = np.log(vals)
@@ -108,13 +129,15 @@ def test_recurrence_affinity():
         # After log-scaling, affinity will match distance up to a constant factor
         ratio = -logvals / distance[i, j]
         if bandwidth is None:
-            assert np.allclose(ratio, ratio[0])
+            # Estimate the global bandwidth using non-zero distances
+            assert np.allclose(-logvals, distance[i, j] * np.nanmax(ratio))
         else:
-            assert np.allclose(ratio, bandwidth)
+            assert np.allclose(-logvals, distance[i, j] * bandwidth)
 
     for metric in ['sqeuclidean', 'cityblock']:
         for bandwidth in [None, 1]:
-            yield __test, metric, bandwidth
+            for self in [False, True]:
+                yield __test, metric, bandwidth, self
 
 
 @pytest.mark.xfail(raises=librosa.ParameterError)

--- a/tests/test_segment.py
+++ b/tests/test_segment.py
@@ -338,8 +338,6 @@ def test_subsegment():
         yield tf, n_segments
 
 
-
-
 @pytest.fixture
 def R_input():
     X = np.random.randn(30, 5)


### PR DESCRIPTION
#### Reference Issue
This PR implements #741 for multi-angle path enhancement, and #840 for extending the `recurrence_matrix` function to support self-loops.


#### What does this implement/fix? Explain your changes.

As discussed in #741, the implementation of multi-angle path enhancement here is a bit different from that of the SM toolbox (and Mueller and Kurth'06).  Rather than resampling the feature sequence at different tempo ratios, the similarity matrix is smoothed directly by convolving with two-dimensional filters at a variety of orientations corresponding to different tempo ratios.  The net effect is similar, but the benefit of this approach is that the similarity matrix calculation is entirely decoupled from the smoothing process.

Also somewhat different from SM toolbox is that the kernel can either be an averaging filter or a zero-mean filter.  The latter is useful for suppressing blocks while enhancing paths, but is disabled by default.  In concert with zero-mean filtering, a clipping parameter is introduced to threshold the output and prevent negative similarities.


TODO:
- [x] add self-loop support to recurrence_matrix
- [x] Clean up docstring formatting

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/842)
<!-- Reviewable:end -->
