### PR TITLE
Test LPC with both float32 and float64

### DIFF
--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -599,10 +599,11 @@ def __lpc(y, order):
     # we may use all the coefficients from the previous order while we compute
     # those for the new one. These two arrays hold ar_coeffs for order M and
     # order M-1.  (Corresponding to a_{M,k} and a_{M-1,k} in eqn 5)
-    ar_coeffs = np.zeros(order+1, dtype=y.dtype)
-    ar_coeffs[0] = 1
-    ar_coeffs_prev = np.zeros(order+1, dtype=y.dtype)
-    ar_coeffs_prev[0] = 1
+    dtype = y.dtype.type
+    ar_coeffs = np.zeros(order+1, dtype=dtype)
+    ar_coeffs[0] = dtype(1)
+    ar_coeffs_prev = np.zeros(order+1, dtype=dtype)
+    ar_coeffs_prev[0] = dtype(1)
 
     # These two arrays hold the forward and backward prediction error. They
     # correspond to f_{M-1,k} and b_{M-1,k} in eqns 10, 11, 13 and 14 of
@@ -622,7 +623,8 @@ def __lpc(y, order):
 
         # Eqn 15 of Marple, with fwd_pred_error and bwd_pred_error
         # corresponding to f_{M-1,k+1} and b{M-1,k} and the result as a_{M,M}
-        reflect_coeff = -2 * np.dot(bwd_pred_error, fwd_pred_error) / den
+        #reflect_coeff = dtype(-2) * np.dot(bwd_pred_error, fwd_pred_error) / dtype(den)
+        reflect_coeff = dtype(-2) * np.dot(bwd_pred_error, fwd_pred_error) / dtype(den)
 
         # Now we use the reflection coefficient and the AR coefficients from
         # the last model order to compute all of the AR coefficients for the
@@ -655,7 +657,7 @@ def __lpc(y, order):
         # fwd_pred_error = f_{M-1,k}       (we have advanced M)
         # den <- DEN_{M}                   (lhs)
         #
-        q = 1 - reflect_coeff**2
+        q = dtype(1) - reflect_coeff**2
         den = q*den - bwd_pred_error[-1]**2 - fwd_pred_error[0]**2
 
         # Shift up forward error.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -627,7 +627,7 @@ def test_lpc_regress():
                    test_data['est_coeffs'][i])
 
 
-@pytest.mark.parametrize('dtype', [np.float32, np.float64])
+@pytest.mark.parametrize('dtype', [np.float64, np.float32])
 def test_lpc_simple(dtype):
     srand()
 
@@ -636,7 +636,7 @@ def test_lpc_simple(dtype):
     truth_a = np.array([1, 0.5, 0.4, 0.3, 0.2, 0.1], dtype=dtype)
     for i in range(n):
         noise = np.random.randn(1000).astype(dtype)
-        filtered = scipy.signal.lfilter([1], truth_a, noise)
+        filtered = scipy.signal.lfilter(dtype([1]), truth_a, noise)
         est_a[i, :] = librosa.lpc(filtered, 5)
     assert dtype==est_a.dtype
     assert np.allclose(truth_a, np.mean(est_a, axis=0), rtol=0, atol=1e-3)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -627,16 +627,18 @@ def test_lpc_regress():
                    test_data['est_coeffs'][i])
 
 
-def test_lpc_simple():
+@pytest.mark.parametrize('dtype', [np.float32, np.float64])
+def test_lpc_simple(dtype):
     srand()
 
     n = 5000
-    est_a = np.zeros((n, 6))
-    truth_a = [1, 0.5, 0.4, 0.3, 0.2, 0.1]
+    est_a = np.zeros((n, 6), dtype=dtype)
+    truth_a = np.array([1, 0.5, 0.4, 0.3, 0.2, 0.1], dtype=dtype)
     for i in range(n):
-        noise = np.random.randn(1000)
+        noise = np.random.randn(1000).astype(dtype)
         filtered = scipy.signal.lfilter([1], truth_a, noise)
         est_a[i, :] = librosa.lpc(filtered, 5)
+    assert dtype==est_a.dtype
     assert np.allclose(truth_a, np.mean(est_a, axis=0), rtol=0, atol=1e-3)
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/master/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
<!-- Example: Fixes #123 -->

Adds tests for #856

#### What does this implement/fix? Explain your changes.

Adds explicit tests for single and double precision numbers for `librosa.lpc`

#### Any other comments?

I wasn't able to reproduce the issue by testing locally against Python 2.7 and 3.7.2.  (with numba 0.40.1 and 0.43.1 respectively).  Opening this PR because the tests are useful regardless and maybe the issue will surface in the CI.