### PR TITLE
[CR requested] ICQT resampling mode and polyphase resampling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.py[co]
 
+__pycache__
+
 # Packages
 *.egg
 *.egg-info

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -269,7 +269,7 @@ def resample(y, orig_sr, target_sr, res_type='kaiser_best', fix=True, scale=Fals
 
             To use a faster method, set `res_type='kaiser_fast'`.
 
-            To use `scipy.signal.resample`, set `res_type='fft'`.
+            To use `scipy.signal.resample`, set `res_type='fft'` or `res_type='scipy'`.
 
             To use `scipy.signal.resample_poly`, set `res_type='polyphase'`.
 

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -273,6 +273,10 @@ def resample(y, orig_sr, target_sr, res_type='kaiser_best', fix=True, scale=Fals
 
             To use `scipy.signal.resample_poly`, set `res_type='polyphase'`.
 
+        .. note::
+            When using `res_type='polyphase'`, only integer sampling rates are
+            supported.
+
     fix : bool
         adjust the length of the resampled signal to be of size exactly
         `ceil(target_sr * len(y) / orig_sr)`
@@ -290,6 +294,11 @@ def resample(y, orig_sr, target_sr, res_type='kaiser_best', fix=True, scale=Fals
     y_hat : np.ndarray [shape=(n * target_sr / orig_sr,)]
         `y` resampled from `orig_sr` to `target_sr`
 
+    Raises
+    ------
+    ParameterError
+        If `res_type='polyphase'` and `orig_sr` or `target_sr` are not both
+        integer-valued.
 
     See Also
     --------
@@ -309,7 +318,6 @@ def resample(y, orig_sr, target_sr, res_type='kaiser_best', fix=True, scale=Fals
     >>> y_8k = librosa.resample(y, sr, 8000)
     >>> y.shape, y_8k.shape
     ((1355168,), (491671,))
-
     """
 
     # First, validate the audio buffer

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -75,9 +75,7 @@ def load(path, sr=22050, mono=True, offset=0.0, duration=None,
         .. note::
             By default, this uses `resampy`'s high-quality mode ('kaiser_best').
 
-            To use a faster method, set `res_type='kaiser_fast'`.
-
-            To use `scipy.signal.resample`, set `res_type='scipy'`.
+            For alternative resampling modes, see `resample`
 
         .. note::
            `audioread` may truncate the precision of the audio data to 16 bits.
@@ -271,7 +269,9 @@ def resample(y, orig_sr, target_sr, res_type='kaiser_best', fix=True, scale=Fals
 
             To use a faster method, set `res_type='kaiser_fast'`.
 
-            To use `scipy.signal.resample`, set `res_type='scipy'`.
+            To use `scipy.signal.resample`, set `res_type='fft'`.
+
+            To use `scipy.signal.resample_poly`, set `res_type='polyphase'`.
 
     fix : bool
         adjust the length of the resampled signal to be of size exactly

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -518,7 +518,7 @@ def pseudo_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
 @cache(level=40)
 def icqt(C, sr=22050, hop_length=512, fmin=None, bins_per_octave=12,
          tuning=0.0, filter_scale=1, norm=1, sparsity=0.01, window='hann',
-         scale=True, length=None, amin=util.Deprecated()):
+         scale=True, length=None, amin=util.Deprecated(), res_type='scipy'):
     '''Compute the inverse constant-Q transform.
 
     Given a constant-Q transform representation `C` of an audio signal `y`,
@@ -568,11 +568,14 @@ def icqt(C, sr=22050, hop_length=512, fmin=None, bins_per_octave=12,
         If provided, the output `y` is zero-padded or clipped to exactly
         `length` samples.
 
-    Returns
-
     amin : float or None [DEPRECATED]
 
         .. note:: This parameter is deprecated in 0.7.0 and will be removed in 0.8.0.
+
+    res_type : string
+        Resampling mode.  By default, this uses `scipy` mode for high-quality reconstruction,
+        but this may be slow depending on your signal duration.
+        See `librosa.resample` for supported modes.
 
     Returns
     -------
@@ -582,6 +585,7 @@ def icqt(C, sr=22050, hop_length=512, fmin=None, bins_per_octave=12,
     See Also
     --------
     cqt
+    core.resample
 
     Notes
     -----
@@ -670,7 +674,7 @@ def icqt(C, sr=22050, hop_length=512, fmin=None, bins_per_octave=12,
         else:
             # Up-sample the previous buffer and add in the new one
             # Scipy-resampling is fast here, since it's a power-of-two relation
-            y = audio.resample(y, 1, 2, scale=True, res_type='scipy', fix=False)
+            y = audio.resample(y, 1, 2, scale=True, res_type=res_type, fix=False)
 
             y[:len(y_oct)] += y_oct
 

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -518,7 +518,7 @@ def pseudo_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
 @cache(level=40)
 def icqt(C, sr=22050, hop_length=512, fmin=None, bins_per_octave=12,
          tuning=0.0, filter_scale=1, norm=1, sparsity=0.01, window='hann',
-         scale=True, length=None, amin=util.Deprecated(), res_type='scipy'):
+         scale=True, length=None, amin=util.Deprecated(), res_type='fft'):
     '''Compute the inverse constant-Q transform.
 
     Given a constant-Q transform representation `C` of an audio signal `y`,
@@ -573,8 +573,8 @@ def icqt(C, sr=22050, hop_length=512, fmin=None, bins_per_octave=12,
         .. note:: This parameter is deprecated in 0.7.0 and will be removed in 0.8.0.
 
     res_type : string
-        Resampling mode.  By default, this uses `scipy` mode for high-quality reconstruction,
-        but this may be slow depending on your signal duration.
+        Resampling mode.  By default, this uses `fft` mode for high-quality 
+        reconstruction, but this may be slow depending on your signal duration.
         See `librosa.resample` for supported modes.
 
     Returns

--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -259,8 +259,11 @@ def pitch_shift(y, sr, n_steps, bins_per_octave=12, res_type='kaiser_best'):
 
     res_type : string
         Resample type.
-        Possible options: 'kaiser_best', 'kaiser_fast', and 'scipy'.
-        By default, 'kaiser_best' is used. Refer to core.resample for details.
+        Possible options: 'kaiser_best', 'kaiser_fast', and 'scipy', 'polyphase',
+        'fft'.
+        By default, 'kaiser_best' is used.
+        
+        See `core.resample` for more information.
 
     Returns
     -------
@@ -297,7 +300,8 @@ def pitch_shift(y, sr, n_steps, bins_per_octave=12, res_type='kaiser_best'):
     rate = 2.0 ** (-float(n_steps) / bins_per_octave)
 
     # Stretch in time, then resample
-    y_shift = core.resample(time_stretch(y, rate), float(sr) / rate, sr, res_type=res_type)
+    y_shift = core.resample(time_stretch(y, rate), float(sr) / rate, sr,
+                            res_type=res_type)
 
     # Crop to the same dimension as the input
     return util.fix_length(y_shift, len(y))

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -23,7 +23,7 @@ from test_core import srand
 
 
 def __test_cqt_size(y, sr, hop_length, fmin, n_bins, bins_per_octave,
-                    tuning, filter_scale, norm, sparsity):
+                    tuning, filter_scale, norm, sparsity, res_type):
 
     cqt_output = np.abs(librosa.cqt(y,
                                     sr=sr,
@@ -34,7 +34,8 @@ def __test_cqt_size(y, sr, hop_length, fmin, n_bins, bins_per_octave,
                                     tuning=tuning,
                                     filter_scale=filter_scale,
                                     norm=norm,
-                                    sparsity=sparsity))
+                                    sparsity=sparsity,
+                                    res_type=res_type))
 
     assert cqt_output.shape[0] == n_bins
 
@@ -70,18 +71,18 @@ def test_cqt():
     # num_octaves = 6, 2**(6-1) = 32 > 16
     for hop_length in [-1, 0, 16, 63, 65]:
         yield (pytest.mark.xfail(__test_cqt_size, raises=librosa.ParameterError), y, sr, hop_length, None, 72,
-               12, 0.0, 2, 1, 0.01)
+               12, 0.0, 2, 1, 0.01, None)
 
     # Filters go beyond Nyquist. 500 Hz -> 4 octaves = 8000 Hz > 11000 Hz
     yield (pytest.mark.xfail(__test_cqt_size, raises=librosa.ParameterError), y, sr, 512, 500, 4 * 12,
-           12, 0.0, 2, 1, 0.01)
+           12, 0.0, 2, 1, 0.01, None)
 
     # Test with fmin near Nyquist
     for fmin in [3000, 4800]:
         for n_bins in [1, 2]:
             for bins_per_octave in [12]:
                 yield (__test_cqt_size, y, sr, 512, fmin, n_bins,
-                       bins_per_octave, 0.0, 2, 1, 0.01)
+                       bins_per_octave, 0.0, 2, 1, 0.01, None)
 
     # Test for no errors and correct output size
     for fmin in [None, librosa.note_to_hz('C2')]:
@@ -90,9 +91,9 @@ def test_cqt():
                 for tuning in [None, 0, 0.25]:
                     for filter_scale in [1, 2]:
                         for norm in [1, 2]:
-                            yield (__test_cqt_size, y, sr, 512, fmin, n_bins,
-                                   bins_per_octave, tuning,
-                                   filter_scale, norm, 0.01)
+                            for res_type in [None, 'polyphase']:
+                                yield (__test_cqt_size, y, sr, 512, fmin, n_bins,
+                                        bins_per_octave, tuning, filter_scale, norm, 0.01, res_type)
 
 
 def test_hybrid_cqt():
@@ -105,7 +106,7 @@ def test_hybrid_cqt():
     y = make_signal(sr, duration, None)
 
     def __test(hop_length, fmin, n_bins, bins_per_octave,
-               tuning, resolution, norm, sparsity):
+               tuning, resolution, norm, sparsity, res_type):
 
         C2 = librosa.hybrid_cqt(y, sr=sr,
                                 hop_length=hop_length,
@@ -113,7 +114,7 @@ def test_hybrid_cqt():
                                 bins_per_octave=bins_per_octave,
                                 tuning=tuning, filter_scale=resolution,
                                 norm=norm,
-                                sparsity=sparsity)
+                                sparsity=sparsity, res_type=res_type)
 
         C1 = np.abs(librosa.cqt(y, sr=sr,
                                 hop_length=hop_length,
@@ -121,7 +122,7 @@ def test_hybrid_cqt():
                                 bins_per_octave=bins_per_octave,
                                 tuning=tuning, filter_scale=resolution,
                                 norm=norm,
-                                sparsity=sparsity))
+                                sparsity=sparsity, res_type=res_Type))
 
         assert C1.shape == C2.shape
 
@@ -144,9 +145,10 @@ def test_hybrid_cqt():
                 for tuning in [None, 0, 0.25]:
                     for resolution in [1, 2]:
                         for norm in [1, 2]:
-                            yield (__test, 512, fmin, n_bins,
-                                   bins_per_octave, tuning,
-                                   resolution, norm, 0.01)
+                            for res_type in [None, 'polyphase']:
+                                yield (__test, 512, fmin, n_bins,
+                                        bins_per_octave, tuning,
+                                        resolution, norm, 0.01)
 
 
 def test_cqt_position():

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -122,7 +122,7 @@ def test_hybrid_cqt():
                                 bins_per_octave=bins_per_octave,
                                 tuning=tuning, filter_scale=resolution,
                                 norm=norm,
-                                sparsity=sparsity, res_type=res_Type))
+                                sparsity=sparsity, res_type=res_type))
 
         assert C1.shape == C2.shape
 
@@ -148,7 +148,7 @@ def test_hybrid_cqt():
                             for res_type in [None, 'polyphase']:
                                 yield (__test, 512, fmin, n_bins,
                                         bins_per_octave, tuning,
-                                        resolution, norm, 0.01)
+                                        resolution, norm, 0.01, res_type)
 
 
 def test_cqt_position():

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -306,7 +306,7 @@ def test_hybrid_cqt_white_noise():
 
 def test_icqt():
 
-    def __test(sr, scale, hop_length, over_sample, length, y):
+    def __test(sr, scale, hop_length, over_sample, length, res_type, y):
 
         bins_per_octave = over_sample * 12
         n_bins = 7 * bins_per_octave
@@ -324,7 +324,8 @@ def test_icqt():
                             scale=scale,
                             hop_length=hop_length,
                             bins_per_octave=bins_per_octave,
-                            length=_len)
+                            length=_len,
+                            res_type=res_type)
 
         # Only test on the middle section
         if length:
@@ -348,4 +349,5 @@ def test_icqt():
             for scale in [False, True]:
                 for hop_length in [128, 384, 512]:
                     for length in [None, True]:
-                        yield __test, sr, scale, hop_length, over_sample, length, y
+                        for res_type in ['scipy', 'kaiser_fast']:
+                            yield __test, sr, scale, hop_length, over_sample, length, res_type, y

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -349,5 +349,5 @@ def test_icqt():
             for scale in [False, True]:
                 for hop_length in [128, 384, 512]:
                     for length in [None, True]:
-                        for res_type in ['scipy', 'kaiser_fast']:
+                        for res_type in ['scipy', 'kaiser_fast', 'polyphase']:
                             yield __test, sr, scale, hop_length, over_sample, length, res_type, y

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -153,6 +153,7 @@ def test_resample_stereo():
         assert y2.flags['C_CONTIGUOUS']
 
         # Check that we're within one sample of the target length target_length = y.shape[-1] * sr_out // sr_in
+        target_length = y.shape[-1] * sr_out // sr_in
         assert np.abs(y2.shape[-1] - target_length) <= 1
 
     y, sr_in = librosa.load(os.path.join('tests', 'data', 'test1_44100.wav'),

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -127,7 +127,7 @@ def test_resample_mono():
         y, sr_in = librosa.load(os.path.join('tests', 'data', infile), sr=None, duration=5)
 
         for sr_out in [8000, 22050]:
-            for res_type in ['kaiser_best', 'kaiser_fast', 'scipy']:
+            for res_type in ['kaiser_best', 'kaiser_fast', 'scipy', 'fft', 'polyphase']:
                 for fix in [False, True]:
                     yield (__test, y, sr_in, sr_out, res_type, fix)
 
@@ -152,15 +152,14 @@ def test_resample_stereo():
         # Check buffer contiguity
         assert y2.flags['C_CONTIGUOUS']
 
-        # Check that we're within one sample of the target length
-        target_length = y.shape[-1] * sr_out // sr_in
+        # Check that we're within one sample of the target length target_length = y.shape[-1] * sr_out // sr_in
         assert np.abs(y2.shape[-1] - target_length) <= 1
 
     y, sr_in = librosa.load(os.path.join('tests', 'data', 'test1_44100.wav'),
                             mono=False, sr=None, duration=5)
 
     for sr_out in [8000, 22050]:
-        for res_type in ['kaiser_fast', 'scipy']:
+        for res_type in ['kaiser_fast', 'fft', 'polyphase']:
             for fix in [False, True]:
                 yield __test, y, sr_in, sr_out, res_type, fix
 
@@ -185,10 +184,17 @@ def test_resample_scale():
     y, sr_in = librosa.load(os.path.join('tests', 'data','test1_22050.wav'),
                             mono=True, sr=None, duration=3)
 
-    for res_type in ['scipy', 'kaiser_best', 'kaiser_fast']:
+    for res_type in ['fft', 'kaiser_best', 'kaiser_fast', 'polyphase']:
         for sr_out in [11025, 22050, 44100]:
             yield __test, sr_in, sr_out, res_type, y
             yield __test, sr_out, sr_in, res_type, y
+
+
+@pytest.mark.parametrize('sr_in, sr_out', [(100, 100.1), (100.1, 100)])
+@pytest.mark.xfail(raises=librosa.ParameterError)
+def test_resample_poly_float(sr_in, sr_out):
+    y = np.empty(128)
+    librosa.resample(y, sr_in, sr_out, res_type='polyphase')
 
 
 def test_stft():


### PR DESCRIPTION
#### Reference Issue
Fixes #857 and #576 


#### What does this implement/fix? Explain your changes.

This PR exposes the resampling mode as a parameter to `icqt`.

Additionally, it adds a wrapper for scipy's polyphase resampler.

#### Any other comments?

- polyphase resampling is only supported when the sampling rates are both integer-valued.  The up- and down-sampling ratios are calculated by greatest common divisor.  This is triggered by `res_type='polyphase'`.
- Because `scipy` now has multiple resamplers built in, saying `res_type='scipy'` is no longer informative.  We now support a more informative `res_type='fft'` (equivalent to the old `='scipy'`), though the old version still works.  This should lead to slightly more readable code going forward.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/859)
<!-- Reviewable:end -->
