### PR TITLE
Added ref parameter to piptrack

### DIFF
--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -4,6 +4,7 @@
 
 import warnings
 import numpy as np
+import six
 
 from .spectrum import _spectrogram
 from . import time_frequency
@@ -165,7 +166,8 @@ def pitch_tuning(frequencies, resolution=0.01, bins_per_octave=12):
 @cache(level=30)
 def piptrack(y=None, sr=22050, S=None, n_fft=2048, hop_length=None,
              fmin=150.0, fmax=4000.0, threshold=0.1,
-             win_length=None, window='hann', center=True, pad_mode='reflect'):
+             win_length=None, window='hann', center=True, pad_mode='reflect',
+             ref=None):
     '''Pitch tracking on thresholded parabolically-interpolated STFT.
 
     This implementation uses the parabolic interpolation method described by [1]_.
@@ -190,8 +192,11 @@ def piptrack(y=None, sr=22050, S=None, n_fft=2048, hop_length=None,
         number of samples to hop
 
     threshold : float in `(0, 1)`
-        A bin in spectrum X is considered a pitch when it is greater than
-        `threshold*X.max()`
+        A bin in spectrum `S` is considered a pitch when it is greater than
+        `threshold*ref(S)`.
+
+        By default, `ref(S)` is taken to be `max(S, axis=0)` (the maximum value in
+        each column).
 
     fmin : float > 0 [scalar]
         lower frequency cutoff.
@@ -223,6 +228,11 @@ def piptrack(y=None, sr=22050, S=None, n_fft=2048, hop_length=None,
         If `center=True`, the padding mode to use at the edges of the signal.
         By default, STFT uses reflection padding.
 
+    ref : scalar or callable [default=np.max]
+        If scalar, the reference value against which `S` is compared for determining
+        pitches.
+
+        If callable, the reference value is computed as `ref(S, axis=0)`.
 
     .. note::
         One of `S` or `y` must be provided.
@@ -250,8 +260,21 @@ def piptrack(y=None, sr=22050, S=None, n_fft=2048, hop_length=None,
 
     Examples
     --------
+    Computing pitches from a waveform input
+
     >>> y, sr = librosa.load(librosa.util.example_audio_file())
     >>> pitches, magnitudes = librosa.piptrack(y=y, sr=sr)
+
+    Or from a spectrogram input
+
+    >>> S = np.abs(librosa.stft(y))
+    >>> pitches, magnitudes = librosa.piptrack(S=S, sr=sr)
+
+    Or with an alternate reference value for pitch detection, where
+    values above the mean spectral energy in each frame are counted as pitches
+
+    >>> pitches, magnitudes = librosa.piptrack(S=S, sr=sr, threshold=1,
+    ...                                        ref=np.mean)
 
     '''
 
@@ -295,8 +318,15 @@ def piptrack(y=None, sr=22050, S=None, n_fft=2048, hop_length=None,
 
     # Compute the column-wise local max of S after thresholding
     # Find the argmax coordinates
-    idx = np.argwhere(freq_mask &
-                      util.localmax(S * (S > (threshold * S.max(axis=0)))))
+    if ref is None:
+        ref = np.max
+
+    if six.callable(ref):
+        ref_value = threshold * ref(S, axis=0)
+    else:
+        ref_value = np.abs(ref)
+
+    idx = np.argwhere(freq_mask & util.localmax(S * (S > ref_value)))
 
     # Store pitch and magnitude
     pitches[idx[:, 0], idx[:, 1]] = ((idx[:, 0] + shift[idx[:, 0], idx[:, 1]])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -710,14 +710,15 @@ def test_pitch_tuning():
 
 def test_piptrack_properties():
 
-    def __test(S, n_fft, hop_length, fmin, fmax, threshold):
+    def __test(S, n_fft, hop_length, fmin, fmax, threshold, ref):
 
         pitches, mags = librosa.core.piptrack(S=S,
                                               n_fft=n_fft,
                                               hop_length=hop_length,
                                               fmin=fmin,
                                               fmax=fmax,
-                                              threshold=threshold)
+                                              threshold=threshold,
+                                              ref=ref)
 
         # Shape tests
         assert S.shape == pitches.shape
@@ -742,7 +743,8 @@ def test_piptrack_properties():
             for fmin in [0, 100]:
                 for fmax in [4000, 8000, sr // 2]:
                     for threshold in [0.1, 0.2, 0.5]:
-                        yield __test, S, n_fft, hop_length, fmin, fmax, threshold
+                        for ref in [None, 1.0, np.max]:
+                            yield __test, S, n_fft, hop_length, fmin, fmax, threshold, ref
 
 
 def test_piptrack_errors():


### PR DESCRIPTION
#### Reference Issue
Fixes #776 


#### What does this implement/fix? Explain your changes.

This PR adds a new parameter `ref=` to `piptrack()`, allowing users to override the reference thresholding behavior for determining which bins correspond to pitches.

The logic is as follows:

- By default, previous behavior is retained.  pitches are detected whenever `S >= threshold * max(S, axis=0)`
- If `ref` is a callable, then the above generalizes to `S >= threshold * ref(S, axis=0)`.
- If `ref` is a scalar, then the comparison is done directly on magnitudes, bypassing the threshold: `S >= abs(ref)`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/867)
<!-- Reviewable:end -->
