### PR TITLE
Accelerated lag<->recurrence, util.shear, deprecated roll_sparse

### DIFF
--- a/.travis_dependencies.sh
+++ b/.travis_dependencies.sh
@@ -40,7 +40,7 @@ if [ ! -d "$src" ]; then
         conda install -c conda-forge ffmpeg pysoundfile python-coveralls
 
         if [[ "$TRAVIS_PYTHON_VERSION" == "3.5" ]]; then
-            conda install -c numba numba
+            conda install -c numba "numba>=0.43"
         fi
 
         source deactivate

--- a/.travis_dependencies.sh
+++ b/.travis_dependencies.sh
@@ -39,6 +39,10 @@ if [ ! -d "$src" ]; then
 
         conda install -c conda-forge ffmpeg pysoundfile python-coveralls
 
+        if [[ "$TRAVIS_PYTHON_VERSION" == "3.5" ]]; then
+            conda install -c numba numba
+        fi
+
         source deactivate
     popd
 else

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -26,7 +26,7 @@ If you use conda/Anaconda environments, librosa can be installed from the
 
     conda install -c conda-forge librosa
 
-If you're using a python 3.5 environment in conda, you may run into trouble with the `numba` dependency.
+If you're using a Python 3.5 environment in conda, you may run into trouble with the `numba` dependency.
 This can be avoided by installing from the `numba` conda channel before installing librosa::
 
    conda install -c numba numba

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -26,6 +26,10 @@ If you use conda/Anaconda environments, librosa can be installed from the
 
     conda install -c conda-forge librosa
 
+If you're using a python 3.5 environment in conda, you may run into trouble with the `numba` dependency.
+This can be avoided by installing from the `numba` conda channel before installing librosa::
+
+   conda install -c numba numba
 
 Source
 ~~~~~~

--- a/librosa/segment.py
+++ b/librosa/segment.py
@@ -557,12 +557,12 @@ def recurrence_to_lag(rec, pad=True, axis=-1):
 
     if pad:
         if sparse:
-            kron = np.asarray([[1, 0]]).swapaxes(axis, 0)
+            padding = np.asarray([[1, 0]], dtype=rec.dtype).swapaxes(axis, 0)
             if axis == 0:
                 rec_fmt = 'csr'
             else:
                 rec_fmt = 'csc'
-            rec = scipy.sparse.kron(kron.astype(rec.dtype), rec, format=rec_fmt)
+            rec = scipy.sparse.kron(padding, rec, format=rec_fmt)
         else:
             padding = [(0, 0), (0, 0)]
             padding[(1-axis)] = (0, t)

--- a/librosa/util/__init__.py
+++ b/librosa/util/__init__.py
@@ -19,7 +19,7 @@ Array operations
 
     axis_sort
     normalize
-    roll_sparse
+    shear
     sparsify_rows
 
     buf_to_float
@@ -63,6 +63,14 @@ File operations
     example_audio_file
     find_files
 
+
+Deprecated
+----------
+
+.. autosummary::
+    :toctree: generated/
+
+    roll_sparse
 """
 
 from .utils import *  # pylint: disable=wildcard-import

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -7,10 +7,12 @@ import scipy.sparse
 import six
 
 import numpy as np
+import numba
 from numpy.lib.stride_tricks import as_strided
 
 from .._cache import cache
 from .exceptions import ParameterError
+from .decorators import deprecated
 
 # Constrain STFT block sizes to 256 KB
 MAX_MEM_BLOCK = 2**8 * 2**10
@@ -23,6 +25,7 @@ __all__ = ['MAX_MEM_BLOCK',
            'peak_pick',
            'sparsify_rows',
            'roll_sparse',
+           'shear',
            'fill_off_diagonal',
            'index_to_slice',
            'sync',
@@ -1101,10 +1104,14 @@ def sparsify_rows(x, quantile=0.01):
     return x_sparse.tocsr()
 
 
+@deprecated('0.7.1', '0.8.0')
 def roll_sparse(x, shift, axis=0):
     '''Sparse matrix roll
 
     This operation is equivalent to ``numpy.roll``, but operates on sparse matrices.
+
+    .. warning:: This function is deprecated in version 0.7.1.
+                 It will be removed in version 0.8.0.
 
     Parameters
     ----------
@@ -1708,3 +1715,101 @@ def cyclic_gradient(data, edge_order=1, axis=-1):
     slices = [slice(None)] * data.ndim
     slices[axis] = slice(edge_order, -edge_order)
     return grad[tuple(slices)]
+
+
+@numba.jit(nopython=True)
+def __shear_dense(X, factor=+1, axis=-1):
+    '''Numba-accelerated shear for dense (ndarray) arrays'''
+
+    if axis == 0:
+        X = X.T
+    
+    X_shear = np.empty_like(X)
+    
+    for i in range(X.shape[1]):
+        X_shear[:, i] = np.roll(X[:, i], factor * i)
+        
+    if axis == 0:
+        X_shear = X_shear.T
+        
+    return X_shear
+
+
+def __shear_sparse(X, factor=+1, axis=-1):
+    '''Fast shearing for sparse matrices
+
+    Shearing is performed using CSC array indices,
+    and the result is converted back to whatever sparse format
+    the data was originally provided in.
+    '''
+    fmt = X.format
+    if axis == 0:
+        X = X.T
+        
+    # Now we're definitely rolling on the correct axis
+    X_shear = X.tocsc(copy=True) 
+    
+    # The idea here is to repeat the shear amount (factor * range)
+    # by the number of non-zeros for each column.
+    # The number of non-zeros is computed by diffing the index pointer array
+    roll = np.repeat(factor * np.arange(X_shear.shape[1]), np.diff(X_shear.indptr))
+
+    # In-place roll
+    np.mod(X_shear.indices + roll, X_shear.shape[0], out=X_shear.indices)
+    
+    if axis == 0:
+        X_shear = X_shear.T
+    
+    # And convert back to the input format
+    return X_shear.asformat(fmt)
+
+
+def shear(X, factor=1, axis=-1):
+    '''Shear a matrix by a given factor.
+
+    The `n`th column `X[:, n]` will be displaced (rolled)
+    by `factor * n`.
+
+    This is primarily useful for converting between lag and recurrence
+    representations: shearing with `factor=-1` converts the main diagonal
+    to a horizontal.  Shearing with `factor=1` converts a horizontal to
+    a diagonal.
+
+
+    Parameters
+    ----------
+    X : np.ndarray [ndim=2] or scipy.sparse matrix
+        The array to be sheared
+
+    factor : integer
+        The shear factor: `X[:, n] -> np.roll(X[:, n], factor * n)`
+
+    axis : integer
+        The axis along which to shear
+
+    Returns
+    -------
+    X_shear : same type as `X`
+        The sheared matrix
+
+    Examples
+    --------
+    >>> E = np.eye(3)
+    >>> librosa.util.shear(E, factor=-1, axis=-1)
+    array([[1., 1., 1.],
+           [0., 0., 0.],
+           [0., 0., 0.]])
+    >>> librosa.util.shear(E, factor=-1, axis=0)
+    array([[1., 0., 0.],
+           [1., 0., 0.],
+           [1., 0., 0.]])
+    >>> librosa.util.shear(E, factor=1, axis=-1)
+    array([[1., 0., 0.],
+           [0., 0., 1.],
+           [0., 1., 0.]])
+    '''
+
+    if scipy.sparse.isspmatrix(X):
+        return __shear_sparse(X, factor=factor, axis=axis)
+    else:
+        return __shear_dense(X, factor=factor, axis=axis)

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         'decorator >= 3.0.0',
         'six >= 1.3',
         'resampy >= 0.2.0',
-        'numba >= 0.38.0',
+        'numba >= 0.43.0',
         'soundfile >= 0.9.0',
     ],
     extras_require={

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1090,8 +1090,6 @@ def psig():
 @pytest.mark.parametrize('edge_order', [1, 2])
 @pytest.mark.parametrize('axis', [0, 1, -1])
 def test_cyclic_gradient(psig, edge_order, axis):
-
-
     grad = librosa.util.cyclic_gradient(psig,
                                         edge_order=edge_order,
                                         axis=axis)
@@ -1104,3 +1102,47 @@ def test_cyclic_gradient(psig, edge_order, axis):
         assert np.allclose(grad, 0)
     else:
         assert np.allclose(grad, [-1.5, 1, 1, 1, -1.5])
+
+
+
+def test_shear_dense():
+
+    E = np.eye(3)
+
+    E_shear = librosa.util.shear(E, factor=1, axis=0)
+    assert np.allclose(E_shear, np.asarray([[1, 0, 0], [0, 0, 1], [0, 1, 0]]))
+
+    E_shear = librosa.util.shear(E, factor=1, axis=1)
+    assert np.allclose(E_shear, np.asarray([[1, 0, 0], [0, 0, 1], [0, 1, 0]]))
+
+    E_shear = librosa.util.shear(E, factor=-1, axis=1)
+    assert np.allclose(E_shear, np.asarray([[1, 1, 1], [0, 0, 0], [0, 0, 0]]))
+
+    E_shear = librosa.util.shear(E, factor=-1, axis=0)
+    assert np.allclose(E_shear, np.asarray([[1, 0, 0], [1, 0, 0], [1, 0, 0]]))
+
+
+@pytest.mark.parametrize('fmt', ['csc', 'csr', 'lil', 'dok'])
+def test_shear_sparse(fmt):
+    E = scipy.sparse.identity(3, format=fmt)
+
+    E_shear = librosa.util.shear(E, factor=1, axis=0)
+    assert E_shear.format == fmt
+    assert np.allclose(E_shear.toarray(),
+                       np.asarray([[1, 0, 0], [0, 0, 1], [0, 1, 0]]))
+
+    E_shear = librosa.util.shear(E, factor=1, axis=1)
+    assert E_shear.format == fmt
+    assert np.allclose(E_shear.toarray(),
+                       np.asarray([[1, 0, 0], [0, 0, 1], [0, 1, 0]]))
+
+    E_shear = librosa.util.shear(E, factor=-1, axis=1)
+    assert E_shear.format == fmt
+    assert np.allclose(E_shear.toarray(),
+                       np.asarray([[1, 1, 1], [0, 0, 0], [0, 0, 0]]))
+
+    E_shear = librosa.util.shear(E, factor=-1, axis=0)
+    assert E_shear.format == fmt
+    assert np.allclose(E_shear.toarray(),
+                       np.asarray([[1, 0, 0], [1, 0, 0], [1, 0, 0]]))
+

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1146,3 +1146,7 @@ def test_shear_sparse(fmt):
     assert np.allclose(E_shear.toarray(),
                        np.asarray([[1, 0, 0], [1, 0, 0], [1, 0, 0]]))
 
+
+@pytest.mark.xfail(raises=librosa.ParameterError)
+def test_shear_badfactor():
+    librosa.util.shear(np.eye(3), factor=None)


### PR DESCRIPTION
#### Reference Issue
Fixes #839 and #907 

[EDIT by @lostanlen: fixes #907]


#### What does this implement/fix? Explain your changes.

This PR contains a rewrite of the lag<->recurrence conversion functions.

The new version is somewhere between 2 and 6000x faster, but functionally equivalent.

To support this, I added a new function `util.shear` which shears a 2-d array along a given axis at a given slope (positive or negative).  For dense matrices, it uses a numba-accelerated roll loop.  For sparse matrices, it operates directly on compressed index data structures to shear the matrix without moving data.

The old `roll_sparse` function is now deprecated and will be removed in 0.8.

#### Any other comments?

We now require numba >= 0.43 for `np.roll` support.