### PR TITLE
CQT tuning correction, tuning standardization, deprecate A440=

### DIFF
--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -54,7 +54,7 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
     bins_per_octave : int > 0 [scalar]
         Number of bins per octave
 
-    tuning : None or float in `[-0.5, 0.5)`
+    tuning : None or float
         Tuning offset in fractions of a bin.
 
         If `None`, tuning will be automatically estimated from the signal.
@@ -313,7 +313,7 @@ def hybrid_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
     bins_per_octave : int > 0 [scalar]
         Number of bins per octave
 
-    tuning : None or float in `[-0.5, 0.5)`
+    tuning : None or float
         Tuning offset in fractions of a bin.
 
         If `None`, tuning will be automatically estimated from the signal.
@@ -461,7 +461,7 @@ def pseudo_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
     bins_per_octave : int > 0 [scalar]
         Number of bins per octave
 
-    tuning : None or float in `[-0.5, 0.5)`
+    tuning : None or float
         Tuning offset in fractions of a bin.
 
         If `None`, tuning will be automatically estimated from the signal.
@@ -566,7 +566,7 @@ def icqt(C, sr=22050, hop_length=512, fmin=None, bins_per_octave=12,
     fmin : float > 0 [scalar]
         Minimum frequency. Defaults to C1 ~= 32.70 Hz
 
-    tuning : float in `[-0.5, 0.5)` [scalar]
+    tuning : float [scalar]
         Tuning offset in fractions of a bin.
 
         The minimum frequency of the CQT will be modified to

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -55,9 +55,12 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
         Number of bins per octave
 
     tuning : None or float in `[-0.5, 0.5)`
-        Tuning offset in fractions of a bin (cents).
+        Tuning offset in fractions of a bin.
 
         If `None`, tuning will be automatically estimated from the signal.
+
+        The minimum frequency of the resulting CQT will be modified to
+        `fmin * 2**(tuning / bins_per_octave)`.
 
     filter_scale : float > 0
         Filter scale factor. Small values (<1) use shorter windows
@@ -172,11 +175,14 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
         fmin = note_to_hz('C1')
 
     if tuning is None:
-        tuning = estimate_tuning(y=y, sr=sr)
+        tuning = estimate_tuning(y=y, sr=sr, bins_per_octave=bins_per_octave)
+
+    # Apply tuning correction
+    fmin = fmin * 2.0**(tuning / bins_per_octave)
 
     # First thing, get the freqs of the top octave
     freqs = cqt_frequencies(n_bins, fmin,
-                            bins_per_octave=bins_per_octave, tuning=tuning)[-bins_per_octave:]
+                            bins_per_octave=bins_per_octave)[-bins_per_octave:]
 
     fmin_t = np.min(freqs)
     fmax_t = np.max(freqs)
@@ -207,7 +213,6 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
         fft_basis, n_fft, _ = __cqt_filter_fft(sr, fmin_t,
                                                n_filters,
                                                bins_per_octave,
-                                               tuning,
                                                filter_scale,
                                                norm,
                                                sparsity,
@@ -235,7 +240,6 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
     fft_basis, n_fft, _ = __cqt_filter_fft(sr, fmin_t,
                                            n_filters,
                                            bins_per_octave,
-                                           tuning,
                                            filter_scale,
                                            norm,
                                            sparsity,
@@ -271,7 +275,6 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
         lengths = filters.constant_q_lengths(sr, fmin,
                                              n_bins=n_bins,
                                              bins_per_octave=bins_per_octave,
-                                             tuning=tuning,
                                              window=window,
                                              filter_scale=filter_scale)
         C /= np.sqrt(lengths[:, np.newaxis])
@@ -311,9 +314,12 @@ def hybrid_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
         Number of bins per octave
 
     tuning : None or float in `[-0.5, 0.5)`
-        Tuning offset in fractions of a bin (cents).
+        Tuning offset in fractions of a bin.
 
         If `None`, tuning will be automatically estimated from the signal.
+
+        The minimum frequency of the resulting CQT will be modified to
+        `fmin * 2**(tuning / bins_per_octave)`.
 
     filter_scale : float > 0
         Filter filter_scale factor. Larger values use longer windows.
@@ -365,18 +371,19 @@ def hybrid_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
         fmin = note_to_hz('C1')
 
     if tuning is None:
-        tuning = estimate_tuning(y=y, sr=sr)
+        tuning = estimate_tuning(y=y, sr=sr, bins_per_octave=bins_per_octave)
+
+    # Apply tuning correction
+    fmin = fmin * 2.0**(tuning / bins_per_octave)
 
     # Get all CQT frequencies
     freqs = cqt_frequencies(n_bins, fmin,
-                            bins_per_octave=bins_per_octave,
-                            tuning=tuning)
+                            bins_per_octave=bins_per_octave)
 
     # Compute the length of each constant-Q basis function
     lengths = filters.constant_q_lengths(sr, fmin,
                                          n_bins=n_bins,
                                          bins_per_octave=bins_per_octave,
-                                         tuning=tuning,
                                          filter_scale=filter_scale,
                                          window=window)
 
@@ -397,7 +404,6 @@ def hybrid_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
                                    fmin=fmin_pseudo,
                                    n_bins=n_bins_pseudo,
                                    bins_per_octave=bins_per_octave,
-                                   tuning=tuning,
                                    filter_scale=filter_scale,
                                    norm=norm,
                                    sparsity=sparsity,
@@ -411,7 +417,6 @@ def hybrid_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
                                    fmin=fmin,
                                    n_bins=n_bins_full,
                                    bins_per_octave=bins_per_octave,
-                                   tuning=tuning,
                                    filter_scale=filter_scale,
                                    norm=norm,
                                    sparsity=sparsity,
@@ -457,9 +462,12 @@ def pseudo_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
         Number of bins per octave
 
     tuning : None or float in `[-0.5, 0.5)`
-        Tuning offset in fractions of a bin (cents).
+        Tuning offset in fractions of a bin.
 
         If `None`, tuning will be automatically estimated from the signal.
+
+        The minimum frequency of the resulting CQT will be modified to
+        `fmin * 2**(tuning / bins_per_octave)`.
 
     filter_scale : float > 0
         Filter filter_scale factor. Larger values use longer windows.
@@ -503,11 +511,14 @@ def pseudo_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
         fmin = note_to_hz('C1')
 
     if tuning is None:
-        tuning = estimate_tuning(y=y, sr=sr)
+        tuning = estimate_tuning(y=y, sr=sr, bins_per_octave=bins_per_octave)
+
+    # Apply tuning correction
+    fmin = fmin * 2.0**(tuning / bins_per_octave)
 
     fft_basis, n_fft, _ = __cqt_filter_fft(sr, fmin, n_bins,
                                            bins_per_octave,
-                                           tuning, filter_scale,
+                                           filter_scale,
                                            norm, sparsity,
                                            hop_length=hop_length,
                                            window=window)
@@ -526,7 +537,6 @@ def pseudo_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
         lengths = filters.constant_q_lengths(sr, fmin,
                                              n_bins=n_bins,
                                              bins_per_octave=bins_per_octave,
-                                             tuning=tuning,
                                              window=window,
                                              filter_scale=filter_scale)
 
@@ -557,7 +567,10 @@ def icqt(C, sr=22050, hop_length=512, fmin=None, bins_per_octave=12,
         Minimum frequency. Defaults to C1 ~= 32.70 Hz
 
     tuning : float in `[-0.5, 0.5)` [scalar]
-        Tuning offset in fractions of a bin (cents).
+        Tuning offset in fractions of a bin.
+
+        The minimum frequency of the CQT will be modified to
+        `fmin * 2**(tuning / bins_per_octave)`.
 
     filter_scale : float > 0 [scalar]
         Filter scale factor. Small values (<1) use shorter windows
@@ -632,19 +645,20 @@ def icqt(C, sr=22050, hop_length=512, fmin=None, bins_per_octave=12,
     if fmin is None:
         fmin = note_to_hz('C1')
 
+    # Apply tuning correction
+    fmin = fmin * 2.0**(tuning / bins_per_octave)
+
     # Get the top octave of frequencies
     n_bins = len(C)
 
     freqs = cqt_frequencies(n_bins, fmin,
-                            bins_per_octave=bins_per_octave,
-                            tuning=tuning)[-bins_per_octave:]
+                            bins_per_octave=bins_per_octave)[-bins_per_octave:]
 
     n_filters = min(n_bins, bins_per_octave)
 
     fft_basis, n_fft, lengths = __cqt_filter_fft(sr, np.min(freqs),
                                                  n_filters,
                                                  bins_per_octave,
-                                                 tuning,
                                                  filter_scale,
                                                  norm,
                                                  sparsity=sparsity,
@@ -710,7 +724,7 @@ def icqt(C, sr=22050, hop_length=512, fmin=None, bins_per_octave=12,
 
 
 @cache(level=10)
-def __cqt_filter_fft(sr, fmin, n_bins, bins_per_octave, tuning,
+def __cqt_filter_fft(sr, fmin, n_bins, bins_per_octave,
                      filter_scale, norm, sparsity, hop_length=None,
                      window='hann'):
     '''Generate the frequency domain constant-Q filter basis.'''
@@ -719,7 +733,6 @@ def __cqt_filter_fft(sr, fmin, n_bins, bins_per_octave, tuning,
                                         fmin=fmin,
                                         n_bins=n_bins,
                                         bins_per_octave=bins_per_octave,
-                                        tuning=tuning,
                                         filter_scale=filter_scale,
                                         norm=norm,
                                         pad_fft=True,

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -727,7 +727,7 @@ def iirt(y, sr=22050, win_length=2048, hop_length=None, center=True,
           `D[:, t]` is centered at `y[t * hop_length]`.
         - If `False`, then `D[:, t]` begins at `y[t * hop_length]`
 
-    tuning : float in `[-0.5, +0.5)` [scalar]
+    tuning : float [scalar]
         Tuning deviation from A440 in fractions of a bin.
 
     pad_mode : string

--- a/librosa/core/time_frequency.py
+++ b/librosa/core/time_frequency.py
@@ -3,11 +3,13 @@
 '''Time and frequency utilities'''
 
 import re
+import warnings
 
 import numpy as np
 import six
 
 from ..util.exceptions import ParameterError
+from ..util.deprecation import Deprecated
 
 __all__ = ['frames_to_samples', 'frames_to_time',
            'samples_to_frames', 'samples_to_time',
@@ -830,7 +832,7 @@ def mel_to_hz(mels, htk=False):
     return freqs
 
 
-def hz_to_octs(frequencies, A440=440.0):
+def hz_to_octs(frequencies, tuning=0.0, bins_per_octave=12, A440=Deprecated()):
     """Convert frequencies (Hz) to (fractional) octave numbers.
 
     Examples
@@ -844,8 +846,18 @@ def hz_to_octs(frequencies, A440=440.0):
     ----------
     frequencies   : number >0 or np.ndarray [shape=(n,)] or float
         scalar or vector of frequencies
-    A440          : float
+
+    tuning        : number in [-0.5, 0.5)
+        Tuning deviation from A440 in bins per octave.
+
+    bins_per_octave : int > 0
+        Number of bins per octave.
+
+    A440          : float <DEPRECATED>
         frequency of A440 (in Hz)
+
+        .. note:: This parameter is deprecated in 0.7.1 and will be removed
+                  in version 0.8.0.  Use `tuning=` instead.
 
     Returns
     -------
@@ -856,10 +868,18 @@ def hz_to_octs(frequencies, A440=440.0):
     --------
     octs_to_hz
     """
+
+    if isinstance(A440, Deprecated):
+        A440 = 440.0 * 2.0**(tuning / bins_per_octave)
+    else:
+        warnings.warn('Parameter A440={} in hz_to_octs is deprecated in 0.7.1. '
+                      'It will be removed in 0.8.0. '
+                      'Use tuning= instead.'.format(A440), DeprecationWarning)
+
     return np.log2(np.asanyarray(frequencies) / (float(A440) / 16))
 
 
-def octs_to_hz(octs, A440=440.0):
+def octs_to_hz(octs, tuning=0.0, bins_per_octave=12, A440=Deprecated()):
     """Convert octaves numbers to frequencies.
 
     Octaves are counted relative to A.
@@ -887,6 +907,13 @@ def octs_to_hz(octs, A440=440.0):
     --------
     hz_to_octs
     """
+    if isinstance(A440, Deprecated):
+        A440 = 440.0 * 2.0**(tuning / bins_per_octave)
+    else:
+        warnings.warn('Parameter A440={} in octs_to_hz is deprecated in 0.7.1. '
+                      'It will be removed in 0.8.0. '
+                      'Use tuning= instead.'.format(A440), DeprecationWarning)
+
     return (float(A440) / 16)*(2.0**np.asanyarray(octs))
 
 

--- a/librosa/core/time_frequency.py
+++ b/librosa/core/time_frequency.py
@@ -847,8 +847,8 @@ def hz_to_octs(frequencies, tuning=0.0, bins_per_octave=12, A440=Deprecated()):
     frequencies   : number >0 or np.ndarray [shape=(n,)] or float
         scalar or vector of frequencies
 
-    tuning        : number in [-0.5, 0.5)
-        Tuning deviation from A440 in bins per octave.
+    tuning        : float
+        Tuning deviation from A440 in (fractional) bins per octave.
 
     bins_per_octave : int > 0
         Number of bins per octave.
@@ -895,7 +895,14 @@ def octs_to_hz(octs, tuning=0.0, bins_per_octave=12, A440=Deprecated()):
     ----------
     octaves       : np.ndarray [shape=(n,)] or float
         octave number for each frequency
-    A440          : float
+
+    tuning : float
+        Tuning deviation from A440 in (fractional) bins per octave.
+
+    bins_per_octave : int > 0
+        Number of bins per octave.
+
+    A440          : float <DEPRECATED>
         frequency of A440
 
     Returns
@@ -972,8 +979,8 @@ def cqt_frequencies(n_bins, fmin, bins_per_octave=12, tuning=0.0):
     bins_per_octave : int > 0 [scalar]
         Number of bins per octave
 
-    tuning : float in `[-0.5, +0.5)`
-        Deviation from A440 tuning in fractional bins (cents)
+    tuning : float
+        Deviation from A440 tuning in fractional bins
 
     Returns
     -------

--- a/librosa/display.py
+++ b/librosa/display.py
@@ -498,6 +498,7 @@ def specshow(data, x_coords=None, y_coords=None,
              x_axis=None, y_axis=None,
              sr=22050, hop_length=512,
              fmin=None, fmax=None,
+             tuning=0.0,
              bins_per_octave=12,
              ax=None,
              **kwargs):
@@ -585,6 +586,12 @@ def specshow(data, x_coords=None, y_coords=None,
 
     fmax : float > 0 [scalar] or None
         Used for setting the Mel frequency scales
+
+    tuning : float in [-0.5, 0.5)
+        Tuning deviation from A440, in fractions of a bin.
+
+        This is used for CQT frequency scales, so that `fmin` is adjusted
+        to `fmin * 2**(tuning / bins_per_octave)`.
 
     bins_per_octave : int > 0 [scalar]
         Number of bins per octave.  Used for CQT frequency scale.
@@ -719,6 +726,7 @@ def specshow(data, x_coords=None, y_coords=None,
                       sr=sr,
                       fmin=fmin,
                       fmax=fmax,
+                      tuning=tuning,
                       bins_per_octave=bins_per_octave,
                       hop_length=hop_length)
 
@@ -964,6 +972,9 @@ def __coord_cqt_hz(n, fmin=None, bins_per_octave=12, **_kwargs):
     '''Get CQT bin frequencies'''
     if fmin is None:
         fmin = core.note_to_hz('C1')
+
+    # Apply tuning correction
+    fmin = fmin * 2.0**(_kwargs.get('tuning', 0.0) / bins_per_octave)
 
     # we drop by half a bin so that CQT bins are centered vertically
     return core.cqt_frequencies(n+1,

--- a/librosa/display.py
+++ b/librosa/display.py
@@ -587,7 +587,7 @@ def specshow(data, x_coords=None, y_coords=None,
     fmax : float > 0 [scalar] or None
         Used for setting the Mel frequency scales
 
-    tuning : float in [-0.5, 0.5)
+    tuning : float
         Tuning deviation from A440, in fractions of a bin.
 
         This is used for CQT frequency scales, so that `fmin` is adjusted

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -1108,8 +1108,7 @@ def chroma_stft(y=None, sr=22050, S=None, norm=np.inf, n_fft=2048,
         If `center=True`, the padding mode to use at the edges of the signal.
         By default, STFT uses reflection padding.
 
-
-    tuning : float in `[-0.5, 0.5)` [scalar] or None.
+    tuning : float [scalar] or None.
         Deviation from A440 tuning in fractional chroma bins.
         If `None`, it is automatically estimated.
 

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -1110,7 +1110,7 @@ def chroma_stft(y=None, sr=22050, S=None, norm=np.inf, n_fft=2048,
 
 
     tuning : float in `[-0.5, 0.5)` [scalar] or None.
-        Deviation from A440 tuning in fractional bins (cents).
+        Deviation from A440 tuning in fractional chroma bins.
         If `None`, it is automatically estimated.
 
     kwargs : additional keyword arguments
@@ -1181,10 +1181,7 @@ def chroma_stft(y=None, sr=22050, S=None, norm=np.inf, n_fft=2048,
         tuning = estimate_tuning(S=S, sr=sr, bins_per_octave=n_chroma)
 
     # Get the filter bank
-    if 'A440' not in kwargs:
-        kwargs['A440'] = 440.0 * 2.0**(float(tuning) / n_chroma)
-
-    chromafb = filters.chroma(sr, n_fft, **kwargs)
+    chromafb = filters.chroma(sr, n_fft, tuning=tuning, **kwargs)
 
     # Compute raw chroma
     raw_chroma = np.dot(chromafb, S)
@@ -1224,7 +1221,7 @@ def chroma_cqt(y=None, sr=22050, C=None, hop_length=512, fmin=None,
         threshold are discarded, resulting in a sparse chromagram.
 
     tuning : float
-        Deviation (in cents) from A440 tuning
+        Deviation (in fractions of a CQT bin) from A440 tuning
 
     n_chroma : int > 0
         Number of chroma bins to produce
@@ -1353,7 +1350,7 @@ def chroma_cens(y=None, sr=22050, C=None, hop_length=512, fmin=None,
         Column-wise normalization of the chromagram.
 
     tuning : float
-        Deviation (in cents) from A440 tuning
+        Deviation (in fractions of a CQT bin) from A440 tuning
 
     n_chroma : int > 0
         Number of chroma bins to produce

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -228,7 +228,7 @@ def mel(sr, n_fft, n_mels=128, fmin=0.0, fmax=None, htk=False,
 
 
 @cache(level=10)
-def chroma(sr, n_fft, n_chroma=12, A440=440.0, ctroct=5.0,
+def chroma(sr, n_fft, n_chroma=12, tuning=0.0, A440=Deprecated(), ctroct=5.0,
            octwidth=2, norm=2, base_c=True, dtype=np.float32):
     """Create a Filterbank matrix to convert STFT to chroma
 
@@ -244,8 +244,14 @@ def chroma(sr, n_fft, n_chroma=12, A440=440.0, ctroct=5.0,
     n_chroma  : int > 0 [scalar]
         number of chroma bins
 
-    A440      : float > 0 [scalar]
+    tuning : number in [-0.5, 0.5)
+        Tuning deviation from A440 in fractions of a chroma bin.
+
+    A440      : float > 0 [scalar] <Deprecated>
         Reference frequency for A440
+
+        .. note:: This parameter is deprecated in version 0.7.1.
+                  It will be removed in 0.8.0.  Use `tuning=` instead.
 
     ctroct    : float > 0 [scalar]
 
@@ -325,7 +331,9 @@ def chroma(sr, n_fft, n_chroma=12, A440=440.0, ctroct=5.0,
     # Get the FFT bins, not counting the DC component
     frequencies = np.linspace(0, sr, n_fft, endpoint=False)[1:]
 
-    frqbins = n_chroma * hz_to_octs(frequencies, A440)
+    frqbins = n_chroma * hz_to_octs(frequencies,
+                                    tuning=tuning,
+                                    bins_per_octave=n_chroma)
 
     # make up a value for the 0 Hz bin = 1.5 octaves below bin 1
     # (so chroma is 50% rotated from bin 1, and bin width is broad)

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -50,6 +50,7 @@ from .util.exceptions import ParameterError
 
 from .core.time_frequency import note_to_hz, hz_to_midi, midi_to_hz, hz_to_octs
 from .core.time_frequency import fft_frequencies, mel_frequencies
+from .util.deprecation import Deprecated
 
 __all__ = ['mel',
            'chroma',
@@ -390,7 +391,7 @@ def __float_window(window_spec):
 
 
 @cache(level=10)
-def constant_q(sr, fmin=None, n_bins=84, bins_per_octave=12, tuning=0.0,
+def constant_q(sr, fmin=None, n_bins=84, bins_per_octave=12, tuning=Deprecated(),
                window='hann', filter_scale=1, pad_fft=True, norm=1,
                dtype=np.complex64, **kwargs):
     r'''Construct a constant-Q basis.
@@ -416,8 +417,11 @@ def constant_q(sr, fmin=None, n_bins=84, bins_per_octave=12, tuning=0.0,
     bins_per_octave : int > 0 [scalar]
         Number of bins per octave
 
-    tuning : float in `[-0.5, +0.5)` [scalar]
+    tuning : float in `[-0.5, +0.5)` [scalar] <DEPRECATED>
         Tuning deviation from A440 in fractions of a bin
+
+        .. note:: This parameter is deprecated in 0.7.1.  It will be removed in
+                  version 0.8.
 
     window : string, tuple, number, or function
         Windowing function to apply to filters.
@@ -500,17 +504,22 @@ def constant_q(sr, fmin=None, n_bins=84, bins_per_octave=12, tuning=0.0,
     if fmin is None:
         fmin = note_to_hz('C1')
 
-    # Pass-through parameters to get the filter lengths
-    lengths = constant_q_lengths(sr, fmin,
-                                 n_bins=n_bins,
-                                 bins_per_octave=bins_per_octave,
-                                 tuning=tuning,
-                                 window=window,
-                                 filter_scale=filter_scale)
+    if isinstance(tuning, Deprecated):
+        tuning = 0.0
+    else:
+        warnings.warn('The `tuning` parameter to `filters.constant_q` is deprecated in librosa 0.7.1.'
+                      'It will be removed in 0.8.0.', DeprecationWarning)
 
     # Apply tuning correction
     correction = 2.0**(float(tuning) / bins_per_octave)
     fmin = correction * fmin
+
+    # Pass-through parameters to get the filter lengths
+    lengths = constant_q_lengths(sr, fmin,
+                                 n_bins=n_bins,
+                                 bins_per_octave=bins_per_octave,
+                                 window=window,
+                                 filter_scale=filter_scale)
 
     # Q should be capitalized here, so we suppress the name warning
     # pylint: disable=invalid-name
@@ -548,7 +557,7 @@ def constant_q(sr, fmin=None, n_bins=84, bins_per_octave=12, tuning=0.0,
 
 @cache(level=10)
 def constant_q_lengths(sr, fmin, n_bins=84, bins_per_octave=12,
-                       tuning=0.0, window='hann', filter_scale=1):
+                       tuning=Deprecated(), window='hann', filter_scale=1):
     r'''Return length of each filter in a constant-Q basis.
 
     Parameters
@@ -567,6 +576,9 @@ def constant_q_lengths(sr, fmin, n_bins=84, bins_per_octave=12,
 
     tuning : float in `[-0.5, +0.5)` [scalar]
         Tuning deviation from A440 in fractions of a bin
+
+        .. note:: This parameter is deprecated in 0.7.1.  It will be removed in
+                  version 0.8.
 
     window : str or callable
         Window function to use on filters
@@ -601,8 +613,13 @@ def constant_q_lengths(sr, fmin, n_bins=84, bins_per_octave=12,
     if n_bins <= 0 or not isinstance(n_bins, int):
         raise ParameterError('n_bins must be a positive integer')
 
-    correction = 2.0**(float(tuning) / bins_per_octave)
+    if isinstance(tuning, Deprecated):
+        tuning = 0.0
+    else:
+        warnings.warn('The `tuning` parameter to `filters.constant_q_lengths` is deprecated in librosa 0.7.1.'
+                      'It will be removed in 0.8.0.', DeprecationWarning)
 
+    correction = 2.0**(float(tuning) / bins_per_octave)
     fmin = correction * fmin
 
     # Q should be capitalized here, so we suppress the name warning

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -244,7 +244,7 @@ def chroma(sr, n_fft, n_chroma=12, tuning=0.0, A440=Deprecated(), ctroct=5.0,
     n_chroma  : int > 0 [scalar]
         number of chroma bins
 
-    tuning : number in [-0.5, 0.5)
+    tuning : float
         Tuning deviation from A440 in fractions of a chroma bin.
 
     A440      : float > 0 [scalar] <Deprecated>
@@ -425,7 +425,7 @@ def constant_q(sr, fmin=None, n_bins=84, bins_per_octave=12, tuning=Deprecated()
     bins_per_octave : int > 0 [scalar]
         Number of bins per octave
 
-    tuning : float in `[-0.5, +0.5)` [scalar] <DEPRECATED>
+    tuning : float [scalar] <DEPRECATED>
         Tuning deviation from A440 in fractions of a bin
 
         .. note:: This parameter is deprecated in 0.7.1.  It will be removed in
@@ -515,7 +515,8 @@ def constant_q(sr, fmin=None, n_bins=84, bins_per_octave=12, tuning=Deprecated()
     if isinstance(tuning, Deprecated):
         tuning = 0.0
     else:
-        warnings.warn('The `tuning` parameter to `filters.constant_q` is deprecated in librosa 0.7.1.'
+        warnings.warn('The `tuning` parameter to `filters.constant_q` '
+                      'is deprecated in librosa 0.7.1. '
                       'It will be removed in 0.8.0.', DeprecationWarning)
 
     # Apply tuning correction
@@ -582,7 +583,7 @@ def constant_q_lengths(sr, fmin, n_bins=84, bins_per_octave=12,
     bins_per_octave : int > 0 [scalar]
         Number of bins per octave
 
-    tuning : float in `[-0.5, +0.5)` [scalar]
+    tuning : float [scalar] <DEPRECATED>
         Tuning deviation from A440 in fractions of a bin
 
         .. note:: This parameter is deprecated in 0.7.1.  It will be removed in
@@ -1002,7 +1003,7 @@ def mr_frequencies(tuning):
 
     Parameters
     ----------
-    tuning : float in `[-0.5, +0.5)` [scalar]
+    tuning : float [scalar]
         Tuning deviation from A440, measure as a fraction of the equally
         tempered semitone (1/12 of an octave).
 
@@ -1063,7 +1064,7 @@ def semitone_filterbank(center_freqs=None, tuning=0.0, sample_rates=None, flayou
         Center frequencies of the filter kernels.
         Also defines the number of filters in the filterbank.
 
-    tuning : float in `[-0.5, +0.5)` [scalar]
+    tuning : float [scalar]
         Tuning deviation from A440 as a fraction of a semitone (1/12 of an octave
         in equal temperament).
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -155,10 +155,15 @@ def test_chromafb():
         if octwidth == 0:
             octwidth = None
 
+        # Convert A440 parameter to tuning parameter
+        A440 = DATA['a440'][0, 0]
+
+        tuning = DATA['nchroma'][0, 0] * (np.log2(A440) - np.log2(440.0))
+
         wts = librosa.filters.chroma(DATA['sr'][0, 0],
                                      DATA['nfft'][0, 0],
                                      DATA['nchroma'][0, 0],
-                                     A440=DATA['a440'][0, 0],
+                                     tuning=tuning,
                                      ctroct=DATA['ctroct'][0, 0],
                                      octwidth=octwidth,
                                      norm=2,


### PR DESCRIPTION
#### Reference Issue
Fixes #925 


#### What does this implement/fix? Explain your changes.

This PR addresses the following issues:

- [x] redundant tuning estimation in CQT
- [x] incorrect bin resolution of CQT tuning estimation
- [x] deprecation of `tuning=` parameter in CQT basis constructors
- [x] standardize `tuning=` parameter to be in "fractions of a bin" rather than "cents" across the library
- [x] deprecate `A440=` parameters in favor of `tuning=` parameters across the library.

#### Any other comments?

As mentioned in the discussion of #925, the approach to tuning correction going forward is to simplify the CQT basis constructors to not support tuning.  Rather, it is the job of the caller (ie, `librosa.cqt`) to adjust the `fmin` parameter as a function of tuning prior to requesting the basis.  This simplifies all of the downstream logic, and clarifies exactly the interpretation of `fmin` when tuning is non-zero.

A couple of quirks that popped up in implementing this:

- Should we support `tuning=` in the display module, ie in specshow?  If we don't, then the bin centers for `cqt_hz` decoration will be incorrect.  However, the user may not have the tuning value on-hand if it's automatically calculated and not returned.

- Can we find a more accurate reference for `filters.constant_q`?  The function has generalized substantially from its first implementation, and I don't think the ref we have now is appropriate.

I'll signal for a CR once the last two bullet points are done.