### PR TITLE
Allow initial phase estimates for griffinlim methods

### DIFF
--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -363,7 +363,7 @@ def test_icqt():
 @pytest.fixture
 def y_chirp():
     sr = 22050
-    y = librosa.chirp(55, 55 * 2**3, length=sr//4, sr=sr)
+    y = librosa.chirp(55, 55 * 2**3, length=sr//8, sr=sr)
     return y
 
 
@@ -378,8 +378,9 @@ def y_chirp():
 @pytest.mark.parametrize('random_state', [None, 0, np.random.RandomState()])
 @pytest.mark.parametrize('fmin', [40.0])
 @pytest.mark.parametrize('dtype', [np.float32, np.float64])
+@pytest.mark.parametrize('init', [None, 'random'])
 def test_griffinlim_cqt(y_chirp, hop_length, window, use_length, over_sample, fmin,
-                        res_type, pad_mode, scale, momentum, random_state, dtype):
+                        res_type, pad_mode, scale, momentum, init, random_state, dtype):
 
     if use_length:
         length = len(y_chirp)
@@ -408,6 +409,7 @@ def test_griffinlim_cqt(y_chirp, hop_length, window, use_length, over_sample, fm
                                    random_state=random_state,
                                    length=length,
                                    res_type=res_type,
+                                   init=init,
                                    dtype=dtype)
 
     y_inv = librosa.icqt(Cmag, sr=sr, fmin=fmin, hop_length=hop_length,
@@ -422,6 +424,12 @@ def test_griffinlim_cqt(y_chirp, hop_length, window, use_length, over_sample, fm
 
     # Check that the data is okay
     assert np.all(np.isfinite(y_rec))
+
+
+@pytest.mark.xfail(raises=librosa.ParameterError)
+def test_griffinlim_cqt_badinit():
+    x = np.zeros((33, 3))
+    librosa.griffinlim_cqt(x, init='garbage')
 
 
 @pytest.mark.xfail(raises=librosa.ParameterError)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1913,7 +1913,7 @@ def test_reset_fftlib():
 @pytest.fixture
 def y_chirp():
     sr = 22050
-    y = librosa.chirp(55, 55 * 2**7, length=sr//2, sr=sr)
+    y = librosa.chirp(55, 55 * 2**7, length=sr//8, sr=sr)
     return y
 
 
@@ -1926,7 +1926,8 @@ def y_chirp():
 @pytest.mark.parametrize('pad_mode', ['constant', 'reflect'])
 @pytest.mark.parametrize('momentum', [0, 0.99])
 @pytest.mark.parametrize('random_state', [None, 0, np.random.RandomState()])
-def test_griffinlim(y_chirp, hop_length, win_length, window, center, dtype, use_length, pad_mode, momentum, random_state):
+@pytest.mark.parametrize('init', [None, 'random'])
+def test_griffinlim(y_chirp, hop_length, win_length, window, center, dtype, use_length, pad_mode, momentum, init, random_state):
 
     if use_length:
         length = len(y_chirp)
@@ -1942,6 +1943,7 @@ def test_griffinlim(y_chirp, hop_length, win_length, window, center, dtype, use_
                                window=window, center=center, dtype=dtype,
                                length=length, pad_mode=pad_mode,
                                n_iter=3, momentum=momentum,
+                               init=init,
                                random_state=random_state)
 
     # First, check length
@@ -1950,6 +1952,11 @@ def test_griffinlim(y_chirp, hop_length, win_length, window, center, dtype, use_
 
     # Next, check dtype
     assert y_rec.dtype == dtype
+
+@pytest.mark.xfail(raises=librosa.ParameterError)
+def test_griffinlim_badinit():
+    x = np.zeros((33, 3))
+    librosa.griffinlim(x, init='garbage')
 
 
 @pytest.mark.xfail(raises=librosa.ParameterError)


### PR DESCRIPTION

#### Reference Issue
Fixes #948 


#### What does this implement/fix? Explain your changes.

This PR adds a new parameter `init=` to Griffin-Lim methods.  Supported modes are `None` and `'random'` (default).  If `init=None`, then the initial phase estimate is taken from the spectrogram input.  If the input is a magnitude spectrogram, this is equivalent to initializing with all-zeros.  However, if you have a good phase guess already, you can pass in a complex-valued `S` and the phase will be taken directly.

Under the hood, this is implemented by setting `angles[:] = 1` when `init is None`, so that `S * angles` preserves phase.  This avoids any tricky type-based dispatching, and lets us keep the algorithm exactly as it was before.

As an added bonus, this turns our GL implementation into an any-time algorithm, and computation can be resumed from a previous stopping point.  For instance:

```python
y = griffinlim(S, ..., n_iter=10)

# Is y good enough?  No?  Keep going...
S = librosa.stft(y, ...)
y = griffinlim(S, ..., n_iter=10, init=None)
```
