### PR TITLE
Feature inversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.py[co]
+__pycache__
 
 __pycache__
 

--- a/librosa/core/__init__.py
+++ b/librosa/core/__init__.py
@@ -35,6 +35,8 @@ Spectral representations
     iirt
     fmt
 
+    griffinlim
+
     interp_harmonics
     salience
 

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1567,7 +1567,11 @@ def griffinlim(S, n_iter=32, hop_length=None, win_length=None, window='hann',
     '''Approximate magnitude spectrogram inversion using the Griffin-Lim algorithm [1]_.
 
     Given a short-time Fourier transform magnitude matrix (`S`), the algorithm randomly
-    initializes phase estimates, and then alternates forward- and inverse-stft operations
+    initializes phase estimates, and then alternates forward- and inverse-STFT
+    operations.
+    Note that this assumes reconstruction of a real-valued time-domain signal, and
+    that `S` contains only the non-negative frequencies (as computed by
+    `core.stft`).
 
     .. [1] D. W. Griffin and J. S. Lim,
         "Signal estimation from modified short-time Fourier transform,"
@@ -1576,7 +1580,7 @@ def griffinlim(S, n_iter=32, hop_length=None, win_length=None, window='hann',
     Parameters
     ----------
     S : np.ndarray [shape=(n_fft / 2 + 1, t), non-negative]
-        An array of short-time fourier transform magnitudes
+        An array of short-time Fourier transform magnitudes
 
     n_iter : int > 0
         The number of iterations to run
@@ -1634,17 +1638,17 @@ def griffinlim(S, n_iter=32, hop_length=None, win_length=None, window='hann',
 
     >>> import matplotlib.pyplot as plt
     >>> plt.figure()
-    >>> ax =plt.subplot(3,1,1)
+    >>> ax = plt.subplot(3,1,1)
     >>> librosa.display.waveplot(y, sr=sr, color='b')
     >>> plt.title('Original')
     >>> plt.xlabel('')
     >>> plt.subplot(3,1,2, sharex=ax, sharey=ax)
     >>> librosa.display.waveplot(y_inv, sr=sr, color='g')
-    >>> plt.title('Griffin-Lim')
+    >>> plt.title('Griffin-Lim reconstruction')
     >>> plt.xlabel('')
     >>> plt.subplot(3,1,3, sharex=ax, sharey=ax)
     >>> librosa.display.waveplot(y_istft, sr=sr, color='r')
-    >>> plt.title('Magnitude-only istft')
+    >>> plt.title('Magnitude-only istft reconstruction')
     >>> plt.tight_layout()
     '''
 

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1563,7 +1563,7 @@ def pcen(S, sr=22050, hop_length=512, gain=0.98, bias=2, power=0.5,
 
 
 def griffinlim(S, n_iter=32, hop_length=None, win_length=None, window='hann',
-               center=True, dtype=np.float32, length=None):
+               center=True, dtype=np.float32, length=None, pad_mode='reflect'):
     '''Approximate magnitude spectrogram inversion using the Griffin-Lim algorithm [1]_.
 
     Given a short-time Fourier transform magnitude matrix (`S`), the algorithm randomly
@@ -1600,6 +1600,10 @@ def griffinlim(S, n_iter=32, hop_length=None, win_length=None, window='hann',
     length : None or int > 0
         If provided, the output `y` is zero-padded or clipped to exactly `length`
         samples.
+
+    pad_mode : string
+        If `center=True`, the padding mode to use at the edges of the signal.
+        By default, STFT uses reflection padding.
 
 
     Returns
@@ -1657,7 +1661,8 @@ def griffinlim(S, n_iter=32, hop_length=None, win_length=None, window='hann',
 
         # Rebuild the spectrogram
         rebuilt = stft(inverse, n_fft=n_fft, hop_length=hop_length,
-                       win_length=win_length, window=window, center=center)
+                       win_length=win_length, window=window, center=center,
+                       pad_mode=pad_mode)
 
         # Update our phase estimates
         angles[:] = np.exp(1j * np.angle(rebuilt))

--- a/librosa/feature/__init__.py
+++ b/librosa/feature/__init__.py
@@ -49,6 +49,9 @@ Feature inversion
     :toctree: generated
 
     inverse.mel_to_stft
+    inverse.mel_to_audio
+    inverse.mfcc_to_mel
+    inverse.mfcc_to_audio
 """
 from .utils import *  # pylint: disable=wildcard-import
 from .spectral import *  # pylint: disable=wildcard-import

--- a/librosa/feature/__init__.py
+++ b/librosa/feature/__init__.py
@@ -40,9 +40,19 @@ Feature manipulation
 
     delta
     stack_memory
+
+
+Feature inversion
+-----------------
+
+.. autosummary::
+    :toctree: generated
+
+    inverse.mel_to_stft
 """
 from .utils import *  # pylint: disable=wildcard-import
 from .spectral import *  # pylint: disable=wildcard-import
 from .rhythm import *  # pylint: disable=wildcard-import
+from . import inverse
 
 __all__ = [_ for _ in dir() if not _.startswith('_')]

--- a/librosa/feature/inverse.py
+++ b/librosa/feature/inverse.py
@@ -79,8 +79,10 @@ def mel_to_stft(M, sr=22050, n_fft=2048, power=2.0, **kwargs):
     >>> plt.tight_layout()
     '''
 
-
-    mel_basis = filters.mel(sr, n_fft, n_mels=M.shape[0], **kwargs)
+    # Construct a mel basis with dtype matching the input data
+    mel_basis = filters.mel(sr, n_fft, n_mels=M.shape[0],
+                            dtype=M.dtype,
+                            **kwargs)
 
     # Find the non-negative least squares solution, and apply
     # the inverse exponent

--- a/librosa/feature/inverse.py
+++ b/librosa/feature/inverse.py
@@ -82,8 +82,10 @@ def mel_to_stft(M, sr=22050, n_fft=2048, power=2.0, **kwargs):
                             **kwargs)
 
     # Find the non-negative least squares solution, and apply
-    # the inverse exponent
-    return nnls(mel_basis, M)**(1./power)
+    # the inverse exponent.
+    # We'll do the exponentiation in-place.
+    inverse = nnls(mel_basis, M)
+    return np.power(inverse, 1./power, out=inverse)
 
 
 def mel_to_audio(M, sr=22050, n_fft=2048, hop_length=512, win_length=None,
@@ -185,7 +187,7 @@ def mfcc_to_mel(mfcc, n_mels=128, dct_type=2, norm='ortho', ref=1.0):
         By default, DCT type-2 is used.
 
     norm : None or 'ortho'
-        If `dct_Type` is `2 or 3`, setting `norm='ortho'` uses an ortho-normal
+        If `dct_type` is `2 or 3`, setting `norm='ortho'` uses an orthonormal
         DCT basis.
 
         Normalization is not supported for `dct_type=1`.
@@ -234,7 +236,7 @@ def mfcc_to_audio(mfcc, n_mels=128, dct_type=2, norm='ortho', ref=1.0, **kwargs)
         By default, DCT type-2 is used.
 
     norm : None or 'ortho'
-        If `dct_Type` is `2 or 3`, setting `norm='ortho'` uses an ortho-normal
+        If `dct_type` is `2 or 3`, setting `norm='ortho'` uses an orthonormal
         DCT basis.
 
         Normalization is not supported for `dct_type=1`.

--- a/librosa/feature/inverse.py
+++ b/librosa/feature/inverse.py
@@ -8,6 +8,7 @@ import scipy.fftpack
 from ..core.spectrum import griffinlim
 from ..core.spectrum import db_to_power
 from .. import filters
+from ..util import nnls
 
 
 __all__ = ['mel_to_stft', 'mel_to_audio',
@@ -81,9 +82,9 @@ def mel_to_stft(M, sr=22050, n_fft=2048, power=2.0, **kwargs):
 
     mel_basis = filters.mel(sr, n_fft, n_mels=M.shape[0], **kwargs)
 
-    # FIXME: this would be much better as a non-negative least squares problem
-    # however, scipy.optimize.nnls is not vectorized!
-    return np.clip(np.linalg.lstsq(mel_basis, M, rcond=None)[0], 0, None)**(1./power)
+    # Find the non-negative least squares solution, and apply
+    # the inverse exponent
+    return nnls(mel_basis, M)**(1./power)
 
 
 def mel_to_audio(M, sr=22050, n_fft=2048, hop_length=512, win_length=None,

--- a/librosa/feature/inverse.py
+++ b/librosa/feature/inverse.py
@@ -68,7 +68,8 @@ def mel_to_stft(M, sr=22050, n_fft=2048, power=2.0, **kwargs):
     >>> plt.colorbar()
     >>> plt.title('Original STFT')
     >>> plt.subplot(2,1,2)
-    >>> librosa.display.specshow(librosa.amplitude_to_db(np.abs(S_inv - S), top_db=None),
+    >>> librosa.display.specshow(librosa.amplitude_to_db(np.abs(S_inv - S),
+    ...                                                  ref=S.max(), top_db=None),
     ...                          vmax=0, y_axis='log', x_axis='time', cmap='magma')
     >>> plt.title('Residual error (dB)')
     >>> plt.colorbar()

--- a/librosa/feature/inverse.py
+++ b/librosa/feature/inverse.py
@@ -261,6 +261,6 @@ def mfcc_to_audio(mfcc, n_mels=128, dct_type=2, norm='ortho', ref=1.0, **kwargs)
     core.griffinlim
     scipy.fftpack.dct
     '''
-    M = mfcc_to_mel(mfcc, n_mels=n_mels, dct_type=dct_type, norm=norm, ref=ref)
+    mel_spec = mfcc_to_mel(mfcc, n_mels=n_mels, dct_type=dct_type, norm=norm, ref=ref)
 
-    return mel_to_audio(M, **kwargs)
+    return mel_to_audio(mel_spec, **kwargs)

--- a/librosa/feature/inverse.py
+++ b/librosa/feature/inverse.py
@@ -18,10 +18,6 @@ __all__ = ['mel_to_stft', 'mel_to_audio',
 def mel_to_stft(M, sr=22050, n_fft=2048, power=2.0, **kwargs):
     '''Approximate STFT magnitude from a Mel power spectrogram.
 
-    The magnitudes are recovered by minimizing an unconstrained least-squares
-    objective, and thresholding the solution to produce valid magnitudes.
-
-
     Parameters
     ----------
     M : np.ndarray [shape=(n_mels, n), non-negative]
@@ -52,6 +48,7 @@ def mel_to_stft(M, sr=22050, n_fft=2048, power=2.0, **kwargs):
     feature.melspectrogram
     core.stft
     filters.mel
+    util.nnls
 
 
     Examples
@@ -72,8 +69,7 @@ def mel_to_stft(M, sr=22050, n_fft=2048, power=2.0, **kwargs):
     >>> plt.title('Original STFT')
     >>> plt.subplot(2,1,2)
     >>> librosa.display.specshow(librosa.amplitude_to_db(np.abs(S_inv - S), top_db=None),
-    ...                          cmap='plasma', vmin=-120, vmax=120,
-    ...                          y_axis='log', x_axis='time')
+    ...                          vmax=0, y_axis='log', x_axis='time', cmap='magma')
     >>> plt.title('Residual error (dB)')
     >>> plt.colorbar()
     >>> plt.tight_layout()

--- a/librosa/feature/inverse.py
+++ b/librosa/feature/inverse.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+'''Feature inversion'''
+
+import numpy as np
+import scipy.fftpack
+
+from ..core.spectrum import griffinlim
+from ..core.spectrum import db_to_power
+from .. import filters
+
+
+__all__ = ['mel_to_stft', 'mel_to_audio',
+           'mfcc_to_mel', 'mfcc_to_audio']
+
+
+def mel_to_stft(M, sr=22050, n_fft=2048, power=2.0, **kwargs):
+    '''Approximate STFT magnitude from a Mel power spectrogram.
+
+    The magnitudes are recovered by minimizing an unconstrained least-squares
+    objective, and thresholding the solution to produce valid magnitudes.
+
+
+    Parameters
+    ----------
+    M : np.ndarray [shape=(n_mels, n), non-negative]
+        The spectrogram as produced by `feature.melspectrogram`
+
+    sr : number > 0 [scalar]
+        sampling rate of the underlying signal
+
+    n_fft : int > 0 [scalar]
+        number of FFT components in the resulting STFT
+
+    power : float > 0 [scalar]
+        Exponent for the magnitude melspectrogram
+
+    kwargs : additional keyword arguments
+        Mel filter bank parameters.
+        See `librosa.filters.mel` for details
+
+
+    Returns
+    -------
+    S : np.ndarray [shape=(n_fft, t), non-negative]
+        An approximate linear magnitude spectrogram
+
+
+    See Also
+    --------
+    feature.melspectrogram
+    core.stft
+    filters.mel
+
+
+    Examples
+    --------
+    >>> y, sr = librosa.load(librosa.util.example_audio_file(), duration=5, offset=10)
+    >>> S = np.abs(librosa.stft(y))
+    >>> mel_spec = librosa.feature.melspectrogram(S=S, sr=sr)
+    >>> S_inv = librosa.feature.inverse.mel_to_stft(mel_spec, sr=sr)
+
+    Compare the results visually
+
+    >>> import matplotlib.pyplot as plt
+    >>> plt.figure()
+    >>> plt.subplot(2,1,1)
+    >>> librosa.display.specshow(librosa.amplitude_to_db(S, ref=np.max, top_db=None),
+    ...                          y_axis='log', x_axis='time')
+    >>> plt.colorbar()
+    >>> plt.title('Original STFT')
+    >>> plt.subplot(2,1,2)
+    >>> librosa.display.specshow(librosa.amplitude_to_db(np.abs(S_inv - S), top_db=None),
+    ...                          cmap='plasma', vmin=-120, vmax=120,
+    ...                          y_axis='log', x_axis='time')
+    >>> plt.title('Residual error (dB)')
+    >>> plt.colorbar()
+    >>> plt.tight_layout()
+    '''
+
+
+    mel_basis = filters.mel(sr, n_fft, n_mels=M.shape[0], **kwargs)
+
+    # FIXME: this would be much better as a non-negative least squares problem
+    # however, scipy.optimize.nnls is not vectorized!
+    return np.clip(np.linalg.lstsq(mel_basis, M, rcond=None)[0], 0, None)**(1./power)
+
+
+def mel_to_audio(M, sr=22050, n_fft=2048, hop_length=512, win_length=None,
+                 window='hann', center=True, pad_mode='reflect', power=2.0, n_iter=32,
+                 length=None, dtype=np.float32, **kwargs):
+    """Invert a mel power spectrogram to audio using Griffin-Lim.
+
+    This is primarily a convenience wrapper for:
+
+        >>> S = librosa.feature.inverse.mel_to_stft(M)
+        >>> y = librosa.griffinlim(S)
+
+    Parameters
+    ----------
+    M : np.ndarray [shape=(n_mels, n), non-negative]
+        The spectrogram as produced by `feature.melspectrogram`
+
+    sr : number > 0 [scalar]
+        sampling rate of the underlying signal
+
+    n_fft : int > 0 [scalar]
+        number of FFT components in the resulting STFT
+
+    hop_length : None or int > 0
+        The hop length of the STFT.  If not provided, it will default to `n_fft // 4`
+
+    win_length : None or int > 0
+        The window length of the STFT.  By default, it will equal `n_fft`
+
+    window : string, tuple, number, function, or np.ndarray [shape=(n_fft,)]
+        A window specification as supported by `stft` or `istft`
+
+    center : boolean
+        If `True`, the STFT is assumed to use centered frames.
+        If `False`, the STFT is assumed to use left-aligned frames.
+
+    pad_mode : string
+        If `center=True`, the padding mode to use at the edges of the signal.
+        By default, STFT uses reflection padding.
+
+    power : float > 0 [scalar]
+        Exponent for the magnitude melspectrogram
+
+    n_iter : int > 0
+        The number of iterations for Griffin-Lim
+
+    length : None or int > 0
+        If provided, the output `y` is zero-padded or clipped to exactly `length`
+        samples.
+
+    dtype : np.dtype
+        Real numeric type for the time-domain signal.  Default is 32-bit float.
+
+    kwargs : additional keyword arguments
+        Mel filter bank parameters
+
+
+    Returns
+    -------
+    y : np.ndarray [shape(n,)]
+        time-domain signal reconstructed from `M`
+
+    See Also
+    --------
+    core.griffinlim
+    feature.melspectrogram
+    filters.mel
+    feature.inverse.mel_to_stft
+    """
+
+    stft = mel_to_stft(M, sr=sr, n_fft=n_fft, power=power, **kwargs)
+
+    return griffinlim(stft, n_iter=n_iter, hop_length=hop_length, win_length=win_length,
+                      window=window, center=center, dtype=dtype, length=length,
+                      pad_mode=pad_mode)
+
+
+def mfcc_to_mel(mfcc, n_mels=128, dct_type=2, norm='ortho', ref=1.0):
+    '''Invert Mel-frequency cepstral coefficients to approximate a Mel power
+    spectrogram.
+
+    This inversion proceeds in two steps:
+
+    1. The inverse DCT is applied to the MFCCs
+    2. `core.db_to_power` is applied to map the dB-scaled result to a power
+    spectrogram
+
+
+    Parameters
+    ----------
+    mfcc : np.ndarray [shape=(n_mfcc, n)]
+        The Mel-frequency cepstral coefficients
+
+    n_mels : int > 0
+        The number of Mel frequencies
+
+    dct_type : None or {1, 2, 3}
+        Discrete cosine transform (DCT) type
+        By default, DCT type-2 is used.
+
+    norm : None or 'ortho'
+        If `dct_Type` is `2 or 3`, setting `norm='ortho'` uses an ortho-normal
+        DCT basis.
+
+        Normalization is not supported for `dct_type=1`.
+
+    ref : number or callable
+        Reference power for (inverse) decibel calculation
+
+
+    Returns
+    -------
+    M : np.ndarray [shape=(n_mels, n)]
+        An approximate Mel power spectrum recovered from `mfcc`
+
+
+    See Also
+    --------
+    mfcc
+    melspectrogram
+    scipy.fftpack.dct
+    '''
+
+    logmel = scipy.fftpack.idct(mfcc, axis=0, type=dct_type, norm=norm, n=n_mels)
+
+    return db_to_power(logmel, ref=ref)
+
+
+def mfcc_to_audio(mfcc, n_mels=128, dct_type=2, norm='ortho', ref=1.0, **kwargs):
+    '''Convert Mel-frequency cepstral coefficients to a time-domain audio signal
+
+    This function is primarily a convenience wrapper for the following steps:
+
+        1. Convert mfcc to Mel power spectrum (`mfcc_to_mel`)
+        2. Convert Mel power spectrum to time-domain audio (`mel_to_audio`)
+
+
+    Parameters
+    ----------
+    mfcc : np.ndarray [shape=(n_mfcc, n)]
+        The Mel-frequency cepstral coefficients
+
+    n_mels : int > 0
+        The number of Mel frequencies
+
+    dct_type : None or {1, 2, 3}
+        Discrete cosine transform (DCT) type
+        By default, DCT type-2 is used.
+
+    norm : None or 'ortho'
+        If `dct_Type` is `2 or 3`, setting `norm='ortho'` uses an ortho-normal
+        DCT basis.
+
+        Normalization is not supported for `dct_type=1`.
+
+    ref : number or callable
+        Reference power for (inverse) decibel calculation
+
+    kwargs : additional keyword arguments
+        Parameters to pass through to `mel_to_audio`
+
+    Returns
+    -------
+    y : np.ndarray [shape=(n)]
+        A time-domain signal reconstructed from `mfcc`
+
+    See Also
+    --------
+    mfcc_to_mel
+    mel_to_audio
+    feature.mfcc
+    core.griffinlim
+    scipy.fftpack.dct
+    '''
+    M = mfcc_to_mel(mfcc, n_mels=n_mels, dct_type=dct_type, norm=norm, ref=ref)
+
+    return mel_to_audio(M, **kwargs)

--- a/librosa/util/__init__.py
+++ b/librosa/util/__init__.py
@@ -40,6 +40,7 @@ Miscellaneous
 
     localmax
     peak_pick
+    nnls
 
 
 Input validation
@@ -67,6 +68,7 @@ from .utils import *  # pylint: disable=wildcard-import
 from .files import *  # pylint: disable=wildcard-import
 from .matching import *  # pylint: disable=wildcard-import
 from .deprecation import *  # pylint: disable=wildcard-import
+from ._nnls import *  # pylint: disable=wildcard-import
 from . import decorators
 from . import exceptions
 

--- a/librosa/util/_nnls.py
+++ b/librosa/util/_nnls.py
@@ -54,8 +54,8 @@ __all__ = ['nnls']
 
 
 @jit(nopython=True)
-def _nnls(A, B, rho, eps_abs=1e-6, eps_rel=1e-4, max_iter=100):
-    '''Compute a non-negative least-squares solution to 
+def _nnls(A, B, rho, eps_abs=1e-6, eps_rel=1e-4, max_iter=250):
+    '''Compute a non-negative least-squares solution to
     min_{X>=0} \|AX - B\|_F^2
     '''
     # X* = Z + r^-1 * (I - A'(r I - AA')^-1 A) (A'B - A'A Z)
@@ -144,7 +144,7 @@ def _nnls(A, B, rho, eps_abs=1e-6, eps_rel=1e-4, max_iter=100):
     return Y
 
 
-def nnls(A, B, eps_abs=1e-6, eps_rel=1e-4, max_iter=100):
+def nnls(A, B, eps_abs=1e-6, eps_rel=1e-4, max_iter=250):
     '''Non-negative least squares.
 
     Given two matrices A and B, find a non-negative matrix X

--- a/librosa/util/_nnls.py
+++ b/librosa/util/_nnls.py
@@ -53,7 +53,7 @@ from numba import jit
 __all__ = ['nnls']
 
 
-@jit(nopython=True, parallel=True, cache=True)
+@jit(nopython=True, cache=True)
 def _nnls(A, B, rho, eps_abs=1e-6, eps_rel=1e-4, max_iter=500):
     '''Compute a non-negative least-squares solution to
     min_{X>=0} \|AX - B\|_F^2

--- a/librosa/util/_nnls.py
+++ b/librosa/util/_nnls.py
@@ -150,7 +150,7 @@ def nnls(A, B, **kwargs):
 
     # Process in blocks:
     if B.shape[-1] <= n_columns:
-        return _nnls_lbfgs_block(A, B, **kwargs)
+        return _nnls_lbfgs_block(A, B, **kwargs).astype(A.dtype)
 
     x = np.linalg.lstsq(A, B, rcond=None)[0].astype(A.dtype)
     np.clip(x, 0, None, out=x)

--- a/librosa/util/_nnls.py
+++ b/librosa/util/_nnls.py
@@ -54,7 +54,7 @@ __all__ = ['nnls']
 
 
 @jit(nopython=True)
-def _nnls(A, B, rho, eps_abs=1e-6, eps_rel=1e-4, max_iter=250):
+def _nnls(A, B, rho, eps_abs=1e-6, eps_rel=1e-4, max_iter=500):
     '''Compute a non-negative least-squares solution to
     min_{X>=0} \|AX - B\|_F^2
     '''
@@ -144,7 +144,7 @@ def _nnls(A, B, rho, eps_abs=1e-6, eps_rel=1e-4, max_iter=250):
     return Y
 
 
-def nnls(A, B, eps_abs=1e-6, eps_rel=1e-4, max_iter=250):
+def nnls(A, B, eps_abs=1e-6, eps_rel=1e-4, max_iter=500):
     '''Non-negative least squares.
 
     Given two matrices A and B, find a non-negative matrix X

--- a/librosa/util/_nnls.py
+++ b/librosa/util/_nnls.py
@@ -53,7 +53,7 @@ from numba import jit
 __all__ = ['nnls']
 
 
-@jit(nopython=True)
+@jit(nopython=True, parallel=True, cache=True)
 def _nnls(A, B, rho, eps_abs=1e-6, eps_rel=1e-4, max_iter=500):
     '''Compute a non-negative least-squares solution to
     min_{X>=0} \|AX - B\|_F^2

--- a/librosa/util/_nnls.py
+++ b/librosa/util/_nnls.py
@@ -79,6 +79,9 @@ def _nnls(A, B, rho, eps_abs=1e-6, eps_rel=1e-4, max_iter=500):
     # identiy matrices with dtype matching A
     Im = np.eye(m, m, 0, A.dtype)
 
+    # Pre-allocate LA' to ensure efficient ordering
+    LAt = np.zeros((m, n), A.dtype)
+
     if n <= m:
         # This will be a small matrix if A is wide
         # Say L = r^-1 * (I - A'(rI - AA')^-1 A)
@@ -90,9 +93,9 @@ def _nnls(A, B, rho, eps_abs=1e-6, eps_rel=1e-4, max_iter=500):
         # A' is m by n  (m >> n)
         # B is n by N
 
-        LAt = np.dot(L, A.T)
+        LAt[:] = np.dot(L, A.T)
     else:
-        LAt = np.linalg.solve(np.dot(A.T, A) + rho * Im, A.T)
+        LAt[:] = np.linalg.solve(np.dot(A.T, A) + rho * Im, A.T)
 
     LAtB = np.dot(LAt, B)
     LAtApI = np.dot(LAt, A) - Im
@@ -193,15 +196,20 @@ def nnls(A, B, eps_abs=1e-6, eps_rel=1e-4, max_iter=500):
 
     >>> import matplotlib.pyplot as plt
     >>> plt.figure()
-    >>> plt.subplot(2,1,1)
+    >>> plt.subplot(3,1,1)
     >>> librosa.display.specshow(librosa.amplitude_to_db(S, ref=np.max), y_axis='log')
     >>> plt.colorbar()
-    >>> plt.title('Original spectrogram')
-    >>> plt.subplot(2,1,2)
+    >>> plt.title('Original spectrogram (1025 bins)')
+    >>> plt.subplot(3,1,2)
+    >>> librosa.display.specshow(librosa.amplitude_to_db(M, ref=np.max),
+    ...                          y_axis='mel')
+    >>> plt.title('Mel spectrogram (128 bins)')
+    >>> plt.colorbar()
+    >>> plt.subplot(3,1,3)
     >>> librosa.display.specshow(librosa.amplitude_to_db(S_recover, ref=np.max),
     ...                          y_axis='log')
     >>> plt.colorbar()
-    >>> plt.title('Reconstructed spectrogram')
+    >>> plt.title('Reconstructed spectrogram (1025 bins)')
     >>> plt.tight_layout()
     '''
 

--- a/librosa/util/_nnls.py
+++ b/librosa/util/_nnls.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+'''Non-negative least squares'''
+
+# The scipy library provides an nnls solver, but it does
+# not generalize efficiently to matrix-valued problems.
+# We therefore provide an alternate solver here.
+#
+# The NNLS solver we implement below is based on the ADMM
+# algorithm for convex optimization.  Instead of directly
+# solving:
+#   min_{X>=0} |AX - B|^2
+# we solve a related problem:
+#   min_{X, Y>=0} |AX - B|^2 + I[X = Y]
+# where the last term is the indicator that X and Y are
+# identical.
+#
+# The X,Y problem can be solved using augmented lagrangian
+# methods, which results in a loop of the following updates:
+#
+# 1. X <- min_X |AX - B|^2 + r |X - (Y - W)|^2
+# 2. Y <- min_{Y>=0} |X - (Y - W)|^2 = max(0, X + W)
+# 3. W <- W + X - Y
+#
+# where W is the matrix of lagrangian dual variables for
+# the equality constraint, and r is a step size parameter.
+# Steps 2 and 3 are trivial, and step 1 can be viewed as
+# a generalized Tikhonov regularization problem.
+#
+# The optimal solution to step 1 is given by
+#   X <- Y - W + (A'A + rI)^-1 (A'B - A'A(Y - W))
+#
+# This is efficient to compute if A is tall (so A'A is small),
+# but for wide A, we can use the Woodbury matrix identity to
+# compute it more efficiently. The implementation given below
+# dynamically selects the more efficient method at run-time.
+#
+# A couple of additional optimizations are provided to improve
+# stability:
+#   1. The solver is warm-started by X = leastsq(A, B) and Y = X_+
+#   2. The step-size r (rho in the code) is tuned by the effective
+#      condition number of A.  This is inspired by Nishihara et al.,
+#      which assumes strong convexity of the objective (which we
+#      don't generally have).
+#   3. If the target B is a vector (not a matrix), we fall back on the
+#      scipy solver.
+
+
+import numpy as np
+import scipy.optimize
+from numba import jit
+
+__all__ = ['nnls']
+
+
+@jit(nopython=True)
+def _nnls(A, B, rho, eps_abs=1e-6, eps_rel=1e-4, max_iter=100):
+    '''Compute a non-negative least-squares solution to 
+    min_{X>=0} \|AX - B\|_F^2
+    '''
+    # X* = Z + r^-1 * (I - A'(r I - AA')^-1 A) (A'B - A'A Z)
+    #
+    # Say L = r^-1 * (I - A'(rI - AA')^-1 A)
+    #
+    # then X* <= Z + LA'B - LA'AZ
+
+    # Can we infer rho from the spectrum of A?
+    #   nishihara'15 say to use
+    #       rho* = sqrt(lambda_min(A'A) * lambda_max(A'A))
+    #
+    #   but this assumes strong convexity on f, i.e., A is full-rank.
+    #   that's not the case for us, but we do have strong convexity over A's column space
+    #   so instead, we'll initialze using the (nonzero) singular values of A:
+    #       rho* = sigma_min(A) * sigma_max(A)
+
+    n, m = A.shape
+    _, N = B.shape
+
+    if n <= m:
+        # This will be a small matrix if A is wide
+        # Say L = r^-1 * (I - A'(rI - AA')^-1 A)
+        L = rho**-1 * (np.eye(m) - np.dot(A.T, np.linalg.solve(rho * np.eye(n) + np.dot(A, A.T), A)))
+
+        # L is m by m
+        # A' is m by n  (m >> n)
+        # B is n by N
+
+        LAt = np.dot(L, A.T)
+    else:
+        LAt = np.linalg.solve(np.dot(A.T, A) + rho * np.eye(m), A.T)
+
+    LAtB = np.dot(LAt, B)
+    LAtApI = np.dot(LAt, A) - np.eye(m)
+
+    # Initialize X and Y with the (thresholded) least squares solution
+    # This puts our initial iterate X into the column space of A
+    # so that we have strong (local) convexity
+    X = np.linalg.lstsq(A, B)[0]
+    Y = np.maximum(X, 0.0)
+    W = X - Y
+
+    residual = W.copy()
+
+    for _ in range(max_iter):
+        # Primal update 1: generalized tikhonov solve
+        X[:] = LAtB - np.dot(LAtApI, Y - W)
+
+        # Primal update 2: projection onto feasible set
+        np.maximum(X + W, 0, Y)
+
+        # Dual update
+        residual[:] = X - Y
+        W += residual
+
+        # Convergence criteria:
+        #    dual residual:   res_dual = rho * (W - W_prev)
+        #    primal residual: res_primal = X - Y
+        #                          but W - W_prev = X - Y
+        #    so res_dual = rho * rho_primal
+        # boyd et al suggest for stopping criteria:
+        #    |res_dual|_F <= sqrt(n) * eps_absolute + eps_relative * rho * norm(W)
+        #    |res_primal|_F <= sqrt(n) * eps_absolute + eps_relative * max(norm(X), norm(Y))
+        #    |res_primal| <= sqrt(n) * eps_absolute / rho + eps_relative * norm(W)
+        #
+        # so convergence is when
+        #    |X - Y| <= min(t1, t2)
+        #    where t1 = sqrt(n) * eps_absolute + eps_relative * max(norm(X), norm(Y))
+        #          t2 = sqrt(n) * eps_absolute / rho + eps_relative * norm(W)
+
+        # Convergence thresholds for primal and dual variables
+        t_primal = np.sqrt(X.size) * eps_abs + eps_rel * np.sqrt(max(np.sum(X**2), np.sum(Y**2)))
+        t_dual = np.sqrt(X.size) * eps_abs / rho + eps_rel * np.sqrt(np.sum(W**2))
+
+        if np.sum(residual**2) <= min(t_primal, t_dual)**2:
+            break
+
+    # Y is the feasible point that we've found
+    return Y
+
+
+def nnls(A, B, eps_abs=1e-6, eps_rel=1e-4, max_iter=100):
+    '''Non-negative least squares.
+
+    Given two matrices A and B, find a non-negative matrix X
+    that minimizes the sum squared error:
+
+        err(X) = sum_i,j ((AX)[i,j] - B[i, j])^2
+
+    Parameters
+    ----------
+    A : np.ndarray [shape=(m, n)]
+        The basis matrix
+
+    B : np.ndarray [shape=(m, N)]
+        The target matrix
+
+    eps_abs : number > 0
+        The absolute precision threshold
+
+    eps_rel : number > 0
+        The relative precision threshold
+
+    max_iter : int > 0
+        The maximum number of iterations for the solver
+
+
+    Returns
+    -------
+    X : np.ndarray [shape=(n, N), non-negative]
+        A minimizing solution to |AX - B|^2
+
+    See Also
+    --------
+    scipy.optimize.nnls
+
+    Examples
+    --------
+
+    '''
+
+    # If B is a single vector, punt up to the scipy method
+    if B.ndim == 1:
+        return scipy.optimize.nnls(A, B)[0]
+
+    # Otherwise, initialize our step size
+    svds = np.linalg.svd(A, compute_uv=False)
+    rho = 0.5 * svds.max() * svds.min()
+
+    # Cast up to float64 because numba isn't smart about typing
+    return _nnls(A.astype(np.float64),
+                 B.astype(np.float64),
+                 rho=rho,
+                 eps_abs=eps_abs,
+                 eps_rel=eps_rel,
+                 max_iter=max_iter)

--- a/librosa/util/_nnls.py
+++ b/librosa/util/_nnls.py
@@ -181,7 +181,28 @@ def nnls(A, B, eps_abs=1e-6, eps_rel=1e-4, max_iter=100):
 
     Examples
     --------
+    Approximate a magnitude spectrum from its mel spectrogram
 
+    >>> y, sr = librosa.load(librosa.util.example_audio_file(), offset=30, duration=10)
+    >>> S = np.abs(librosa.stft(y, n_fft=2048))
+    >>> M = librosa.feature.melspectrogram(S=S, sr=sr, power=1)
+    >>> mel_basis = librosa.filters.mel(sr, n_fft=2048, n_mels=M.shape[0])
+    >>> S_recover = librosa.util.nnls(mel_basis, M)
+
+    Plot the results
+
+    >>> import matplotlib.pyplot as plt
+    >>> plt.figure()
+    >>> plt.subplot(2,1,1)
+    >>> librosa.display.specshow(librosa.amplitude_to_db(S, ref=np.max), y_axis='log')
+    >>> plt.colorbar()
+    >>> plt.title('Original spectrogram')
+    >>> plt.subplot(2,1,2)
+    >>> librosa.display.specshow(librosa.amplitude_to_db(S_recover, ref=np.max),
+    ...                          y_axis='log')
+    >>> plt.colorbar()
+    >>> plt.title('Reconstructed spectrogram')
+    >>> plt.tight_layout()
     '''
 
     # If B is a single vector, punt up to the scipy method

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1621,7 +1621,9 @@ def y_chirp():
 @pytest.mark.parametrize('dtype', [np.float32, np.float64])
 @pytest.mark.parametrize('use_length', [False, True])
 @pytest.mark.parametrize('pad_mode', ['constant', 'reflect'])
-def test_griffinlim(y_chirp, hop_length, win_length, window, center, dtype, use_length, pad_mode):
+@pytest.mark.parametrize('momentum', [0, 0.99])
+@pytest.mark.parametrize('random_state', [None, 0, np.random.RandomState()])
+def test_griffinlim(y_chirp, hop_length, win_length, window, center, dtype, use_length, pad_mode, momentum, random_state):
 
     if use_length:
         length = len(y_chirp)
@@ -1636,7 +1638,8 @@ def test_griffinlim(y_chirp, hop_length, win_length, window, center, dtype, use_
     y_rec = librosa.griffinlim(S, hop_length=hop_length, win_length=win_length,
                                window=window, center=center, dtype=dtype,
                                length=length, pad_mode=pad_mode,
-                               n_iter=3)
+                               n_iter=3, momentum=momentum,
+                               random_state=random_state)
 
     # First, check length
     if use_length:
@@ -1644,3 +1647,17 @@ def test_griffinlim(y_chirp, hop_length, win_length, window, center, dtype, use_
 
     # Next, check dtype
     assert y_rec.dtype == dtype
+
+
+@pytest.mark.xfail(raises=librosa.ParameterError)
+def test_griffinlim_momentum():
+    x = np.zeros((33, 3))
+    librosa.griffinlim(x, momentum=-1)
+
+
+def test_griffinlim_momentum_warn():
+    x = np.zeros((33, 3))
+    with pytest.warns(UserWarning):
+        librosa.griffinlim(x, momentum=2)
+
+

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -788,7 +788,6 @@ def test_mfcc():
 @pytest.mark.parametrize('dtype', [np.float32, np.float64])
 @pytest.mark.parametrize('n_fft', [1024, 2048])
 def test_mel_to_stft(power, dtype, n_fft):
-
     srand()
 
     # Make a random mel spectrum, 4 frames
@@ -810,3 +809,58 @@ def test_mel_to_stft(power, dtype, n_fft):
 
     # Check that the approximation is good in RMSE terms
     assert np.sqrt(np.mean((mel_basis.dot(stft**power) - mels)**2)) <= 5e-2
+
+
+def test_mel_to_audio():
+    y = librosa.tone(440.0, sr=22050, duration=1)
+
+    M = librosa.feature.melspectrogram(y=y, sr=22050)
+
+    y_inv = librosa.feature.inverse.mel_to_audio(M, sr=22050, length=len(y))
+
+    # Sanity check the length
+    assert len(y) == len(y_inv)
+
+    # And that it's valid audio
+    assert librosa.util.valid_audio(y_inv)
+
+
+@pytest.mark.parametrize('n_mfcc', [13, 20])
+@pytest.mark.parametrize('n_mels', [64, 128])
+@pytest.mark.parametrize('dct_type', [2, 3])
+def test_mfcc_to_mel(n_mfcc, n_mels, dct_type):
+    y = librosa.tone(440.0, sr=22050, duration=1)
+
+    mfcc = librosa.feature.mfcc(y=y, sr=22050,
+                                n_mels=n_mels, n_mfcc=n_mfcc, dct_type=dct_type)
+
+    melspec = librosa.feature.melspectrogram(y=y, sr=22050, n_mels=n_mels)
+    
+    mel_recover = librosa.feature.inverse.mfcc_to_mel(mfcc, n_mels=n_mels,
+                                                      dct_type=dct_type)
+
+    # Quick shape check
+    assert melspec.shape == mel_recover.shape
+
+    # Check non-negativity
+    assert np.all(mel_recover >= 0)
+
+
+@pytest.mark.parametrize('n_mfcc', [13, 20])
+@pytest.mark.parametrize('n_mels', [64, 128])
+@pytest.mark.parametrize('dct_type', [2, 3])
+def test_mfcc_to_audio(n_mfcc, n_mels, dct_type):
+    y = librosa.tone(440.0, sr=22050, duration=1)
+
+    mfcc = librosa.feature.mfcc(y=y, sr=22050,
+                                n_mels=n_mels, n_mfcc=n_mfcc, dct_type=dct_type)
+
+    y_inv = librosa.feature.inverse.mfcc_to_audio(mfcc, n_mels=n_mels,
+                                                  dct_type=dct_type,
+                                                  length=len(y))
+
+    # Sanity check the length
+    assert len(y) == len(y_inv)
+
+    # And that it's valid audio
+    assert librosa.util.valid_audio(y_inv)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1039,7 +1039,7 @@ def test_nnls_vector(dtype_A, dtype_B):
 @pytest.mark.parametrize('dtype_A', [np.float32, np.float64])
 @pytest.mark.parametrize('dtype_B', [np.float32, np.float64])
 @pytest.mark.parametrize('x_size', [3, 30])
-def test_nnls_wide(dtype_A, dtype_B, x_size):
+def test_nnls_matrix(dtype_A, dtype_B, x_size):
     srand()
 
     # Make a random basis
@@ -1054,17 +1054,17 @@ def test_nnls_wide(dtype_A, dtype_B, x_size):
     x_rec = librosa.util.nnls(A, B)
 
     assert np.all(x_rec >= 0)
-    assert np.sqrt(np.mean((B - A.dot(x_rec))**2)) <= 1e-6
+    assert np.sqrt(np.mean((B - A.dot(x_rec))**2)) <= 1e-5
 
 
 @pytest.mark.parametrize('dtype_A', [np.float32, np.float64])
 @pytest.mark.parametrize('dtype_B', [np.float32, np.float64])
-@pytest.mark.parametrize('x_size', [3, 30])
-def test_nnls_wide(dtype_A, dtype_B, x_size):
+@pytest.mark.parametrize('x_size', [16, 64, 256])
+def test_nnls_multiblock(dtype_A, dtype_B, x_size):
     srand()
 
     # Make a random basis
-    A = np.random.randn(7, 5).astype(dtype_A)
+    A = np.random.randn(7, 1025).astype(dtype_A)
 
     # Make a random latent matrix
     #   when x_size is 3, B is 7x3 (smaller than A)
@@ -1075,4 +1075,4 @@ def test_nnls_wide(dtype_A, dtype_B, x_size):
     x_rec = librosa.util.nnls(A, B)
 
     assert np.all(x_rec >= 0)
-    assert np.sqrt(np.mean((B - A.dot(x_rec))**2)) <= 1e-6
+    assert np.sqrt(np.mean((B - A.dot(x_rec))**2)) <= 1e-5

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1075,4 +1075,4 @@ def test_nnls_multiblock(dtype_A, dtype_B, x_size):
     x_rec = librosa.util.nnls(A, B)
 
     assert np.all(x_rec >= 0)
-    assert np.sqrt(np.mean((B - A.dot(x_rec))**2)) <= 1e-5
+    assert np.sqrt(np.mean((B - A.dot(x_rec))**2)) <= 1e-4

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1032,6 +1032,7 @@ def test_nnls_vector(dtype_A, dtype_B):
 
     x_rec = librosa.util.nnls(A, B)
 
+    assert np.all(x_rec >= 0)
     assert np.sqrt(np.mean((B - A.dot(x_rec))**2)) <= 1e-6
 
 
@@ -1050,6 +1051,7 @@ def test_nnls_wide(dtype_A, dtype_B):
 
     x_rec = librosa.util.nnls(A, B)
 
+    assert np.all(x_rec >= 0)
     assert np.sqrt(np.mean((B - A.dot(x_rec))**2)) <= 1e-6
 
 
@@ -1068,5 +1070,5 @@ def test_nnls_wide(dtype_A, dtype_B):
 
     x_rec = librosa.util.nnls(A, B)
 
+    assert np.all(x_rec >= 0)
     assert np.sqrt(np.mean((B - A.dot(x_rec))**2)) <= 1e-6
-

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1015,3 +1015,58 @@ def test_util_fill_off_diagonal_8_12():
     librosa.util.fill_off_diagonal(mut_x, 0.25)
 
     assert np.array_equal(mut_x, gt_x.T)
+
+
+@pytest.mark.parametrize('dtype_A', [np.float32, np.float64])
+@pytest.mark.parametrize('dtype_B', [np.float32, np.float64])
+def test_nnls_vector(dtype_A, dtype_B):
+    srand()
+
+    # Make a random basis
+    A = np.random.randn(5, 7).astype(dtype_A)
+
+    # Make a random latent vector
+    x = np.random.randn(A.shape[1])**2
+
+    B = A.dot(x).astype(dtype_B)
+
+    x_rec = librosa.util.nnls(A, B)
+
+    assert np.sqrt(np.mean((B - A.dot(x_rec))**2)) <= 1e-6
+
+
+@pytest.mark.parametrize('dtype_A', [np.float32, np.float64])
+@pytest.mark.parametrize('dtype_B', [np.float32, np.float64])
+def test_nnls_wide(dtype_A, dtype_B):
+    srand()
+
+    # Make a random basis
+    A = np.random.randn(5, 7).astype(dtype_A)
+
+    # Make a random latent matrix
+    x = np.random.randn(A.shape[1], 3)**2
+
+    B = A.dot(x).astype(dtype_B)
+
+    x_rec = librosa.util.nnls(A, B)
+
+    assert np.sqrt(np.mean((B - A.dot(x_rec))**2)) <= 1e-6
+
+
+@pytest.mark.parametrize('dtype_A', [np.float32, np.float64])
+@pytest.mark.parametrize('dtype_B', [np.float32, np.float64])
+def test_nnls_wide(dtype_A, dtype_B):
+    srand()
+
+    # Make a random basis
+    A = np.random.randn(7, 5).astype(dtype_A)
+
+    # Make a random latent matrix
+    x = np.random.randn(A.shape[1], 3)**2
+
+    B = A.dot(x).astype(dtype_B)
+
+    x_rec = librosa.util.nnls(A, B)
+
+    assert np.sqrt(np.mean((B - A.dot(x_rec))**2)) <= 1e-6
+

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1038,14 +1038,16 @@ def test_nnls_vector(dtype_A, dtype_B):
 
 @pytest.mark.parametrize('dtype_A', [np.float32, np.float64])
 @pytest.mark.parametrize('dtype_B', [np.float32, np.float64])
-def test_nnls_wide(dtype_A, dtype_B):
+@pytest.mark.parametrize('x_size', [3, 30])
+def test_nnls_wide(dtype_A, dtype_B, x_size):
     srand()
 
     # Make a random basis
     A = np.random.randn(5, 7).astype(dtype_A)
 
     # Make a random latent matrix
-    x = np.random.randn(A.shape[1], 3)**2
+    #   when x_size is 3, B is 7x3 (smaller than A)
+    x = np.random.randn(A.shape[1], x_size)**2
 
     B = A.dot(x).astype(dtype_B)
 
@@ -1057,14 +1059,16 @@ def test_nnls_wide(dtype_A, dtype_B):
 
 @pytest.mark.parametrize('dtype_A', [np.float32, np.float64])
 @pytest.mark.parametrize('dtype_B', [np.float32, np.float64])
-def test_nnls_wide(dtype_A, dtype_B):
+@pytest.mark.parametrize('x_size', [3, 30])
+def test_nnls_wide(dtype_A, dtype_B, x_size):
     srand()
 
     # Make a random basis
     A = np.random.randn(7, 5).astype(dtype_A)
 
     # Make a random latent matrix
-    x = np.random.randn(A.shape[1], 3)**2
+    #   when x_size is 3, B is 7x3 (smaller than A)
+    x = np.random.randn(A.shape[1], x_size)**2
 
     B = A.dot(x).astype(dtype_B)
 


### PR DESCRIPTION
#### Reference Issue
Implements #843 


#### What does this implement/fix? Explain your changes.

This PR adds the following functions:

- `core.griffinlim` (adapted from jongwook's implementation)
- `feature.inverse.mel_to_stft`
- `feature.inverse.mel_to_audio`
- `feature.inverse.mfcc_to_mel`
- `feature.inverse.mfcc_to_audio`


#### Any other comments?

This is still very much a work in progress.  Everything basically works and is more or less documented.  

The major gap to fill right now is in the mel basis inversion.  Ideally, this should be a non-negative, linear least squares problem to recover the STFT magnitudes from the Mel magnitudes.  Right now, it uses a single unconstrained least-squares solve and projects the solution down to the feasible set.  This gets us pretty close, but it's not optimal.  Numpy does not directly provide an nnls solver, and scipy does, but it does not vectorize, so we'd have to solve each column independently.

At the risk of creating some feature bloat, I think there's some justification to providing our own vectorized NNLS solver under `util`.  NNLS occurs in a few places in audio, for example: [NNLS Chroma](https://www.eecs.qmul.ac.uk/~simond/pub/2010/Mauch-Dixon-ISMIR-2010.pdf), [onset detection](http://mac.citi.sinica.edu.tw/~yang/pub/liang15spl.pdf), and estimating stem mixing coefficients from a mix, to name a few.

At the moment, I'm thinking of implementing nnls as a numba-accelerated admm algorithm.  As far as I can tell, all of the required operations are supported by numba (lstsq, thresholding), so it shouldn't be too hard to get it together. (Famous last words, I know).

#### TODO

- [x] Unit tests
- [x] NNLS?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/844)
<!-- Reviewable:end -->
