### PR TITLE
JIT caching for numba functions

### DIFF
--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -343,7 +343,7 @@ def istft(stft_matrix, hop_length=None, win_length=None, window='hann',
     return y
 
 
-@jit(nopython=True)
+@jit(nopython=True, cache=True, parallel=True)
 def __overlap_add(y, ytmp, hop_length):
     # numba-accelerated overlap add for inverse stft
     # y is the pre-allocated output buffer

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -343,7 +343,7 @@ def istft(stft_matrix, hop_length=None, win_length=None, window='hann',
     return y
 
 
-@jit(nopython=True, cache=True, parallel=True)
+@jit(nopython=True, cache=True)
 def __overlap_add(y, ytmp, hop_length):
     # numba-accelerated overlap add for inverse stft
     # y is the pre-allocated output buffer

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -1160,7 +1160,7 @@ def semitone_filterbank(center_freqs=None, tuning=0.0, sample_rates=None, flayou
     return filterbank, fb_sample_rates
 
 
-@jit(nopython=True, cache=True, parallel=True)
+@jit(nopython=True, cache=True)
 def __window_ss_fill(x, win_sq, n_frames, hop_length):  # pragma: no cover
     '''Helper function for window sum-square calculation.'''
 

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -1160,7 +1160,7 @@ def semitone_filterbank(center_freqs=None, tuning=0.0, sample_rates=None, flayou
     return filterbank, fb_sample_rates
 
 
-@jit(nopython=True)
+@jit(nopython=True, cache=True, parallel=True)
 def __window_ss_fill(x, win_sq, n_frames, hop_length):  # pragma: no cover
     '''Helper function for window sum-square calculation.'''
 

--- a/librosa/sequence.py
+++ b/librosa/sequence.py
@@ -234,7 +234,7 @@ def dtw(X=None, Y=None, C=None, metric='euclidean', step_sizes_sigma=None,
         return D
 
 
-@jit(nopython=True)
+@jit(nopython=True, cache=True, parallel=True)
 def __dtw_calc_accu_cost(C, D, D_steps, step_sizes_sigma,
                          weights_mul, weights_add, max_0, max_1):  # pragma: no cover
     '''Calculate the accumulated cost matrix D.
@@ -302,7 +302,7 @@ def __dtw_calc_accu_cost(C, D, D_steps, step_sizes_sigma,
     return D, D_steps
 
 
-@jit(nopython=True)
+@jit(nopython=True, cache=True, parallel=True)
 def __dtw_backtracking(D_steps, step_sizes_sigma):  # pragma: no cover
     '''Backtrack optimal warping path.
 
@@ -352,7 +352,7 @@ def __dtw_backtracking(D_steps, step_sizes_sigma):  # pragma: no cover
     return wp
 
 
-@jit(nopython=True)
+@jit(nopython=True, cache=True, parallel=True)
 def _viterbi(log_prob, log_trans, log_p_init, state, value, ptr):  # pragma: no cover
     '''Core Viterbi algorithm.
 

--- a/librosa/sequence.py
+++ b/librosa/sequence.py
@@ -234,7 +234,7 @@ def dtw(X=None, Y=None, C=None, metric='euclidean', step_sizes_sigma=None,
         return D
 
 
-@jit(nopython=True, cache=True, parallel=True)
+@jit(nopython=True, cache=True)
 def __dtw_calc_accu_cost(C, D, D_steps, step_sizes_sigma,
                          weights_mul, weights_add, max_0, max_1):  # pragma: no cover
     '''Calculate the accumulated cost matrix D.
@@ -302,7 +302,7 @@ def __dtw_calc_accu_cost(C, D, D_steps, step_sizes_sigma,
     return D, D_steps
 
 
-@jit(nopython=True, cache=True, parallel=True)
+@jit(nopython=True, cache=True)
 def __dtw_backtracking(D_steps, step_sizes_sigma):  # pragma: no cover
     '''Backtrack optimal warping path.
 
@@ -352,7 +352,7 @@ def __dtw_backtracking(D_steps, step_sizes_sigma):  # pragma: no cover
     return wp
 
 
-@jit(nopython=True, cache=True, parallel=True)
+@jit(nopython=True, cache=True)
 def _viterbi(log_prob, log_trans, log_p_init, state, value, ptr):  # pragma: no cover
     '''Core Viterbi algorithm.
 

--- a/librosa/util/decorators.py
+++ b/librosa/util/decorators.py
@@ -6,9 +6,8 @@
 import warnings
 from decorator import decorator
 import six
-from numba.decorators import jit as optional_jit
 
-__all__ = ['moved', 'deprecated', 'optional_jit']
+__all__ = ['moved', 'deprecated']
 
 
 def moved(moved_from, version, version_removed):

--- a/librosa/util/decorators.py
+++ b/librosa/util/decorators.py
@@ -6,8 +6,9 @@
 import warnings
 from decorator import decorator
 import six
+from numba.decorators import jit as optional_jit
 
-__all__ = ['moved', 'deprecated']
+__all__ = ['moved', 'deprecated', 'optional_jit']
 
 
 def moved(moved_from, version, version_removed):

--- a/librosa/util/matching.py
+++ b/librosa/util/matching.py
@@ -13,7 +13,7 @@ from .utils import valid_intervals
 __all__ = ['match_intervals', 'match_events']
 
 
-@numba.jit(nopython=True)
+@numba.jit(nopython=True, cache=True, parallel=True)
 def __jaccard(int_a, int_b):  # pragma: no cover
     '''Jaccard similarity between two intervals
 
@@ -45,7 +45,7 @@ def __jaccard(int_a, int_b):  # pragma: no cover
     return 0.0
 
 
-@numba.jit(nopython=True)
+@numba.jit(nopython=True, cache=True, parallel=True)
 def __match_interval_overlaps(query, intervals_to, candidates):  # pragma: no cover
     '''Find the best Jaccard match from query to candidates'''
 
@@ -59,7 +59,7 @@ def __match_interval_overlaps(query, intervals_to, candidates):  # pragma: no co
     return best_idx
 
 
-@numba.jit(nopython=True)
+@numba.jit(nopython=True, cache=True, parallel=True)
 def __match_intervals(intervals_from, intervals_to, strict=True):  # pragma: no cover
     '''Numba-accelerated interval matching algorithm.
 
@@ -298,7 +298,7 @@ def match_events(events_from, events_to, left=True, right=True):
     return __match_events_helper(output, events_from, events_to, left, right)
 
 
-@numba.jit(nopython=True)
+@numba.jit(nopython=True, cache=True, parallel=True)
 def __match_events_helper(output, events_from, events_to, left=True, right=True):  # pragma: no cover
     # mock dictionary for events
     from_idx = np.argsort(events_from)

--- a/librosa/util/matching.py
+++ b/librosa/util/matching.py
@@ -13,7 +13,7 @@ from .utils import valid_intervals
 __all__ = ['match_intervals', 'match_events']
 
 
-@numba.jit(nopython=True, cache=True, parallel=True)
+@numba.jit(nopython=True, cache=True)
 def __jaccard(int_a, int_b):  # pragma: no cover
     '''Jaccard similarity between two intervals
 
@@ -45,7 +45,7 @@ def __jaccard(int_a, int_b):  # pragma: no cover
     return 0.0
 
 
-@numba.jit(nopython=True, cache=True, parallel=True)
+@numba.jit(nopython=True, cache=True)
 def __match_interval_overlaps(query, intervals_to, candidates):  # pragma: no cover
     '''Find the best Jaccard match from query to candidates'''
 
@@ -59,7 +59,7 @@ def __match_interval_overlaps(query, intervals_to, candidates):  # pragma: no co
     return best_idx
 
 
-@numba.jit(nopython=True, cache=True, parallel=True)
+@numba.jit(nopython=True, cache=True)
 def __match_intervals(intervals_from, intervals_to, strict=True):  # pragma: no cover
     '''Numba-accelerated interval matching algorithm.
 
@@ -298,7 +298,7 @@ def match_events(events_from, events_to, left=True, right=True):
     return __match_events_helper(output, events_from, events_to, left, right)
 
 
-@numba.jit(nopython=True, cache=True, parallel=True)
+@numba.jit(nopython=True, cache=True)
 def __match_events_helper(output, events_from, events_to, left=True, right=True):  # pragma: no cover
     # mock dictionary for events
     from_idx = np.argsort(events_from)


### PR DESCRIPTION
#### Reference Issue
Fixes #846 


#### What does this implement/fix? Explain your changes.

This function enables caching of jitted functions across sessions.  No change to functionality here, but it shaves about 6 seconds off of the test suite.  More to the point, it cuts down on time for frequently used functions the first time you use them (e.g. when starting a notebook).

I also experimented locally with the `parallel` option and saw no benefit.  Many of the functions we numbafy are inherently sequential anyway (eg dtw), so I wouldn't expect much benefit here.

#### Any other comments?

I see no need for CR here; I'll merge once CI passes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/855)
<!-- Reviewable:end -->
