### PR TITLE
fix: dtw(C=C,subseq=True) doesn't work

### DIFF
--- a/librosa/sequence.py
+++ b/librosa/sequence.py
@@ -226,7 +226,7 @@ def dtw(X=None, Y=None, C=None, metric='euclidean', step_sizes_sigma=None,
         wp = np.asarray(wp, dtype=int)
 
         # since we transposed in the beginning, we have to adjust the index pairs back
-        if subseq and (X.shape[1] > Y.shape[1]):
+        if subseq and (C.shape[0] > C.shape[1]):
             wp = np.fliplr(wp)
 
         return D, wp

--- a/tests/test_dtw.py
+++ b/tests/test_dtw.py
@@ -140,6 +140,18 @@ def test_dtw_subseq():
     assert np.array_equal(X, mut_X)
 
 
+def test_dtw_subseq_supplied_distance_matrix():
+    X = np.array([[0], [1], [2]])
+    Y = np.array([[1], [2], [3], [4]])
+    C = cdist(X, Y)
+
+    costs0, path0 = librosa.sequence.dtw(X.T, Y.T, subseq=True)
+    costs1, path1 = librosa.sequence.dtw(C=C, subseq=True)
+
+    assert np.array_equal(costs0, costs1)
+    assert np.array_equal(path1, path1)
+
+
 def test_dtw_subseq_sym():
     Y = np.array([10., 10., 0., 1., 2., 3., 10., 10.])
     X = np.arange(4)

--- a/tests/test_dtw.py
+++ b/tests/test_dtw.py
@@ -149,7 +149,7 @@ def test_dtw_subseq_supplied_distance_matrix():
     costs1, path1 = librosa.sequence.dtw(C=C, subseq=True)
 
     assert np.array_equal(costs0, costs1)
-    assert np.array_equal(path1, path1)
+    assert np.array_equal(path0, path1)
 
 
 def test_dtw_subseq_sym():


### PR DESCRIPTION
#### Reference Issue
Fixes https://github.com/librosa/librosa/issues/869

#### What does this implement/fix? Explain your changes.

Just get dimensions from C ndarray (which is always computed anyway), not from X and Y (thous are optional).

