### PR TITLE
[MRG] more efficient length trimming for inverters

### DIFF
--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -657,7 +657,7 @@ def icqt(C, sr=22050, hop_length=512, fmin=None, bins_per_octave=12,
                       'frequency resolution of your CQT.'.format(hop_length, min(lengths)))
 
     if length is not None:
-        n_frames = int(np.ceil((max(lengths)+C.shape[1])/hop_length))
+        n_frames = int(np.ceil((max(lengths)+n_fft+C.shape[1]) / hop_length))
         C = C[:, :n_frames]
 
     # The basis gets renormalized by the effective window length above;

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -657,7 +657,7 @@ def icqt(C, sr=22050, hop_length=512, fmin=None, bins_per_octave=12,
                       'frequency resolution of your CQT.'.format(hop_length, min(lengths)))
 
     if length is not None:
-        n_frames = ceil((max(lengths)+C.shape[1])/hop_length)
+        n_frames = int(np.ceil((max(lengths)+C.shape[1])/hop_length))
         C = C[:, :n_frames]
 
     # The basis gets renormalized by the effective window length above;

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -656,6 +656,10 @@ def icqt(C, sr=22050, hop_length=512, fmin=None, bins_per_octave=12,
                       'Consider decreasing your hop length or increasing the '
                       'frequency resolution of your CQT.'.format(hop_length, min(lengths)))
 
+    if length is not None:
+        n_frames = ceil((max(lengths)+C.shape[1])/hop_length)
+        C = C[:, :n_frames]
+
     # The basis gets renormalized by the effective window length above;
     # This step undoes that
     fft_basis = fft_basis.todense() * n_fft / lengths[:, np.newaxis]

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -657,7 +657,7 @@ def icqt(C, sr=22050, hop_length=512, fmin=None, bins_per_octave=12,
                       'frequency resolution of your CQT.'.format(hop_length, min(lengths)))
 
     if length is not None:
-        n_frames = int(np.ceil((max(lengths)+n_fft+C.shape[1]) / hop_length))
+        n_frames = int(np.ceil((length+max(lengths)) / hop_length))
         C = C[:, :n_frames]
 
     # The basis gets renormalized by the effective window length above;

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -295,7 +295,7 @@ def istft(stft_matrix, hop_length=None, win_length=None, window='hann',
     if length is None:
         n_frames = stft_matrix.shape[1]
     else:
-        n_frames = ceil(length / hop_length)
+        n_frames = int(np.ceil(length / hop_length))
 
     expected_signal_len = n_fft + hop_length * (n_frames - 1)
     y = np.zeros(expected_signal_len, dtype=dtype)

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -296,7 +296,7 @@ def istft(stft_matrix, hop_length=None, win_length=None, window='hann',
         n_frames = stft_matrix.shape[1]
     else:
         if center:
-            padded_length = length + int(n_fft//2)
+            padded_length = length + int(n_fft)
         else:
             padded_length = length
         n_frames = int(np.ceil(padded_length / hop_length))

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -291,7 +291,12 @@ def istft(stft_matrix, hop_length=None, win_length=None, window='hann',
     # Pad out to match n_fft, and add a broadcasting axis
     ifft_window = util.pad_center(ifft_window, n_fft)[:, np.newaxis]
 
-    n_frames = stft_matrix.shape[1]
+    # For efficiency, trim STFT frames according to signal length if available
+    if length is None:
+        n_frames = stft_matrix.shape[1]
+    else:
+        n_frames = ceil(length / hop_length)
+
     expected_signal_len = n_fft + hop_length * (n_frames - 1)
     y = np.zeros(expected_signal_len, dtype=dtype)
 

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -295,7 +295,11 @@ def istft(stft_matrix, hop_length=None, win_length=None, window='hann',
     if length is None:
         n_frames = stft_matrix.shape[1]
     else:
-        n_frames = int(np.ceil(length / hop_length))
+        if center:
+            padded_length = length + int(n_fft//2)
+        else:
+            padded_length = length
+        n_frames = int(np.ceil(padded_length / hop_length))
 
     expected_signal_len = n_fft + hop_length * (n_frames - 1)
     y = np.zeros(expected_signal_len, dtype=dtype)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -484,7 +484,7 @@ def test_istft_reconstruction():
                     for length in [None, len(x) - 1000, len(x + 1000)]:
                         yield (__test, x, n_fft, hop_length, win, atol, length)
                         yield (__test, x, n_fft, hop_length, symwin, atol, length)
-                # also tests with passing widnow function itself
+                # also tests with passing window function itself
                 yield (__test, x, n_fft, n_fft // 9, window_func, atol, None)
 
         # test with default paramters


### PR DESCRIPTION
#### Reference Issue
Fixes #854

Inverse transforms support a `length=` parameter which ensures that the output has a specific number of samples. This is primarily used to extend reconstructed signals to match an input signal's length when the transform (eg STFT) discards any samples that don't fill up an entire window at the end of the signal.

If the user specifies a much shorter length than the inversion would otherwise produce, the reconstructed signal is truncated down to the given length. This results in a lot of wasted computation.

A simple optimization would be to trim the input feature down to the minimum number of frames necessary to reconstruct the target length. This wouldn't change the result, only make the inversion methods faster for partial reconstruction.


#### What does this implement/fix? Explain your changes.
During CR of our last ICQT rewrite (#852, which closed #802), i noticed that the kwarg `length` could potentially be used to preemptively trim the CQT input to a smaller number of frames _before_ running inversion, rather than trimming in the waveform domain after inverting the entire CQT.
This PR implements this simple optimization on `istft` as well as `icqt`.

#### Any other comments?
Work in progress. Need to write tests and a performance benchmark.
