### PR TITLE
[FIX] type error in soundfile reading

### DIFF
--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -127,9 +127,9 @@ def load(path, sr=22050, mono=True, offset=0.0, duration=None,
             sr_native = sf_desc.samplerate
             if offset:
                 # Seek to the start of the target read
-                sf_desc.seek(offset * sr_native)
+                sf_desc.seek(int(offset * sr_native))
             if duration is not None:
-                frame_duration = duration * sr_native
+                frame_duration = int(duration * sr_native)
             else:
                 frame_duration = -1
 


### PR DESCRIPTION
#847 

#### What does this implement/fix? Explain your changes.

There was a lurking type error in the offset/duration calculations for soundfile-based IO.  This PR fixes it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/853)
<!-- Reviewable:end -->
