### PR TITLE
resample type option added in pitch_shift()

### DIFF
--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -239,7 +239,7 @@ def time_stretch(y, rate):
     return y_stretch
 
 
-def pitch_shift(y, sr, n_steps, bins_per_octave=12, res_type='kaiser_fast'):
+def pitch_shift(y, sr, n_steps, bins_per_octave=12, res_type='kaiser_best'):
     '''Pitch-shift the waveform by `n_steps` half-steps.
 
 

--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -260,6 +260,7 @@ def pitch_shift(y, sr, n_steps, bins_per_octave=12, res_type='kaiser_fast'):
     res_type : string
         Resample type.
         Possible options: 'kaiser_best', 'kaiser_fast', and 'scipy'.
+        By default, 'kaiser_best' is used. Refer to core.resample for details.
 
     Returns
     -------
@@ -290,15 +291,13 @@ def pitch_shift(y, sr, n_steps, bins_per_octave=12, res_type='kaiser_fast'):
     ...                                          bins_per_octave=24)
     '''
 
-    if bins_per_octave < 1 or not np.issubdtype(type(bins_per_octave),
-                                                np.integer):
+    if bins_per_octave < 1 or not np.issubdtype(type(bins_per_octave), np.integer):
         raise ParameterError('bins_per_octave must be a positive integer.')
 
     rate = 2.0 ** (-float(n_steps) / bins_per_octave)
 
     # Stretch in time, then resample
-    y_shift = core.resample(time_stretch(y, rate), float(sr) / rate, sr,
-                            res_type=res_type)
+    y_shift = core.resample(time_stretch(y, rate), float(sr) / rate, sr, res_type=res_type)
 
     # Crop to the same dimension as the input
     return util.fix_length(y_shift, len(y))

--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -239,7 +239,7 @@ def time_stretch(y, rate):
     return y_stretch
 
 
-def pitch_shift(y, sr, n_steps, bins_per_octave=12):
+def pitch_shift(y, sr, n_steps, bins_per_octave=12, res_type='kaiser_fast'):
     '''Pitch-shift the waveform by `n_steps` half-steps.
 
 
@@ -257,6 +257,9 @@ def pitch_shift(y, sr, n_steps, bins_per_octave=12):
     bins_per_octave : float > 0 [scalar]
         how many steps per octave
 
+    res_type : string
+        Resample type.
+        Possible options: 'kaiser_best', 'kaiser_fast', and 'scipy'.
 
     Returns
     -------
@@ -287,13 +290,15 @@ def pitch_shift(y, sr, n_steps, bins_per_octave=12):
     ...                                          bins_per_octave=24)
     '''
 
-    if bins_per_octave < 1 or not np.issubdtype(type(bins_per_octave), np.integer):
+    if bins_per_octave < 1 or not np.issubdtype(type(bins_per_octave),
+                                                np.integer):
         raise ParameterError('bins_per_octave must be a positive integer.')
 
     rate = 2.0 ** (-float(n_steps) / bins_per_octave)
 
     # Stretch in time, then resample
-    y_shift = core.resample(time_stretch(y, rate), float(sr) / rate, sr)
+    y_shift = core.resample(time_stretch(y, rate), float(sr) / rate, sr,
+                            res_type=res_type)
 
     # Crop to the same dimension as the input
     return util.fix_length(y_shift, len(y))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/master/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
<!-- Example: Fixes #123 -->


#### What does this implement/fix? Explain your changes.
As for resampling, 'kaiser_best' can take twice as much time as 'kaiser_fast'. This can be a bottle neck in some applications where a lot of resampling calls are made. It'd be nice if this is made optional.


#### Any other comments?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/863)
<!-- Reviewable:end -->
