### PR TITLE
Deprecated ifgram

### DIFF
--- a/librosa/core/__init__.py
+++ b/librosa/core/__init__.py
@@ -29,7 +29,8 @@ Spectral representations
 
     stft
     istft
-    ifgram
+    reassigned_spectrogram
+
     cqt
     icqt
     hybrid_cqt
@@ -110,6 +111,13 @@ Pitch and tuning
     estimate_tuning
     pitch_tuning
     piptrack
+
+Deprecated
+----------
+.. autosummary::
+    :toctree: generated/
+
+    ifgram
 """
 
 from .time_frequency import *  # pylint: disable=wildcard-import

--- a/librosa/core/harmonic.py
+++ b/librosa/core/harmonic.py
@@ -17,7 +17,7 @@ def salience(S, freqs, h_range, weights=None, aggregate=None,
     Parameters
     ----------
     S : np.ndarray [shape=(d, n)]
-        input time frequency magnitude representation (stft, ifgram, etc).
+        input time frequency magnitude representation (e.g. STFT or CQT magnitudes).
         Must be real-valued and non-negative.
     freqs : np.ndarray, shape=(S.shape[axis])
         The frequency values corresponding to S's elements along the

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -18,6 +18,7 @@ from .audio import resample
 from .._cache import cache
 from .. import util
 from ..util.exceptions import ParameterError
+from ..util.decorators import deprecated
 from ..filters import get_window, semitone_filterbank
 from ..filters import window_sumsquare
 
@@ -132,7 +133,7 @@ def stft(y, n_fft=2048, hop_length=None, win_length=None, window='hann',
     --------
     istft : Inverse STFT
 
-    ifgram : Instantaneous frequency spectrogram
+    reassigned_spectrogram : Time-frequency reassigned STFT
 
 
     Notes
@@ -406,6 +407,7 @@ def __overlap_add(y, ytmp, hop_length):
         y[sample:(sample + n_fft)] += ytmp[:, frame]
 
 
+@deprecated('0.7.1', '0.8.0')
 def ifgram(y, sr=22050, n_fft=2048, hop_length=None, win_length=None,
            window='hann', norm=False, center=True, ref_power=1e-6,
            clip=True, dtype=np.complex64, pad_mode='reflect'):
@@ -420,6 +422,11 @@ def ifgram(y, sr=22050, n_fft=2048, hop_length=None, win_length=None,
         frequency."
         International Conference on Acoustics, Speech, and Signal Processing,
         ICASSP-95., Vol. 1. IEEE, 1995.
+
+
+    .. warning:: This function is deprecated in version 0.7.1, and will be removed
+                 in version 0.8.0.  The function `reassigned_spectrogram` provides
+                 equivalent functionality, and should be used instead of `ifgram`.
 
     Parameters
     ----------
@@ -490,6 +497,7 @@ def ifgram(y, sr=22050, n_fft=2048, hop_length=None, win_length=None,
     See Also
     --------
     stft : Short-time Fourier Transform
+    reassigned_spectrogram : Time-frequency reassigned spectrogram
 
     Examples
     --------

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -133,7 +133,7 @@ def stft(y, n_fft=2048, hop_length=None, win_length=None, window='hann',
     --------
     istft : Inverse STFT
 
-    reassigned_spectrogram : Time-frequency reassigned STFT
+    reassigned_spectrogram : Time-frequency reassigned spectrogram
 
 
     Notes
@@ -426,7 +426,7 @@ def ifgram(y, sr=22050, n_fft=2048, hop_length=None, win_length=None,
 
     .. warning:: This function is deprecated in version 0.7.1, and will be removed
                  in version 0.8.0.  The function `reassigned_spectrogram` provides
-                 equivalent functionality, and should be used instead of `ifgram`.
+                 comparable functionality, and should be used instead of `ifgram`.
 
     Parameters
     ----------


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This PR deprecates `ifgram` in favor of the new `reassigned_spectrogram` function merged in #926 .

It also fixes a few spots of documentation that were not updated in the #926 merge but should have been.  No functionality changes here.