### PR TITLE
Check boundary condition for non-subseq dtw

### DIFF
--- a/librosa/sequence.py
+++ b/librosa/sequence.py
@@ -224,10 +224,10 @@ def dtw(X=None, Y=None, C=None, metric='euclidean', step_sizes_sigma=None,
         if subseq:
             # search for global minimum in last row of D-matrix
             wp_end_idx = np.argmin(D[-1, :]) + 1
-            wp = __dtw_backtracking(D_steps[:, :wp_end_idx], step_sizes_sigma)
+            wp = __dtw_backtracking(D_steps[:, :wp_end_idx], step_sizes_sigma, subseq)
         else:
             # perform warping path backtracking
-            wp = __dtw_backtracking(D_steps, step_sizes_sigma)
+            wp = __dtw_backtracking(D_steps, step_sizes_sigma, subseq)
 
         wp = np.asarray(wp, dtype=int)
 
@@ -312,7 +312,7 @@ def __dtw_calc_accu_cost(C, D, D_steps, step_sizes_sigma,
 
 
 @jit(nopython=True, cache=True)
-def __dtw_backtracking(D_steps, step_sizes_sigma):  # pragma: no cover
+def __dtw_backtracking(D_steps, step_sizes_sigma, subseq):  # pragma: no cover
     '''Backtrack optimal warping path.
 
     Uses the saved step sizes from the cost accumulation
@@ -327,6 +327,9 @@ def __dtw_backtracking(D_steps, step_sizes_sigma):  # pragma: no cover
 
     step_sizes_sigma : np.ndarray [shape=[n, 2]]
         Specifies allowed step sizes as used by the dtw.
+
+    subseq : binary
+        Enable subsequence DTW, e.g., for retrieval tasks.
 
     Returns
     -------
@@ -348,7 +351,7 @@ def __dtw_backtracking(D_steps, step_sizes_sigma):  # pragma: no cover
     # Stop criteria:
     # Setting it to (0, 0) does not work for the subsequence dtw,
     # so we only ask to reach the first row of the matrix.
-    while cur_idx[0] > 0:
+    while (subseq and cur_idx[0] > 0) or (not subseq and cur_idx != (0, 0)):
         cur_step_idx = D_steps[(cur_idx[0], cur_idx[1])]
 
         # save tuple with minimal acc. cost in path

--- a/tests/test_dtw.py
+++ b/tests/test_dtw.py
@@ -76,6 +76,32 @@ def test_dtw_global_supplied_distance_matrix():
     assert np.array_equal(gt_D, mut_D)
 
 
+def test_dtw_gobal_boundary():
+    # Verify that boundary condition is fulfilled for subseq=False.
+    # See https://github.com/librosa/librosa/pull/920
+    X = np.array([1, 2, 3, 4, 5])
+    Y = np.array([1, 1, 1, 2, 4, 5, 6, 5, 5])
+    gt_wp = np.array([[0, 0], [0, 1], [0, 2], [1, 3], [2, 3], [3, 4], [4, 5],
+                      [4, 6], [4, 7], [4, 8]])
+
+    D, wp = librosa.sequence.dtw(X, Y, subseq=False)
+    wp = wp[::-1]
+    assert np.array_equal(gt_wp, wp)
+
+
+def test_dtw_subseq_boundary():
+    # Verify that boundary condition doesn't have to be fulfilled for
+    # subseq=True.
+    # See https://github.com/librosa/librosa/pull/920
+    X = np.array([1, 2, 3, 4, 5])
+    Y = np.array([1, 1, 1, 2, 4, 5, 6, 5, 5])
+    gt_wp = np.array([[0, 2], [1, 3], [2, 3], [3, 4], [4, 5]])
+
+    D, wp = librosa.sequence.dtw(X, Y, subseq=True)
+    wp = wp[::-1]
+    assert np.array_equal(gt_wp, wp)
+
+
 @pytest.mark.xfail(raises=librosa.ParameterError)
 def test_dtw_incompatible_args_01():
     librosa.sequence.dtw(C=1, X=1, Y=1)


### PR DESCRIPTION
For non-subsequence dynamic time warping, currently the boundary condition is not always satisfied. See the following minimal example:

```
import numpy as np
from matplotlib import pyplot as plt
import librosa

x = np.array([1, 2, 3, 4, 5])
y = np.array([1, 1, 1, 2, 4, 5, 6, 5, 5])
D, wp = librosa.sequence.dtw(x, y)

plt.imshow(D, aspect='auto', cmap='gray_r', origin='lower')
plt.plot(wp[:, 1], wp[:, 0], 'ro-')
```
![dtw](https://user-images.githubusercontent.com/5499717/60976482-0ccb8b80-a32e-11e9-89bd-f6f200b504b3.png)

This is because the backtracking loop currently stops when the beginning of the first sequence is reached. That makes sense for subsequence DTW, but not for usual DTW. I fixed that by adding a `subseq` keyword for the backtracking function and use a different loop stop criterion based on that. Now it looks like this:
![dtw2](https://user-images.githubusercontent.com/5499717/60976586-43a1a180-a32e-11e9-91c3-79c143dc1366.png)