### PR TITLE
stabler exponentiation in PCEN + logarithmic limit case

### DIFF
--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1565,11 +1565,15 @@ def pcen(S, sr=22050, hop_length=512, gain=0.98, bias=2, power=0.5,
         zi = np.empty(shape)
         zi[:] = scipy.signal.lfilter_zi([b], [1, b - 1])[:]
 
+    # Temporal integration
     S_smooth, zf = scipy.signal.lfilter([b], [1, b - 1], ref, zi=zi,
                                         axis=axis)
 
+    # Adaptive gain control
     # Working in log-space gives us some stability, and a slight speedup
     smooth = np.exp(-gain * (np.log(eps) + np.log1p(S_smooth / eps)))
+
+    # Dynamic range compression
     if power == 0:
         S_out = np.log1p(S*smooth)
     elif bias == 0:

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1471,11 +1471,12 @@ def pcen(S, sr=22050, hop_length=512, gain=0.98, bias=2, power=0.5,
     >>> y, sr = librosa.load(librosa.util.example_audio_file(),
     ...                      offset=10, duration=10)
 
-    >>> # We'll use power=1 to get a magnitude spectrum
-    >>> # instead of a power spectrum
+    >>> # We recommend scaling y to the range [-2**31, 2**31[ before applying
+    >>> # PCEN's default parameters. Furthermore, we use power=1 to get a
+    >>> # magnitude spectrum instead of a power spectrum.
     >>> S = librosa.feature.melspectrogram(y, sr=sr, power=1)
     >>> log_S = librosa.amplitude_to_db(S, ref=np.max)
-    >>> pcen_S = librosa.pcen(S)
+    >>> pcen_S = librosa.pcen(S * (2**31))
     >>> plt.figure()
     >>> plt.subplot(2,1,1)
     >>> librosa.display.specshow(log_S, x_axis='time', y_axis='mel')
@@ -1490,7 +1491,7 @@ def pcen(S, sr=22050, hop_length=512, gain=0.98, bias=2, power=0.5,
 
     Compare PCEN with and without max-filtering
 
-    >>> pcen_max = librosa.pcen(S, max_size=3)
+    >>> pcen_max = librosa.pcen(S * (2**31), max_size=3)
     >>> plt.figure()
     >>> plt.subplot(2,1,1)
     >>> librosa.display.specshow(pcen_S, x_axis='time', y_axis='mel')

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1355,7 +1355,7 @@ def pcen(S, sr=22050, hop_length=512, gain=0.98, bias=2, power=0.5,
 
         b = (sqrt(1 + 4* T**2) - 1) / (2 * T**2)
 
-    where `T = time_constant * sr / hop_length`.
+    where `T = time_constant * sr / hop_length`, as in [2]_.
 
     This normalization is designed to suppress background noise and
     emphasize foreground signals, and can be used as an alternative to
@@ -1380,6 +1380,11 @@ def pcen(S, sr=22050, hop_length=512, gain=0.98, bias=2, power=0.5,
        (2017, March). Trainable frontend for robust and far-field keyword spotting.
        In Acoustics, Speech and Signal Processing (ICASSP), 2017
        IEEE International Conference on (pp. 5670-5674). IEEE.
+
+    .. [2] Lostanlen, V., Salamon, J., McFee, B., Cartwright, M., Farnsworth, A.,
+       Kelling, S., and Bello, J. P. Per-Channel Energy Normalization: Why and How.
+       IEEE Signal Processing Letters, 26(1), 39-43.
+
 
     Parameters
     ----------
@@ -1716,11 +1721,11 @@ def griffinlim(S, n_iter=32, hop_length=None, win_length=None, window='hann',
         rebuilt = stft(inverse, n_fft=n_fft, hop_length=hop_length,
                        win_length=win_length, window=window, center=center,
                        pad_mode=pad_mode)
-        
+
         # Update our phase estimates
         angles[:] = rebuilt - (momentum / (1 + momentum)) * tprev
         angles[:] /= np.abs(angles) + 1e-16
-    
+
     # Return the final phase estimates
     return istft(S * angles, hop_length=hop_length, win_length=win_length,
                  window=window, center=center, dtype=dtype, length=length)

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1346,7 +1346,14 @@ def pcen(S, sr=22050, hop_length=512, gain=0.98, bias=2, power=0.5,
 
         P[f, t] = (S / (eps + M[f, t])**gain + bias)**power - bias**power
 
-    where `M` is the result of applying a low-pass, temporal IIR filter
+    IMPORTANT: the default values of eps, gain, bias, and power match the
+    original publication [1]_, in which M is a 40-band mel-frequency
+    spectrogram with 25 ms windowing, 10 ms frame shift, and raw audio values
+    in the interval [-2**31; 2**31-1[. If you use these default values, we
+    recommend to make sure that the raw audio is properly scaled to this
+    interval, and not to [-1, 1[ as is most often the case.
+
+    The matrix `M` is the result of applying a low-pass, temporal IIR filter
     to `S`:
 
         M[f, t] = (1 - b) * M[f, t - 1] + b * S[f, t]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -811,7 +811,7 @@ def test_estimate_tuning():
         # Round to the proper number of decimals
         deviation = np.around(tuning - tuning_est, int(-np.log10(resolution)))
 
-        # Take the minimum floating point for positive and negative deviations 
+        # Take the minimum floating point for positive and negative deviations
         max_dev = np.min([np.mod(deviation, 1.0), np.mod(-deviation, 1.0)])
 
         # We'll accept an answer within three bins of the resolution
@@ -1438,8 +1438,8 @@ def test_pcen():
     #   bias < 0
     yield tf, 1, -1, 1, 0.5, 0.5, 1e-6, 1, S, S
 
-    #   power <= 0
-    yield tf, 1, 1, 0, 0.5, 0.5, 1e-6, 1, S, S
+    #   power < 0
+    yield tf, 1, 1, -0.1, 0.5, 0.5, 1e-6, 1, S, S
 
     #   b < 0
     yield tf, 1, 1, 1, -2, 0.5, 1e-6, 1, S, S

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1465,6 +1465,19 @@ def test_pcen():
     #   gain=1, bias=0, power=1, b=1, eps=1e-20 => ones
     yield __test, 1, 0, 1, 1.0, 0.5, 1e-20, 1, S, np.ones_like(S)
 
+    # Dynamic range compression. Disjunction of cases
+    #   gain=0, bias=1, power=0
+    P = librosa.pcen(S, gain=0.0, bias=1.0, power=0.0, eps=1e-20)
+    assert np.allclose(S, np.expm1(P))
+
+    #   gain=0, bias=0, power=1e-3
+    P = librosa.pcen(S, gain=0.0, bias=0.0, power=1e-3, eps=1e-20)
+    assert np.allclose(S, np.exp(1e3*np.log(P)))
+
+    #   gain=0, bias=1, power=1e-3
+    P = librosa.pcen(S, gain=0.0, bias=1.0, power=1e-3, eps=1e-20)
+    assert np.allclose(S, np.expm1(1e3*np.log1p(P)))
+
     # Catch the complex warning
     yield __test, 1, 0, 1, 1.0, 0.5, 1e-20, 1, S * 1.j, np.ones_like(S)
 


### PR DESCRIPTION
#### Reference Issue
Fixes #891, and does more :)


#### What does this implement/fix? Explain your changes.
* `expm1`-based dynamic range compression in PCEN
* `bias==0` has to be special-cased to avoid division by zero in `expm1` exponentiation
* i also implemented `power==0` which turned out to be really useful and interpretable in my WASPAA paper
* multiplied by (2**31) in the docstring as per RFL's original code
* cited our IEEE SPL paper on the rationale behind the `time_constant`
* some comments and formatting in the pcen function


#### Any other comments?
I realize that there's a lot going on in this PR. I'm happy to break it into smaller PR's if that makes a clearer git log.
