### PR TITLE
Stream generator

### DIFF
--- a/docs/examples/plot_pcen_stream.py
+++ b/docs/examples/plot_pcen_stream.py
@@ -43,11 +43,13 @@ hop_length = n_fft // 2
 # fill_value pads out the last frame with zeros so that we have a
 # full frame at the end of the signal, even if the signal doesn't
 # divide evenly into full frames.
-blocks, sr = librosa.stream(filename, block_length=16,
-                            frame_length=n_fft,
-                            hop_length=hop_length,
-                            mono=True,
-                            fill_value=0)
+sr = librosa.get_samplerate(filename)
+
+stream = librosa.stream(filename, block_length=16,
+                        frame_length=n_fft,
+                        hop_length=hop_length,
+                        mono=True,
+                        fill_value=0)
 #####################################################################
 # For this example, we'll compute PCEN on each block, average over
 # frequency, and store the results in a list.
@@ -58,7 +60,7 @@ pcen_blocks = []
 # Initialize the PCEN filter delays to steady state
 zi = None
 
-for y_block in blocks:
+for y_block in stream:
     # Compute the STFT (without padding, so center=False)
     D = librosa.stft(y_block, n_fft=n_fft, hop_length=hop_length,
                      center=False)
@@ -71,9 +73,6 @@ for y_block in blocks:
 
     # Compute the average PCEN over frequency, and append it to our list
     pcen_blocks.extend(np.mean(P, axis=0))
-
-# Close the block reader
-blocks.close()
 
 # Cast to a numpy array for use downstream
 pcen_blocks = np.asarray(pcen_blocks)

--- a/docs/ioformats.rst
+++ b/docs/ioformats.rst
@@ -15,7 +15,7 @@ For a list of codecs supported by `soundfile`, see the *libsndfile* `documentati
 
 Librosa's load function is meant for the common case where you want to load an entire (fragment of a) recording into memory, but some applications require more flexibility.
 In these cases, we recommend using `soundfile` directly.
-Reading audio files using `soundfile` is similar to the method in *librosa*. One important difference is that the read data is of shape ``(nb_samples, nb_channels)`` compared to ``(nb_channels, nb_samples)`` in :func:`<librosa.core.load>`. Also the signal is not resampled to 22050 Hz by default, hence it would need be transposed and resampled for further processing in *librosa*. The following example is equivalent to ``librosa.load(librosa.util.example_audio_file())``:
+Reading audio files using `soundfile` is similar to the method in *librosa*. One important difference is that the read data is of shape ``(nb_samples, nb_channels)`` compared to ``(nb_channels, nb_samples)`` in :func:`librosa.core.load`. Also the signal is not resampled to 22050 Hz by default, hence it would need be transposed and resampled for further processing in *librosa*. The following example is equivalent to ``librosa.load(librosa.util.example_audio_file())``:
 
 .. code-block:: python
     :linenos:
@@ -35,34 +35,54 @@ Blockwise Reading
 -----------------
 
 For large audio signals it could be beneficial to not load the whole audio file
-into memory. *PySoundFile* supports blockwise reading. In the following example
-a block of 1024 samples of audio are read and directly fed into the chroma
-feature extractor.
+into memory.  Librosa 0.7 introduces a streaming interface, which can be used to
+work on short fragments of audio sequentially.  :func:`librosa.core.stream` cuts an input
+file into *blocks* of audio, which correspond to a given number of *frames*,
+which can be iterated over as in the following example:
+
 
 .. code-block:: python
-    :linenos:
+   :linenos:
 
-    import numpy as np
-    import soundfile as sf
-    from librosa.feature import chroma_stft
+   import librosa
 
-    block_gen = sf.blocks('stereo_file.wav', blocksize=1024)
-    rate = sf.info('stereo_file.wav').samplerate
+   sr = librosa.get_samplerate('/path/to/file.wav')
 
-    chromas = []
-    for bl in block_gen:
-        # downmix frame to mono (averaging out the channel dimension)
-        y=np.mean(bl, axis=1)
-        # compute chroma feature
-        chromas.append(chroma_stft(y, sr=rate))
+   # Set the frame parameters to be equivalent to the librosa defaults
+   # in the file's native sampling rate
+   frame_length = (2048 * sr) // 22050
+   hop_length = (512 * sr) // 22050
 
+   # Stream the data, working on 128 frames at a time
+   stream = librosa.stream('path/to/file.wav',
+                           block_length=128,
+                           frame_length=frame_length,
+                           hop_length=hop_length)
+
+   chromas = []
+   for y in stream:
+      chroma_block = librosa.feature.chroma_stft(y=y, sr=sr,
+                                                 n_fft=frame_length,
+                                                 hop_length=hop_length,
+                                                 center=False)
+      chromas.append(chromas)
+                                                
+
+In this example, each audio fragment ``y`` will consist of 128 frames worth of samples,
+or more specifically, ``len(y) == frame_length + (block_length - 1) * hop_length``.
+Each fragment ``y`` will overlap with the subsequent fragment by ``frame_length - hop_length``
+samples, which ensures that stream processing will provide equivalent results to if the entire
+sequence was processed in one step (assuming padding / centering is disabled).
+
+For more details about the streaming interface, refer to :func:`librosa.core.stream`.
 
 
 Read file-like objects
 ----------------------
 
 If you want to read audio from file-like objects (also called *virtual files*)
-you can use `soundfile` as well.  (This will also work with `librosa.load`, provided that the underlying codec is supported by `soundfile`.)
+you can use `soundfile` as well.  (This will also work with :func:`librosa.core.load` and :func:`librosa.core.stream`, provided
+that the underlying codec is supported by `soundfile`.)
 
 E.g.: read files from zip compressed archives:
 

--- a/librosa/core/__init__.py
+++ b/librosa/core/__init__.py
@@ -75,6 +75,10 @@ Time and frequency conversion
     time_to_frames
     time_to_samples
 
+    blocks_to_frames
+    blocks_to_samples
+    blocks_to_time
+
     hz_to_note
     hz_to_midi
     midi_to_hz

--- a/librosa/core/__init__.py
+++ b/librosa/core/__init__.py
@@ -14,6 +14,7 @@ Audio processing
     to_mono
     resample
     get_duration
+    get_samplerate
     autocorrelate
     lpc
     zero_crossings

--- a/librosa/core/__init__.py
+++ b/librosa/core/__init__.py
@@ -10,6 +10,7 @@ Audio processing
     :toctree: generated/
 
     load
+    stream
     to_mono
     resample
     get_duration

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -300,13 +300,11 @@ def stream(path, block_length, frame_length, hop_length,
     dtype : numeric type
         data type of audio buffers to be produced
 
-    Returns
-    -------
-    stream : generator
-        A generator which produces blocks of audio.
-
-    sr : number > 0
-        The sampling rate of the audio
+    Yields
+    ------
+    y : np.ndarray
+        An audio buffer of (at most) 
+        `block_length * (hop_length-1) + frame_length` samples.
 
     See Also
     --------
@@ -320,20 +318,24 @@ def stream(path, block_length, frame_length, hop_length,
     at a time.  Note that streaming operation requires left-aligned
     frames, so we must set `center=False` to avoid padding artifacts.
 
-    >>> stream, sr = librosa.stream(librosa.util.example_audio_file(),
-    ...                             block_length=256,
-    ...                             frame_length=4096,
-    ...                             hop_length=1024)
+    >>> filename = librosa.util.example_audio_file()
+    >>> sr = librosa.get_samplerate(filename)
+    >>> stream librosa.stream(filename,
+    ...                       block_length=256,
+    ...                       frame_length=4096,
+    ...                       hop_length=1024)
     >>> for y_block in stream:
     ...     D_block = librosa.stft(y_block, center=False)
 
     Or compute a mel spectrogram over a stream, using a shorter frame
     and non-overlapping windows
 
-    >>> stream, sr = librosa.stream(librosa.util.example_audio_file(),
-    ...                             block_length=256,
-    ...                             frame_length=2048,
-    ...                             hop_length=2048)
+    >>> filename = librosa.util.example_audio_file()
+    >>> sr = librosa.get_samplerate(filename)
+    >>> stream = librosa.stream(filename,
+    ...                         block_length=256,
+    ...                         frame_length=2048,
+    ...                         hop_length=2048)
     >>> for y_block in stream:
     ...     m_block = librosa.feature.melspectrogram(y_block, sr=sr,
     ...                                              n_fft=2048,
@@ -353,16 +355,6 @@ def stream(path, block_length, frame_length, hop_length,
     sr = sf.info(path).samplerate
 
     # Construct the stream
-    block_stream = __stream(path, sr, block_length, frame_length, hop_length,
-                            mono, offset, duration, fill_value, dtype)
-
-    return block_stream, sr
-
-
-def __stream(path, sr, block_length, frame_length, hop_length,
-             mono, offset, duration, fill_value, dtype):
-    '''Private function for wrapping sf.blocks in a librosa interface.'''
-
     if offset:
         start = int(offset * sr)
     else:

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -324,6 +324,9 @@ def stream(path, block_length, frame_length=2048, hop_length=512,
 
     '''
 
+    if not (isinstance(block_length, int) and block_length > 0):
+        raise ParameterError('block_length={} must be a positive integer')
+
     # Get the sample rate from the file info
     sr = sf.info(path).samplerate
 

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -344,11 +344,11 @@ def stream(path, block_length, frame_length, hop_length,
 
     '''
 
-    if not (isinstance(block_length, int) and block_length > 0):
+    if not (np.issubdtype(type(block_length), np.integer) and block_length > 0):
         raise ParameterError('block_length={} must be a positive integer')
-    if not (isinstance(frame_length, int) and frame_length > 0):
+    if not (np.issubdtype(type(frame_length), np.integer) and frame_length > 0):
         raise ParameterError('frame_length={} must be a positive integer')
-    if not (isinstance(hop_length, int) and hop_length > 0):
+    if not (np.issubdtype(type(hop_length), np.integer) and hop_length > 0):
         raise ParameterError('hop_length={} must be a positive integer')
 
     # Get the sample rate from the file info

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -326,6 +326,10 @@ def stream(path, block_length, frame_length=2048, hop_length=512,
 
     if not (isinstance(block_length, int) and block_length > 0):
         raise ParameterError('block_length={} must be a positive integer')
+    if not (isinstance(frame_length, int) and frame_length > 0):
+        raise ParameterError('frame_length={} must be a positive integer')
+    if not (isinstance(hop_length, int) and hop_length > 0):
+        raise ParameterError('hop_length={} must be a positive integer')
 
     # Get the sample rate from the file info
     sr = sf.info(path).samplerate

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -18,7 +18,8 @@ from .._cache import cache
 from .. import util
 from ..util.exceptions import ParameterError
 
-__all__ = ['load', 'stream', 'to_mono', 'resample', 'get_duration',
+__all__ = ['load', 'stream', 'to_mono', 'resample',
+           'get_duration', 'get_samplerate',
            'autocorrelate', 'lpc', 'zero_crossings',
            'clicks', 'tone', 'chirp']
 
@@ -353,6 +354,7 @@ def __stream(path, sr, block_length, frame_length, hop_length,
                        fill_value=fill_value,
                        start=start,
                        frames=frames,
+                       dtype=dtype,
                        always_2d=False)
 
     for block in blocks:
@@ -568,6 +570,9 @@ def get_duration(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
         and is therefore useful for querying the duration of
         long files.
 
+        As in `load()`, this can also be an integer or open file-handle
+        that can be processed by `soundfile`.
+
     Returns
     -------
     d : float >= 0
@@ -590,7 +595,7 @@ def get_duration(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
     if filename is not None:
         try:
             return sf.info(filename).duration
-        except:
+        except RuntimeError:
             with audioread.audio_open(filename) as fdesc:
                 return fdesc.duration
 
@@ -614,6 +619,37 @@ def get_duration(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
             n_samples = y.shape[-1]
 
     return float(n_samples) / sr
+
+
+def get_samplerate(path):
+    '''Get the sampling rate for a given file.
+
+    Parameters
+    ----------
+    path : string, int, or file-like
+        The path to the file to be loaded
+        As in `load()`, this can also be an integer or open file-handle
+        that can be processed by `soundfile`.
+
+    Returns
+    -------
+    sr : number > 0
+        The sampling rate of the given audio file
+
+    Examples
+    --------
+    Get the sampling rate for the included audio file
+
+    >>> path = librosa.util.example_audio_file()
+    >>> librosa.get_samplerate(path)
+    44100
+    '''
+    try:
+        return sf.info(path).samplerate
+    except RuntimeError:
+        with audioread.audio_open(path) as fdesc:
+            return fdesc.samplerate
+
 
 @cache(level=20)
 def autocorrelate(y, max_size=None, axis=-1):

--- a/librosa/core/time_frequency.py
+++ b/librosa/core/time_frequency.py
@@ -12,6 +12,8 @@ from ..util.exceptions import ParameterError
 __all__ = ['frames_to_samples', 'frames_to_time',
            'samples_to_frames', 'samples_to_time',
            'time_to_samples', 'time_to_frames',
+           'blocks_to_samples', 'blocks_to_frames',
+           'blocks_to_time',
            'note_to_hz', 'note_to_midi',
            'midi_to_hz', 'midi_to_note',
            'hz_to_note', 'hz_to_midi',
@@ -254,7 +256,7 @@ def samples_to_time(samples, sr=22050):
 
     Returns
     -------
-    times : np.ndarray [shape=samples.shape, dtype=int]
+    times : np.ndarray [shape=samples.shape]
         Time values corresponding to `samples` (in seconds)
 
     See Also
@@ -277,6 +279,136 @@ def samples_to_time(samples, sr=22050):
     '''
 
     return np.asanyarray(samples) / float(sr)
+
+
+def blocks_to_frames(blocks, block_length):
+    '''Convert block indices to frame indices
+
+    Parameters
+    ----------
+    blocks : np.ndarray
+        Block index or array of block indices
+
+    block_length : int > 0
+        The number of frames per block
+
+    Returns
+    -------
+    frames : np.ndarray [shape=samples.shape, dtype=int]
+        The index or indices of frames corresponding to the beginning
+        of each provided block.
+
+    See Also
+    --------
+    blocks_to_samples
+    blocks_to_time
+
+    Examples
+    --------
+    Get frame indices for each block in a stream
+
+    >>> filename = librosa.util.example_audio_file()
+    >>> sr = librosa.get_samplerate(filename)
+    >>> stream = librosa.stream(filename, block_length=16, 
+    ...                         frame_length=2048, hop_length=512)
+    >>> for n, y in enumerate(stream):
+    ...     n_frame = librosa.blocks_to_frames(n, block_length=16)
+
+    '''
+    return block_length * np.asanyarray(blocks)
+
+
+def blocks_to_samples(blocks, block_length, hop_length):
+    '''Convert block indices to sample indices
+
+    Parameters
+    ----------
+    blocks : np.ndarray
+        Block index or array of block indices
+
+    block_length : int > 0
+        The number of frames per block
+
+    hop_length : int > 0
+        The number of samples to advance between frames
+
+    Returns
+    -------
+    samples : np.ndarray [shape=samples.shape, dtype=int]
+        The index or indices of samples corresponding to the beginning
+        of each provided block.
+
+        Note that these correspond to the *first* sample index in
+        each block, and are not frame-centered.
+
+    See Also
+    --------
+    blocks_to_frames
+    blocks_to_time
+
+    Examples
+    --------
+    Get sample indices for each block in a stream
+
+    >>> filename = librosa.util.example_audio_file()
+    >>> sr = librosa.get_samplerate(filename)
+    >>> stream = librosa.stream(filename, block_length=16, 
+    ...                         frame_length=2048, hop_length=512)
+    >>> for n, y in enumerate(stream):
+    ...     n_sample = librosa.blocks_to_samples(n, block_length=16,
+    ...                                          hop_length=512)
+
+    '''
+    frames = blocks_to_frames(blocks, block_length)
+    return frames_to_samples(frames, hop_length=hop_length)
+
+
+def blocks_to_time(blocks, block_length, hop_length, sr):
+    '''Convert block indices to time (in seconds)
+
+    Parameters
+    ----------
+    blocks : np.ndarray
+        Block index or array of block indices
+
+    block_length : int > 0
+        The number of frames per block
+
+    hop_length : int > 0
+        The number of samples to advance between frames
+
+    sr : int > 0
+        The sampling rate (samples per second)
+
+    Returns
+    -------
+    times : np.ndarray [shape=samples.shape]
+        The time index or indices (in seconds) corresponding to the 
+        beginning of each provided block.
+
+        Note that these correspond to the time of the *first* sample 
+        in each block, and are not frame-centered.
+
+    See Also
+    --------
+    blocks_to_frames
+    blocks_to_samples
+
+    Examples
+    --------
+    Get time indices for each block in a stream
+
+    >>> filename = librosa.util.example_audio_file()
+    >>> sr = librosa.get_samplerate(filename)
+    >>> stream = librosa.stream(filename, block_length=16, 
+    ...                         frame_length=2048, hop_length=512)
+    >>> for n, y in enumerate(stream):
+    ...     n_time = librosa.blocks_to_time(n, block_length=16,
+    ...                                     hop_length=512, sr=sr)
+
+    '''
+    samples = blocks_to_samples(blocks, block_length, hop_length)
+    return samples_to_time(samples, sr=sr)
 
 
 def note_to_hz(note, **kwargs):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1671,11 +1671,11 @@ def test_get_samplerate(ext):
     assert sr == 22050
 
 
-@pytest.mark.parametrize('block_length', [10, 30,
+@pytest.mark.parametrize('block_length', [10, np.int64(30),
                                           pytest.mark.xfail(0, raises=librosa.ParameterError)])
-@pytest.mark.parametrize('frame_length', [1024, 2048,
+@pytest.mark.parametrize('frame_length', [1024, np.int64(2048),
                                           pytest.mark.xfail(0, raises=librosa.ParameterError)])
-@pytest.mark.parametrize('hop_length', [512, 1024,
+@pytest.mark.parametrize('hop_length', [512, np.int64(1024),
                                           pytest.mark.xfail(0, raises=librosa.ParameterError)])
 @pytest.mark.parametrize('mono', [False, True])
 @pytest.mark.parametrize('offset', [0.0, 2.0])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1661,3 +1661,11 @@ def test_griffinlim_momentum_warn():
         librosa.griffinlim(x, momentum=2)
 
 
+@pytest.mark.parametrize('ext', ['wav', 'mp3'])
+def test_get_samplerate(ext):
+
+    path = os.path.join('tests', 'data',
+                        os.path.extsep.join(['test1_22050', ext]))
+
+    sr = librosa.get_samplerate(path)
+    assert sr == 22050

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1671,9 +1671,12 @@ def test_get_samplerate(ext):
     assert sr == 22050
 
 
-@pytest.mark.parametrize('block_length', [10, 30])
-@pytest.mark.parametrize('frame_length', [1024, 2048])
-@pytest.mark.parametrize('hop_length', [512, 1024])
+@pytest.mark.parametrize('block_length', [10, 30,
+                                          pytest.mark.xfail(0, raises=librosa.ParameterError)])
+@pytest.mark.parametrize('frame_length', [1024, 2048,
+                                          pytest.mark.xfail(0, raises=librosa.ParameterError)])
+@pytest.mark.parametrize('hop_length', [512, 1024,
+                                          pytest.mark.xfail(0, raises=librosa.ParameterError)])
 @pytest.mark.parametrize('mono', [False, True])
 @pytest.mark.parametrize('offset', [0.0, 2.0])
 @pytest.mark.parametrize('duration', [None, 1.0])
@@ -1685,11 +1688,6 @@ def test_stream(block_length, frame_length, hop_length, mono, offset,
     # test data is stereo, int 16
     path = os.path.join('tests', 'data', 'test1_22050.wav')
 
-    # First, load the reference data.
-    # We'll cast to mono here to simplify checking
-    y_full, sr = librosa.load(path, sr=None, dtype=dtype, mono=True,
-                              offset=offset, duration=duration)
-
     blocks, sr_stream = librosa.stream(path, block_length=block_length,
                                        frame_length=frame_length,
                                        hop_length=hop_length,
@@ -1697,12 +1695,7 @@ def test_stream(block_length, frame_length, hop_length, mono, offset,
                                        offset=offset, duration=duration,
                                        fill_value=fill_value)
 
-    # First, check the rate
-    assert sr == sr_stream
-
     y_frame_stream = []
-    y_frame = librosa.util.frame(y_full, frame_length, hop_length)
-
     target_length = frame_length + (block_length - 1) * hop_length
 
     for y_block in blocks:
@@ -1730,6 +1723,15 @@ def test_stream(block_length, frame_length, hop_length, mono, offset,
 
     # Concatenate the framed blocks together
     y_frame_stream = np.concatenate(y_frame_stream, axis=1)
+
+    # Load the reference data.
+    # We'll cast to mono here to simplify checking
+
+    y_full, sr = librosa.load(path, sr=None, dtype=dtype, mono=True,
+                              offset=offset, duration=duration)
+    # First, check the rate
+    assert sr == sr_stream
+    y_frame = librosa.util.frame(y_full, frame_length, hop_length)
 
     # Raw audio will not be padded
     n = y_frame.shape[1]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1688,17 +1688,17 @@ def test_stream(block_length, frame_length, hop_length, mono, offset,
     # test data is stereo, int 16
     path = os.path.join('tests', 'data', 'test1_22050.wav')
 
-    blocks, sr_stream = librosa.stream(path, block_length=block_length,
-                                       frame_length=frame_length,
-                                       hop_length=hop_length,
-                                       dtype=dtype, mono=mono,
-                                       offset=offset, duration=duration,
-                                       fill_value=fill_value)
+    stream = librosa.stream(path, block_length=block_length,
+                            frame_length=frame_length,
+                            hop_length=hop_length,
+                            dtype=dtype, mono=mono,
+                            offset=offset, duration=duration,
+                            fill_value=fill_value)
 
     y_frame_stream = []
     target_length = frame_length + (block_length - 1) * hop_length
 
-    for y_block in blocks:
+    for y_block in stream:
         # Check the dtype
         assert y_block.dtype == dtype
 
@@ -1730,7 +1730,6 @@ def test_stream(block_length, frame_length, hop_length, mono, offset,
     y_full, sr = librosa.load(path, sr=None, dtype=dtype, mono=True,
                               offset=offset, duration=duration)
     # First, check the rate
-    assert sr == sr_stream
     y_frame = librosa.util.frame(y_full, frame_length, hop_length)
 
     # Raw audio will not be padded

--- a/tests/test_time_frequency.py
+++ b/tests/test_time_frequency.py
@@ -430,3 +430,57 @@ def test_times_like_scalar():
 
     assert np.allclose(times, expected_times)
 
+
+@pytest.mark.parametrize('blocks', [0, 1, [10, 20]])
+@pytest.mark.parametrize('block_length', [1, 4, 8])
+def test_blocks_to_frames(blocks, block_length):
+    frames = librosa.blocks_to_frames(blocks, block_length)
+
+    # Check shape
+    assert frames.ndim == np.asarray(blocks).ndim
+    assert frames.size == np.asarray(blocks).size
+
+    # Check values
+    assert np.allclose(frames, block_length * np.asanyarray(blocks))
+
+    # Check dtype
+    assert np.issubdtype(frames.dtype, np.int)
+
+
+@pytest.mark.parametrize('blocks', [0, 1, [10, 20]])
+@pytest.mark.parametrize('block_length', [1, 4, 8])
+@pytest.mark.parametrize('hop_length', [1, 512])
+def test_blocks_to_samples(blocks, block_length, hop_length):
+    samples = librosa.blocks_to_samples(blocks, block_length,
+                                        hop_length)
+
+    # Check shape
+    assert samples.ndim == np.asarray(blocks).ndim
+    assert samples.size == np.asarray(blocks).size
+
+    # Check values
+    assert np.allclose(samples,
+                       np.asanyarray(blocks) * hop_length * block_length)
+
+    # Check dtype
+    assert np.issubdtype(samples.dtype, np.int)
+
+
+@pytest.mark.parametrize('blocks', [0, 1, [10, 20]])
+@pytest.mark.parametrize('block_length', [1, 4, 8])
+@pytest.mark.parametrize('hop_length', [1, 512])
+@pytest.mark.parametrize('sr', [22050, 44100])
+def test_blocks_to_time(blocks, block_length, hop_length, sr):
+    times = librosa.blocks_to_time(blocks, block_length,
+                                   hop_length, sr)
+
+    # Check shape
+    assert times.ndim == np.asarray(blocks).ndim
+    assert times.size == np.asarray(blocks).size
+
+    # Check values
+    assert np.allclose(times,
+                       np.asanyarray(blocks) * hop_length * block_length / float(sr))
+
+    # Check dtype
+    assert np.issubdtype(times.dtype, np.float)


### PR DESCRIPTION
#### Reference Issue
Fixes #772


#### What does this implement/fix? Explain your changes.

This PR provides a stream generator `librosa.stream()` that can be used to process large audio files in small pieces.

This is done by wrapping `soundfile.blocks` in some helper functions that smooth over some of the details in setting up the framing parameters.  Basically it codifies the example previously introduced in #864 into a core function.

Example usage for mel spectrogram construction over 256 frames at a time:
```python
>>> blocks, sr = librosa.stream(filename, block_length=256)
>>> for y_block in blocks:
...    M_block = librosa.feature.melspectrogram(y_block, sr=sr, center=False)
```
If the `M_blocks` produced above are stitched together, the result will be numerically equivalent to
```python
>>> y, sr = librosa.load(filename, sr=None)
>>> M = librosa.feature.melspectrogram(y=y, sr=sr, center=False)
```

Note that data is streamed at the native sampling rate, so the default `frame_length` and `hop_length` may not be consistent with the rest of the API.

#### Any other comments?

The documentation here is pretty thorough on proper usage, but I'm open to suggestions on changes for the API, specifically around the frame length / hop length parameters.  

Once that's settled, I'll put in some unit tests.

RFC @ejhumphrey @lostanlen @faroit @keunwoochoi
