### PR TITLE
Add seek call after sf.info

### DIFF
--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -4,7 +4,7 @@
 
 import os
 import six
-import logging
+import warnings
 
 import soundfile as sf
 import audioread
@@ -23,8 +23,6 @@ __all__ = ['load', 'stream', 'to_mono', 'resample',
            'get_duration', 'get_samplerate',
            'autocorrelate', 'lpc', 'zero_crossings',
            'clicks', 'tone', 'chirp']
-
-logger = logging.getLogger(__name__)
 
 # Resampling bandwidths as percentage of Nyquist
 BW_BEST = resampy.filters.get_filter('kaiser_best')[2]
@@ -144,7 +142,7 @@ def load(path, sr=22050, mono=True, offset=0.0, duration=None,
 
         # If soundfile failed, try audioread instead
         if isinstance(path, six.string_types()):
-            logger.warning('PySoundFile failed. Trying audioread instead.')
+            warnings.warn('PySoundFile failed. Trying audioread instead.')
             y, sr_native = __audioread_load(path, offset, duration, dtype)
         else:
             raise exc

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -4,6 +4,7 @@
 
 import os
 import six
+import logging
 
 import soundfile as sf
 import audioread
@@ -22,6 +23,8 @@ __all__ = ['load', 'stream', 'to_mono', 'resample',
            'get_duration', 'get_samplerate',
            'autocorrelate', 'lpc', 'zero_crossings',
            'clicks', 'tone', 'chirp']
+
+logger = logging.getLogger(__name__)
 
 # Resampling bandwidths as percentage of Nyquist
 BW_BEST = resampy.filters.get_filter('kaiser_best')[2]
@@ -139,8 +142,8 @@ def load(path, sr=22050, mono=True, offset=0.0, duration=None,
 
     except RuntimeError as exc:
         # If soundfile failed, fall back to the audioread loader
-        if hasattr(path, 'name'):
-            path = path.name
+        logger.warning('PySoundFile failed. Trying audioread instead.',
+                       exc_info=exc)
         y, sr_native = __audioread_load(path, offset, duration, dtype)
 
     # Final cleanup for dtype and contiguity
@@ -890,7 +893,7 @@ def __lpc(y, order):
         # fwd_pred_error = f_{M-1,k}       (we have advanced M)
         # den <- DEN_{M}                   (lhs)
         #
-        
+
         q = dtype(1) - reflect_coeff**2
         den = q*den - bwd_pred_error[-1]**2 - fwd_pred_error[0]**2
 

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -4,6 +4,7 @@
 
 import os
 import six
+import sys
 import warnings
 
 import soundfile as sf
@@ -145,7 +146,7 @@ def load(path, sr=22050, mono=True, offset=0.0, duration=None,
             warnings.warn('PySoundFile failed. Trying audioread instead.')
             y, sr_native = __audioread_load(path, offset, duration, dtype)
         else:
-            raise exc
+            six.reraise(*sys.exc_info())
 
     # Final cleanup for dtype and contiguity
     if mono:

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -354,7 +354,7 @@ def stream(path, block_length, frame_length, hop_length,
     sr = sf.info(path).samplerate
 
     # If the input is a file handle, rewind its read position after `sf.info`
-    if not isinstance(path, str) and not isinstance(path, int):
+    if hasattr(path, 'seek'):
         path.seek(0)
 
     # Construct the stream

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -141,10 +141,13 @@ def load(path, sr=22050, mono=True, offset=0.0, duration=None,
             y = sf_desc.read(frames=frame_duration, dtype=dtype, always_2d=False).T
 
     except RuntimeError as exc:
-        # If soundfile failed, fall back to the audioread loader
-        logger.warning('PySoundFile failed. Trying audioread instead.',
-                       exc_info=exc)
-        y, sr_native = __audioread_load(path, offset, duration, dtype)
+
+        # If soundfile failed, try audioread instead
+        if isinstance(path, six.string_types()):
+            logger.warning('PySoundFile failed. Trying audioread instead.')
+            y, sr_native = __audioread_load(path, offset, duration, dtype)
+        else:
+            raise exc
 
     # Final cleanup for dtype and contiguity
     if mono:

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -142,7 +142,7 @@ def load(path, sr=22050, mono=True, offset=0.0, duration=None,
     except RuntimeError as exc:
 
         # If soundfile failed, try audioread instead
-        if isinstance(path, six.string_types()):
+        if isinstance(path, six.string_types):
             warnings.warn('PySoundFile failed. Trying audioread instead.')
             y, sr_native = __audioread_load(path, offset, duration, dtype)
         else:

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -139,6 +139,8 @@ def load(path, sr=22050, mono=True, offset=0.0, duration=None,
 
     except RuntimeError as exc:
         # If soundfile failed, fall back to the audioread loader
+        if hasattr(path, 'name'):
+            path = path.name
         y, sr_native = __audioread_load(path, offset, duration, dtype)
 
     # Final cleanup for dtype and contiguity

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -353,6 +353,10 @@ def stream(path, block_length, frame_length, hop_length,
     # Get the sample rate from the file info
     sr = sf.info(path).samplerate
 
+    # If the input is a file handle, rewind its read position after `sf.info`
+    if not isinstance(path, str) and not isinstance(path, int):
+        path.seek(0)
+
     # Construct the stream
     if offset:
         start = int(offset * sr)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2040,6 +2040,10 @@ def test_stream(path, block_length, frame_length, hop_length, mono, offset,
     # Load the reference data.
     # We'll cast to mono here to simplify checking
 
+    # File objects have to be reset before loading
+    if hasattr(path, 'seek'):
+        path.seek(0)
+
     y_full, sr = librosa.load(path, sr=None, dtype=dtype, mono=True,
                               offset=offset, duration=duration)
     # First, check the rate

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1985,11 +1985,15 @@ def test_get_samplerate(ext):
 @pytest.mark.parametrize('duration', [None, 1.0])
 @pytest.mark.parametrize('fill_value', [None, 999.0])
 @pytest.mark.parametrize('dtype', [np.float32, np.float64])
+@pytest.mark.parametrize('as_file_object', [False, True])
 def test_stream(block_length, frame_length, hop_length, mono, offset,
-                duration, fill_value, dtype):
+                duration, fill_value, dtype, as_file_object):
 
     # test data is stereo, int 16
     path = os.path.join('tests', 'data', 'test1_22050.wav')
+
+    if as_file_object:
+        path = open(path, 'rb')
 
     stream = librosa.stream(path, block_length=block_length,
                             frame_length=frame_length,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1974,6 +1974,19 @@ def test_get_samplerate(ext):
     assert sr == 22050
 
 
+@pytest.fixture(params=['as_file', 'as_string'])
+def path(request):
+
+    # test data is stereo, int 16
+    path = os.path.join('tests', 'data', 'test1_22050.wav')
+
+    if request.param == 'as_string':
+        yield path
+    elif request.param == 'as_file':
+        with open(path, 'rb') as f:
+            yield f
+
+
 @pytest.mark.parametrize('block_length', [10, np.int64(30),
                                           pytest.mark.xfail(0, raises=librosa.ParameterError)])
 @pytest.mark.parametrize('frame_length', [1024, np.int64(2048),
@@ -1985,15 +1998,8 @@ def test_get_samplerate(ext):
 @pytest.mark.parametrize('duration', [None, 1.0])
 @pytest.mark.parametrize('fill_value', [None, 999.0])
 @pytest.mark.parametrize('dtype', [np.float32, np.float64])
-@pytest.mark.parametrize('as_file_object', [False, True])
-def test_stream(block_length, frame_length, hop_length, mono, offset,
-                duration, fill_value, dtype, as_file_object):
-
-    # test data is stereo, int 16
-    path = os.path.join('tests', 'data', 'test1_22050.wav')
-
-    if as_file_object:
-        path = open(path, 'rb')
+def test_stream(path, block_length, frame_length, hop_length, mono, offset,
+                duration, fill_value, dtype):
 
     stream = librosa.stream(path, block_length=block_length,
                             frame_length=frame_length,


### PR DESCRIPTION
## Reference Issue
Fixes https://github.com/librosa/librosa/issues/941

#### What does this implement/fix? Explain your changes.
Rewinds the read position in `librosa.stream` in case the input is a file handle.

```py
import librosa as lr

# Works as expected.
next(lr.stream(lr.util.example_audio_file(), 1, 1024, 512))

# Fixed by this pull request:
next(lr.stream(open(lr.util.example_audio_file(), 'rb'), 1, 1024, 512))
```

#### Any other comments?
Perhaps a unit test should be added for this as well? I'm also curious if this is really something `librosa` should handle or if it's actually a mistake in `soundfile.info`?