### PR TITLE
[CR needed] fixed #851 and #816 to add initialization and streaming support to pcen

### DIFF
--- a/docs/examples/plot_pcen_stream.py
+++ b/docs/examples/plot_pcen_stream.py
@@ -22,7 +22,7 @@ import matplotlib.pyplot as plt
 import soundfile as sf
 
 import librosa as librosa
-import librosa.display as isplay
+import librosa.display as display
 
 
 ######################################################################

--- a/docs/examples/plot_pcen_stream.py
+++ b/docs/examples/plot_pcen_stream.py
@@ -1,0 +1,130 @@
+# coding: utf-8
+# Code source: Brian McFee
+# License: ISC
+"""
+==============
+PCEN Streaming
+==============
+
+This notebook demonstrates how to use `soundfile` streaming IO with `librosa.pcen` 
+to do dynamic per-channel energy normalization on a spectrogram.
+
+This is useful when processing long audio files that are too large to load all at
+once, or when streaming data from a recording device.
+"""
+
+##################################################
+# We'll need numpy and matplotlib for this example
+from __future__ import print_function
+import numpy as np
+import matplotlib.pyplot as plt
+
+import soundfile as sf
+
+import librosa as librosa
+import librosa.display as isplay
+
+
+######################################################################
+# First, we'll start with an audio file that we want to stream
+filename = librosa.util.example_audio_file()
+
+# We can stream in blocks using soundfile
+sr = sf.info(filename).samplerate
+
+
+#####################################################################
+# Next, we'll set up the block reader to work on short segments of 
+# audio at a time.
+
+# We'll generate 16 frames at a time, each frame having 4096 samples
+# and 50% overlap.
+#
+
+n_fft = 4096
+hop_length = n_fft // 2
+
+# Note that to make sure the last frame of one batch overlaps
+# properly with the first frame of the next, we'll need to tell
+# soundfile to rewind the signal after each block by using the
+# `overlap` parameter
+
+# fill_value pads out the last frame with zeros so that we have a
+# full frame at the end of the signal, even if the signal doesn't
+# divide evenly into full frames.
+blocks = sf.blocks(filename, blocksize=n_fft + 15 * hop_length,
+                   overlap=n_fft - hop_length,
+                   fill_value=0)
+
+#####################################################################
+# For this example, we'll compute PCEN on each block, average over
+# frequency, and store the results in a list.
+
+# Make an array to store the frequency-averaged PCEN values
+pcen_blocks = []
+
+# Initialize the PCEN filter delays to steady state
+zi = None
+
+for block in blocks:
+    # downmix frame to mono (averaging out the channel dimension)
+    y = librosa.to_mono(block.T)
+
+    # Compute the STFT (without padding, so center=False)
+    D = librosa.stft(y, n_fft=n_fft, hop_length=hop_length,
+                     center=False)
+
+    # Compute PCEN on the magnitude spectrum, using initial delays
+    # returned from our previous call (if any)
+    # store the final delays for use as zi in the next iteration
+    P, zi = librosa.pcen(np.abs(D), sr=sr, hop_length=hop_length,
+                         zi=zi, return_zf=True)
+
+    # Compute the average PCEN over frequency, and append it to our list
+    pcen_blocks.extend(np.mean(P, axis=0))
+
+# Close the block reader
+blocks.close()
+
+# Cast to a numpy array for use downstream
+pcen_blocks = np.asarray(pcen_blocks)
+
+#####################################################################
+# For the sake of comparison, let's see how it would look had we 
+# run PCEN on the entire spectrum without block-wise processing
+
+y, sr = librosa.load(filename, sr=44100)
+
+# Keep the same parameters as before
+D = librosa.stft(y, n_fft=n_fft, hop_length=hop_length, center=False)
+
+# Compute pcen on the magnitude spectrum.
+# We don't need to worry about initial and final filter delays if
+# we're doing everything in one go.
+P = librosa.pcen(np.abs(D), sr=sr, hop_length=hop_length)
+
+pcen_full = np.mean(P, axis=0)
+
+#####################################################################
+# Plot the PCEN spectrum and the resulting magnitudes
+
+plt.figure()
+# First, plot the spectrum
+ax = plt.subplot(2,1,1)
+librosa.display.specshow(P, sr=sr, hop_length=hop_length, x_axis='time', y_axis='log')
+plt.title('PCEN spectrum')
+
+# Now we'll plot the pcen curves
+plt.subplot(2,1,2, sharex=ax)
+times = librosa.times_like(pcen_full, sr=sr, hop_length=hop_length)
+plt.plot(times, pcen_full, linewidth=3, alpha=0.25, label='Full signal PCEN')
+times = librosa.times_like(pcen_blocks, sr=sr, hop_length=hop_length)
+plt.plot(times, pcen_blocks, linestyle=':', label='Block-wise PCEN')
+plt.legend()
+
+# Zoom in to a short patch to see the fine details
+plt.xlim([30, 40])
+
+# render the plot
+plt.tight_layout()
+plt.show()

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1547,7 +1547,7 @@ def pcen(S, sr=22050, hop_length=512, gain=0.98, bias=2, power=0.5,
         # Make sure zi matches dimension to input
         shape = tuple([1] * ref.ndim)
         zi = np.empty(shape)
-        zi[axis] = scipy.signal.lfilter_zi([b], [1, b - 1])[:]
+        zi[:] = scipy.signal.lfilter_zi([b], [1, b - 1])[:]
 
     S_smooth, zf = scipy.signal.lfilter([b], [1, b - 1], ref, zi=zi,
                                         axis=axis)

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1544,11 +1544,10 @@ def pcen(S, sr=22050, hop_length=512, gain=0.98, bias=2, power=0.5,
             ref = scipy.ndimage.maximum_filter1d(S, max_size, axis=max_axis)
 
     if zi is None:
-        zi = scipy.signal.lfilter_zi([b], [1, b-1])
-
-    # Make sure zi matches dimension to input
-    if ref.ndim == 2:
-        zi = np.atleast_2d(zi)
+        # Make sure zi matches dimension to input
+        shape = tuple([1] * ref.ndim)
+        zi = np.empty(shape)
+        zi[axis] = scipy.signal.lfilter_zi([b], [1, b - 1])[:]
 
     S_smooth, zf = scipy.signal.lfilter([b], [1, b - 1], ref, zi=zi,
                                         axis=axis)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1537,6 +1537,25 @@ def test_pcen_ref():
     assert np.allclose(Y2, X)
 
 
+@pytest.mark.parametrize('x', [np.arange(100),
+                               np.arange(100).reshape((10, 10))])
+def test_pcen_stream(x):
+
+    if x.ndim == 1:
+        x1 = x[:20]
+        x2 = x[20:]
+    else:
+        x1 = x[:, :20]
+        x2 = x[:, 20:]
+
+    p1, zf1 = librosa.pcen(x1, return_zf=True)
+    p2, zf2 = librosa.pcen(x2, zi=zf1, return_zf=True)
+
+    pfull = librosa.pcen(x)
+
+    assert np.allclose(pfull, np.hstack([p1, p2]))
+
+
 def test_get_fftlib():
     import numpy.fft as fft
     assert librosa.get_fftlib() is fft

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1556,6 +1556,30 @@ def test_pcen_stream(x):
     assert np.allclose(pfull, np.hstack([p1, p2]))
 
 
+@pytest.mark.parametrize('axis', [0, 1, 2, -2, -1])
+def test_pcen_stream_multi(axis):
+    srand()
+
+    # Generate a random power spectrum
+    x = np.random.randn(20, 50, 60)**2
+
+    # Make slices along the target axis
+    slice1 = [slice(None)] * x.ndim
+    slice1[axis] = slice(0, 10)
+    slice2 = [slice(None)] * x.ndim
+    slice2[axis] = slice(10, None)
+
+    # Compute pcen piecewise
+    p1, zf1 = librosa.pcen(x[slice1], return_zf=True, axis=axis)
+    p2, zf2 = librosa.pcen(x[slice2], zi=zf1, return_zf=True, axis=axis)
+
+    # And the full pcen
+    pfull = librosa.pcen(x, axis=axis)
+
+    # Compare full to concatenated results
+    assert np.allclose(pfull, np.concatenate([p1, p2], axis=axis))
+
+
 def test_get_fftlib():
     import numpy.fft as fft
     assert librosa.get_fftlib() is fft


### PR DESCRIPTION
#### Reference Issue
Fixes #851 and #816 


#### What does this implement/fix? Explain your changes.

A bug-fix to initialize (by default) the lfilter `zi` to steady-state.

New features: `return_zf` flag to optionally return the final state of the filter, for use as `zi` in a subsequent call to `pcen`.  Also exposing `zi` as a parameter which overrides the steady-state initialization above.

#### Any other comments?

There is a basic unit test that checks the results of this API on a split input against processing the entire input at once, and things line up.  I think that's sufficient for testing here.

I'm a little unsatisfied by some shape hacking I had to do to get the `lfilter_zi` output to line up with multi-dimensional input, and I suspect it won't work for higher-dimensional input (eg stereo tf representations).  If there's a nice way to reshape this automagically according to the input shape, I'm all ears.

Other than that, I think this is good to go.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/864)
<!-- Reviewable:end -->
