### PR TITLE
CQT Griffin-Lim

### DIFF
--- a/librosa/core/__init__.py
+++ b/librosa/core/__init__.py
@@ -38,6 +38,7 @@ Spectral representations
     fmt
 
     griffinlim
+    griffinlim_cqt
 
     interp_harmonics
     salience

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -846,7 +846,7 @@ def __num_two_factors(x):
 
 def griffinlim_cqt(C, n_iter=32, sr=22050, hop_length=512, fmin=None, bins_per_octave=12, tuning=0.0,
                    filter_scale=1, norm=1, sparsity=0.01, window='hann', scale=True,
-                   pad_mode='reflect', res_type='kaiser_fast', 
+                   pad_mode='reflect', res_type='kaiser_fast',
                    length=None, momentum=0.99, random_state=None):
     '''Approximate constant-Q magnitude spectrogram inversion using the "fast" Griffin-Lim
     algorithm [1]_ [2]_.
@@ -947,7 +947,7 @@ def griffinlim_cqt(C, n_iter=32, sr=22050, hop_length=512, fmin=None, bins_per_o
         for phase initialization.
 
         If `np.random.RandomState` instance, the random number generator itself.
-        
+
         If `None`, defaults to the current `np.random` object.
 
 

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -549,7 +549,8 @@ def pseudo_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
 @cache(level=40)
 def icqt(C, sr=22050, hop_length=512, fmin=None, bins_per_octave=12,
          tuning=0.0, filter_scale=1, norm=1, sparsity=0.01, window='hann',
-         scale=True, length=None, amin=util.Deprecated(), res_type='fft'):
+         scale=True, length=None, amin=util.Deprecated(), res_type='fft',
+         dtype=np.float32):
     '''Compute the inverse constant-Q transform.
 
     Given a constant-Q transform representation `C` of an audio signal `y`,
@@ -610,6 +611,9 @@ def icqt(C, sr=22050, hop_length=512, fmin=None, bins_per_octave=12,
         Resampling mode.  By default, this uses `fft` mode for high-quality
         reconstruction, but this may be slow depending on your signal duration.
         See `librosa.resample` for supported modes.
+
+    dtype : numeric type
+        Real numeric type for `y`.  Default is 32-bit float.
 
     Returns
     -------
@@ -706,7 +710,7 @@ def icqt(C, sr=22050, hop_length=512, fmin=None, bins_per_octave=12,
         D_oct = inv_oct.dot(C_oct / C_scale)
 
         # Inverse-STFT that response
-        y_oct = istft(D_oct, window='ones', hop_length=oct_hop)
+        y_oct = istft(D_oct, window='ones', hop_length=oct_hop, dtype=dtype)
 
         # Up-sample that octave
         if y is None:
@@ -846,7 +850,7 @@ def __num_two_factors(x):
 
 def griffinlim_cqt(C, n_iter=32, sr=22050, hop_length=512, fmin=None, bins_per_octave=12, tuning=0.0,
                    filter_scale=1, norm=1, sparsity=0.01, window='hann', scale=True,
-                   pad_mode='reflect', res_type='kaiser_fast',
+                   pad_mode='reflect', res_type='kaiser_fast', dtype=np.float32,
                    length=None, momentum=0.99, random_state=None):
     '''Approximate constant-Q magnitude spectrogram inversion using the "fast" Griffin-Lim
     algorithm [1]_ [2]_.
@@ -932,6 +936,9 @@ def griffinlim_cqt(C, n_iter=32, sr=22050, hop_length=512, fmin=None, bins_per_o
         Griffin-Lim uses the efficient (fast) resampling mode by default.
 
         See `librosa.core.resample` for a list of available options.
+
+    dtype : numeric type
+        Real numeric type for `y`.  Default is 32-bit float.
 
     length : int > 0, optional
         If provided, the output `y` is zero-padded or clipped to exactly
@@ -1023,7 +1030,7 @@ def griffinlim_cqt(C, n_iter=32, sr=22050, hop_length=512, fmin=None, bins_per_o
 
         # Invert with our current estimate of the phases
         inverse = icqt(C * angles, sr=sr, hop_length=hop_length, bins_per_octave=bins_per_octave,
-                       fmin=fmin, tuning=tuning, window=window, length=length, res_type=res_type)
+                       fmin=fmin, tuning=tuning, window=window, length=length, res_type=res_type, dtype=dtype)
 
         # Rebuild the spectrogram
         rebuilt = cqt(inverse, sr=sr, bins_per_octave=bins_per_octave, n_bins=C.shape[0],
@@ -1042,4 +1049,5 @@ def griffinlim_cqt(C, n_iter=32, sr=22050, hop_length=512, fmin=None, bins_per_o
                 fmin=fmin,
                 window=window,
                 length=length,
-                res_type=res_type)
+                res_type=res_type,
+                dtype=dtype)

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1675,7 +1675,8 @@ def griffinlim(S, n_iter=32, hop_length=None, win_length=None, window='hann',
         If int, random_state is the seed used by the random number generator
         for phase initialization.
 
-        If `np.random.RandomState` instance, the random number generator itself;
+        If `np.random.RandomState` instance, the random number
+        generator itself.
 
         If `None`, defaults to the current `np.random` object.
 


### PR DESCRIPTION
#### Reference Issue
Implements #912 
[EDIT by @lostanlen: closes #912]


#### What does this implement/fix? Explain your changes.

This PR adds `griffinlim_cqt` for reconstructing audio from CQT magnitude spectra.

The algorithm is identical to the existing griffinlim, except that stft is replaced by cqt, so the parameters of the function have to change as well.

#### Any other comments?

Tests here are pretty weak, but it seems to work.  I'm not sure what a reasonable trade-off of test coverage and runtime efficiency is here, but i'd be okay with keeping the tests here pretty light.
