### PR TITLE
adds the ability to pass in an array of samples to be placed in for c…

### DIFF
--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -1027,7 +1027,7 @@ def zero_crossings(y, threshold=1e-10, ref_magnitude=None, pad=True,
 
 
 def clicks(times=None, frames=None, sr=22050, hop_length=512,
-           click_freq=1000.0, click_duration=0.1, click=None, length=None):
+           click_freq=1000.0, click_duration=0.1, click=None, length=None, click_samples=[]):
     """Returns a signal with the signal `click` placed at each specified time
 
     Parameters
@@ -1114,6 +1114,10 @@ def clicks(times=None, frames=None, sr=22050, hop_length=512,
         # Convert times to positions
         positions = time_to_samples(times, sr=sr)
 
+    if click_samples is not []:
+        for sample in click_samples:
+            util.valid_audio(sample, mono=True)
+
     if click is not None:
         # Check that we have a well-formed audio buffer
         util.valid_audio(click, mono=True)
@@ -1148,7 +1152,9 @@ def clicks(times=None, frames=None, sr=22050, hop_length=512,
     click_signal = np.zeros(length, dtype=np.float32)
 
     # Place clicks
-    for start in positions:
+    for index, start in enumerate(positions):
+        if click_samples is not []:
+            click = click_samples[index]
         # Compute the end-point of this click
         end = start + click.shape[0]
 


### PR DESCRIPTION

#### Reference Issue
This is a PR for a new feature so new Issue exists right now, though I can create one if that's where discussion is better hosted.  

#### What does this implement/fix? Explain your changes.
What my new functionality allows for is to pass in an array of Samples to the Click Function, which would then generate a sequentially generated series of Clicks with custom samples.  

Why would we want this?  Well basically when I was going through the tutorials I realized that I wanted to combine the functionality displayed in two of the tutorials.
https://musicinformationretrieval.com/pitch_transcription_exercise.html
and 
https://musicinformationretrieval.com/onset_detection.html

Where every time a click is placed, instead of the same sample being placed at each index of the Onset, we can choose a custom sample for each click.  So for example I have a function that takes human speech and I'm extracting beats and pitch so that it is played back using the corresponding Piano sample, which is now possible with the addition of the click_samples keyword.  

![Screen Shot 2019-07-12 at 4 05 07 PM](https://user-images.githubusercontent.com/4544594/61155405-dcffbd80-a4be-11e9-82fe-2fa2be2afdb6.png)

Let me know what ya'll think, I'm happy to make changes or adjustments based on what you think.  Curious if you think others have use for this functionality.  Thanks for all the amazing work on this Lib! 



#### Any other comments?

