### PR TITLE
add show plot in example code

### DIFF
--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -140,6 +140,7 @@ def stft(y, n_fft=2048, hop_length=None, win_length=None, window='hann',
     >>> plt.title('Power spectrogram')
     >>> plt.colorbar(format='%+2.0f dB')
     >>> plt.tight_layout()
+    >>> plt.show()
 
     """
 


### PR DESCRIPTION
I know this is silly, but newbies (like me) may get confused if the actual plotted window is not shown. Shouldn't we show the plot, or is there a particular reason that this is avoided?

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/master/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
<!-- Example: Fixes #123 -->


#### What does this implement/fix? Explain your changes.
Nothing in particular, just adds a line in the tutorial.

#### Any other comments?
No.
