### PR TITLE
fixed #862 and #830, removed deprecations

### DIFF
--- a/docs/cache.rst
+++ b/docs/cache.rst
@@ -57,7 +57,7 @@ As a result, application code may run faster at the expense of larger disk usage
 
 The caching levels are described as follows:
 
-    - 10: filter bases, independent of audio data (dct, mel, chroma, constant-q)
+    - 10: filter bases, independent of audio data (mel, chroma, constant-q)
     - 20: low-level features (cqt, stft, zero-crossings, etc)
     - 30: high-level features (tempo, beats, decomposition, recurrence, etc)
     - 40: post-processing (delta, stack_memory, normalize, sync)

--- a/librosa/core/__init__.py
+++ b/librosa/core/__init__.py
@@ -100,14 +100,6 @@ Pitch and tuning
     estimate_tuning
     pitch_tuning
     piptrack
-
-Deprecated (moved)
-------------------
-.. autosummary::
-    :toctree: generated/
-
-    dtw
-    fill_off_diagonal
 """
 
 from .time_frequency import *  # pylint: disable=wildcard-import
@@ -118,11 +110,5 @@ from .constantq import *  # pylint: disable=wildcard-import
 from .harmonic import *  # pylint: disable=wildcard-import
 from .fft import *  # pylint: disable=wildcard-import
 
-from ..util.decorators import moved as _moved
-from ..util import fill_off_diagonal as _fod
-from ..sequence import dtw as _dtw
-
-dtw = _moved('librosa.sequence.dtw', '0.6.1', '0.7')(_dtw)
-fill_off_diagonal = _moved('librosa.util.fill_off_diagonal', '0.6.1', '0.7')(_fod)
 
 __all__ = [_ for _ in dir() if not _.startswith('_')]

--- a/librosa/feature/__init__.py
+++ b/librosa/feature/__init__.py
@@ -16,7 +16,6 @@ Spectral features
     melspectrogram
     mfcc
     rms
-    rmse
     spectral_centroid
     spectral_bandwidth
     spectral_contrast

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -10,7 +10,6 @@ import scipy.fftpack
 from .. import util
 from .. import filters
 from ..util.exceptions import ParameterError
-from ..util.decorators import moved
 
 from ..core.time_frequency import fft_frequencies
 from ..core.audio import zero_crossings, to_mono
@@ -26,7 +25,6 @@ __all__ = ['spectral_centroid',
            'spectral_flatness',
            'poly_features',
            'rms',
-           'rmse',
            'zero_crossing_rate',
            'chroma_stft',
            'chroma_cqt',
@@ -828,9 +826,6 @@ def rms(y=None, S=None, frame_length=2048, hop_length=512,
     else:
         raise ValueError('Either `y` or `S` must be input.')
     return np.sqrt(np.mean(np.abs(x)**2, axis=0, keepdims=True))
-
-
-rmse = moved('librosa.feature.rmse', '0.6.3', '0.7.0')(rms)
 
 
 def poly_features(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,

--- a/librosa/feature/utils.py
+++ b/librosa/feature/utils.py
@@ -8,12 +8,11 @@ import scipy.signal
 
 from .._cache import cache
 from ..util.exceptions import ParameterError
-from ..util.deprecation import Deprecated
 __all__ = ['delta', 'stack_memory']
 
 
 @cache(level=40)
-def delta(data, width=9, order=1, axis=-1, trim=Deprecated(), mode='interp', **kwargs):
+def delta(data, width=9, order=1, axis=-1, mode='interp', **kwargs):
     r'''Compute delta features: local estimate of the derivative
     of the input data along the selected axis.
 
@@ -36,10 +35,6 @@ def delta(data, width=9, order=1, axis=-1, trim=Deprecated(), mode='interp', **k
     axis      : int [scalar]
         the axis along which to compute deltas.
         Default is -1 (columns).
-
-    trim      : bool [DEPRECATED]
-        This parameter is deprecated in 0.6.0 and will be removed
-        in 0.7.0.
 
     mode : str, {'interp', 'nearest', 'mirror', 'constant', 'wrap'}
         Padding mode for estimating differences at the boundaries.
@@ -98,10 +93,6 @@ def delta(data, width=9, order=1, axis=-1, trim=Deprecated(), mode='interp', **k
     >>> plt.tight_layout()
 
     '''
-    if not isinstance(trim, Deprecated):
-        warn('The `trim` parameter to `delta` is deprecated in librosa 0.6.0.'
-             'It will be removed in 0.7.0.',
-             DeprecationWarning)
 
     data = np.atleast_1d(data)
 

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -33,13 +33,6 @@ Miscellaneous
     mr_frequencies
     window_sumsquare
     diagonal_filter
-
-Deprecated
-----------
-.. autosummary::
-    :toctree: generated/
-
-    dct
 """
 import warnings
 
@@ -54,13 +47,11 @@ from numba import jit
 from ._cache import cache
 from . import util
 from .util.exceptions import ParameterError
-from .util.decorators import deprecated
 
 from .core.time_frequency import note_to_hz, hz_to_midi, midi_to_hz, hz_to_octs
 from .core.time_frequency import fft_frequencies, mel_frequencies
 
-__all__ = ['dct',
-           'mel',
+__all__ = ['mel',
            'chroma',
            'constant_q',
            'constant_q_lengths',
@@ -115,67 +106,6 @@ WINDOW_BANDWIDTHS = {'bart': 1.3334961334912805,
                      'tri': 1.3331706523555851,
                      'triang': 1.3331706523555851,
                      'triangle': 1.3331706523555851}
-
-
-@deprecated('0.6.1', '0.7.0')
-def dct(n_filters, n_input):
-    """Discrete cosine transform (DCT type-II, normalized) basis.
-
-    .. [1] http://en.wikipedia.org/wiki/Discrete_cosine_transform
-
-    .. warning:: This function is deprecated in librosa 0.6.1. It will
-        be removed in 0.7.0.
-
-    Parameters
-    ----------
-    n_filters : int > 0 [scalar]
-        number of output components (DCT filters)
-
-    n_input : int > 0 [scalar]
-        number of input components (frequency bins)
-
-    Returns
-    -------
-    dct_basis: np.ndarray [shape=(n_filters, n_input)]
-        DCT (type-II) basis vectors [1]_
-
-    Notes
-    -----
-    This function caches at level 10.
-
-    See Also
-    --------
-    scipy.fftpack.dct
-
-    Examples
-    --------
-    >>> n_fft = 2048
-    >>> dct_filters = librosa.filters.dct(13, 1 + n_fft // 2)
-    >>> dct_filters
-    array([[ 0.031,  0.031, ...,  0.031,  0.031],
-           [ 0.044,  0.044, ..., -0.044, -0.044],
-           ...,
-           [ 0.044,  0.044, ..., -0.044, -0.044],
-           [ 0.044,  0.044, ...,  0.044,  0.044]])
-
-    >>> import matplotlib.pyplot as plt
-    >>> plt.figure()
-    >>> librosa.display.specshow(dct_filters, x_axis='linear')
-    >>> plt.ylabel('DCT function')
-    >>> plt.title('DCT filter bank')
-    >>> plt.colorbar()
-    >>> plt.tight_layout()
-    """
-
-    basis = np.empty((n_filters, n_input))
-    basis[0, :] = 1.0 / np.sqrt(n_input)
-
-    samples = np.arange(1, 2*n_input, 2) * np.pi / (2.0 * n_input)
-
-    for i in range(1, n_filters):
-        basis[i, :] = np.cos(i*samples) * np.sqrt(2.0/n_input)
-
-    return basis
 
 
 @cache(level=10)

--- a/librosa/version.py
+++ b/librosa/version.py
@@ -35,6 +35,7 @@ def show_versions():
                  'joblib',
                  'decorator',
                  'six',
+                 'soundfile',
                  'resampy',
                  'numba']
 


### PR DESCRIPTION
#### Reference Issue
Fixes #862 and #830 


#### What does this implement/fix? Explain your changes.

- Removes deprecation shims slated for removal in 0.7:
   - DTW functionality in core
   - `dct` filter basis
   - `trim` parameter in `delta`
   - `rmse` --> `rms`
- Updates `show_versions` to include `soundfile`

No CR needed on this one.  I'll merge when CI passes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librosa/librosa/870)
<!-- Reviewable:end -->
