### PR TITLE
time_stretch: STFT kwargs + ISTFT length trimming + doc

### DIFF
--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -186,7 +186,7 @@ def percussive(y, **kwargs):
     return y_perc
 
 
-def time_stretch(y, rate):
+def time_stretch(y, rate, **kwargs):
     '''Time-stretch an audio series by a fixed rate.
 
 
@@ -197,8 +197,10 @@ def time_stretch(y, rate):
 
     rate : float > 0 [scalar]
         Stretch factor.  If `rate > 1`, then the signal is sped up.
-
         If `rate < 1`, then the signal is slowed down.
+
+    kwargs : additional keyword arguments.
+        See `librosa.decompose.stft` for details.
 
     Returns
     -------
@@ -227,8 +229,8 @@ def time_stretch(y, rate):
     if rate <= 0:
         raise ParameterError('rate must be a positive number')
 
-    # Construct the stft
-    stft = core.stft(y)
+    # Construct the short-term Fourier transform (STFT)
+    stft = core.stft(y, **kwargs)
 
     # Stretch by phase vocoding
     stft_stretch = core.phase_vocoder(stft, rate)

--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -204,7 +204,7 @@ def time_stretch(y, rate, **kwargs):
 
     Returns
     -------
-    y_stretch : np.ndarray [shape=(rate * n,)]
+    y_stretch : np.ndarray [shape=(round(n/rate),)]
         audio time series stretched by the specified rate
 
     See Also

--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -245,14 +245,15 @@ def time_stretch(y, rate, **kwargs):
     return y_stretch
 
 
-def pitch_shift(y, sr, n_steps, bins_per_octave=12, res_type='kaiser_best'):
-    '''Pitch-shift the waveform by `n_steps` half-steps.
+def pitch_shift(y, sr, n_steps, bins_per_octave=12, res_type='kaiser_best',
+                **kwargs):
+    '''Shift the pitch of a waveform by `n_steps` semitones.
 
 
     Parameters
     ----------
     y : np.ndarray [shape=(n,)]
-        audio time-series
+        audio time series
 
     sr : number > 0 [scalar]
         audio sampling rate of `y`
@@ -270,6 +271,9 @@ def pitch_shift(y, sr, n_steps, bins_per_octave=12, res_type='kaiser_best'):
         By default, 'kaiser_best' is used.
 
         See `core.resample` for more information.
+
+    kwargs: additional keyword arguments.
+        See `librosa.decompose.stft` for details.
 
     Returns
     -------
@@ -306,7 +310,7 @@ def pitch_shift(y, sr, n_steps, bins_per_octave=12, res_type='kaiser_best'):
     rate = 2.0 ** (-float(n_steps) / bins_per_octave)
 
     # Stretch in time, then resample
-    y_shift = core.resample(time_stretch(y, rate), float(sr) / rate, sr,
+    y_shift = core.resample(time_stretch(y, rate, **kwargs), float(sr)/rate, sr,
                             res_type=res_type)
 
     # Crop to the same dimension as the input

--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -235,8 +235,12 @@ def time_stretch(y, rate, **kwargs):
     # Stretch by phase vocoding
     stft_stretch = core.phase_vocoder(stft, rate)
 
-    # Invert the stft
-    y_stretch = core.istft(stft_stretch, dtype=y.dtype)
+    # Predict the length of y_stretch
+    len_stretch = int(round(len(y)/rate))
+
+    # Invert the STFT
+    y_stretch = core.istft(
+        stft_stretch, dtype=y.dtype, length=len_stretch, **kwargs)
 
     return y_stretch
 


### PR DESCRIPTION
#### Reference Issue
#900
(1) `librosa.effects.time_stretch` calls `stft` with default parameters. It would be good to expose other parameters to the user, and especially `n_fft`. This is particularly important for short inputs, as noted by @jwb95 in #900.

(2) `librosa.effects.time_stretch` does not return the correct length: `len(y)/rate`.

(3) `librosa.effects.time_stretch` docstring claims that the length is `length(y)*rate`.


#### What does this implement/fix? Explain your changes.

(1) 1eafb20. add STFT **kwargs to time_stretch 

(2) 997a955. trim ISTFT to (len(y)/rate) coefficients

(3) 305052b. fix time_stretch doc re: len(y_stretch)


#### Any other comments?
happy to write additional tests if needed