### PR TITLE
times_like audit

### DIFF
--- a/librosa/beat.py
+++ b/librosa/beat.py
@@ -147,8 +147,7 @@ def beat_track(y=None, sr=22050, onset_envelope=None, hop_length=512,
     >>> import matplotlib.pyplot as plt
     >>> hop_length = 512
     >>> plt.figure(figsize=(8, 4))
-    >>> times = librosa.frames_to_time(np.arange(len(onset_env)),
-    ...                                sr=sr, hop_length=hop_length)
+    >>> times = librosa.times_like(onset_env, sr=sr, hop_length=hop_length)
     >>> plt.plot(times, librosa.util.normalize(onset_env),
     ...          label='Onset strength')
     >>> plt.vlines(times[beats], 0, 1, alpha=0.5, color='r',
@@ -296,7 +295,7 @@ def tempo(y=None, sr=22050, onset_envelope=None, hop_length=512, start_bpm=120,
     >>> tg = librosa.feature.tempogram(onset_envelope=onset_env, sr=sr,
     ...                                hop_length=hop_length)
     >>> librosa.display.specshow(tg, x_axis='time', y_axis='tempo')
-    >>> plt.plot(librosa.frames_to_time(np.arange(len(dtempo))), dtempo,
+    >>> plt.plot(librosa.times_like(dtempo), dtempo,
     ...          color='w', linewidth=1.5, label='Tempo estimate')
     >>> plt.title('Dynamic tempo estimation')
     >>> plt.legend(frameon=True, framealpha=0.75)

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -34,24 +34,25 @@ __all__ = ['stft', 'istft', 'magphase', 'iirt', 'ifgram',
 @cache(level=20)
 def stft(y, n_fft=2048, hop_length=None, win_length=None, window='hann',
          center=True, dtype=np.complex64, pad_mode='reflect'):
-    """Short-time Fourier transform (STFT). [1, chapter 2]
-    
+    """Short-time Fourier transform (STFT). [1]_ (chapter 2)
+
     The STFT represents a signal in the time-frequency domain by
     computing discrete Fourier transforms (DFT) over short overlapping
     windows.
 
     This function returns a complex-valued matrix D such that
-        `np.abs(D[f, t])` is the magnitude of frequency bin `f`
-        at frame `t`
-    and
-        `np.angle(D[f, t])` is the phase of frequency bin `f`
-        at frame `t`.
-        
+
+    - `np.abs(D[f, t])` is the magnitude of frequency bin `f`
+      at frame `t`, and
+
+    - `np.angle(D[f, t])` is the phase of frequency bin `f`
+      at frame `t`.
+
     The integers `t` and `f` can be converted to physical units by means
     of the utility functions `frames_to_sample` and `fft_frequencies`.
-        
+
     .. [1] M. Müller. "Fundamentals of Music Processing." Springer, 2015
-         
+
 
     Parameters
     ----------
@@ -63,7 +64,7 @@ def stft(y, n_fft=2048, hop_length=None, win_length=None, window='hann',
         The number of rows in the STFT matrix `D` is (1 + n_fft/2).
         The default value, n_fft=2048 samples, corresponds to a physical
         duration of 93 milliseconds at a sample rate of 22050 Hz, i.e. the
-        default sample rate in librosa. This value is well adapted for music 
+        default sample rate in librosa. This value is well adapted for music
         signals. However, in speech processing, the recommended value is 512,
         corresponding to 23 milliseconds at a sample rate of 22050 Hz.
         In any case, we recommend setting `n_fft` to a power of two for
@@ -71,27 +72,36 @@ def stft(y, n_fft=2048, hop_length=None, win_length=None, window='hann',
 
     hop_length : int > 0 [scalar]
         number of audio samples between adjacent STFT columns.
+
         Smaller values increase the number of columns in `D` without
         affecting the frequency resolution of the STFT.
+
         If unspecified, defaults to `win_length / 4` (see below).
 
     win_length : int <= n_fft [scalar]
         Each frame of audio is windowed by `window()` of length `win_length`
         and then padded with zeros to match `n_fft`.
+
         Smaller values improve the temporal resolution of the STFT (i.e. the
         ability to discriminate impulses that are closely spaced in time)
         at the expense of frequency resolution (i.e. the ability to discriminate
         pure tones that are closely spaced in frequency). This effect is known
         as the time-frequency localization tradeoff and needs to be adjusted
         according to the properties of the input signal `y`.
+
         If unspecified, defaults to ``win_length = n_fft``.
 
     window : string, tuple, number, function, or np.ndarray [shape=(n_fft,)]
         Either:
+
         - a window specification (string, tuple, or number);
           see `scipy.signal.get_window`
+
         - a window function, such as `scipy.signal.hanning`
+
         - a vector or array of length `n_fft`
+
+
         Defaults to a raised cosine window ("hann"), which is adequate for
         most applications in audio signal processing.
 
@@ -105,7 +115,7 @@ def stft(y, n_fft=2048, hop_length=None, win_length=None, window='hann',
         time grid by means of `librosa.core.frames_to_samples`.
         Note, however, that `center` must be set to `False` when analyzing
         signals with `librosa.stream`.
-        
+
         .. see also:: `stream`
 
     dtype : numeric type
@@ -118,7 +128,7 @@ def stft(y, n_fft=2048, hop_length=None, win_length=None, window='hann',
         `y` is padded on both sides with its own reflection, mirrored around
         its first and last sample respectively.
         If `center=False`,  this argument is ignored.
-        
+
         .. see also:: `np.pad`
 
 
@@ -181,7 +191,6 @@ def stft(y, n_fft=2048, hop_length=None, win_length=None, window='hann',
     >>> plt.colorbar(format='%+2.0f dB')
     >>> plt.tight_layout()
     >>> plt.show()
-
     """
 
     # By default, use the entire frame
@@ -886,15 +895,16 @@ def reassigned_spectrogram(y, sr=22050, S=None, n_fft=2048, hop_length=None,
                            reassign_frequencies=True, reassign_times=True,
                            ref_power=1e-6, fill_nan=False, clip=True,
                            dtype=np.complex64, pad_mode="reflect"):
-    """Time-frequency reassigned spectrogram.
+    r"""Time-frequency reassigned spectrogram.
 
     The reassignment vectors are calculated using equations 5.20 and 5.23 in
     [1]_:
 
     .. math::
 
-        \hat{\omega} = \omega - \Im(\frac{S_{dh}}{S_h}) \\
-        \hat{t} = t + \Re(\frac{S_{th}}{S_h})
+        \hat{\omega} = \omega - \Im\left(\frac{S_{dh}}{S_h}\right) \\
+        \hat{t} = t + \Re\left(\frac{S_{th}}{S_h}\right)
+
 
     where `S_h` is the complex STFT calculated using the original window,
     `S_dh` is the complex STFT calculated using the derivative of the original
@@ -919,22 +929,22 @@ def reassigned_spectrogram(y, sr=22050, S=None, n_fft=2048, hop_length=None,
     boundary frames.
 
     .. [1] Flandrin, P., Auger, F., & Chassande-Mottin, E. (2002).
-    Time-Frequency reassignment: From principles to algorithms. In Applications
-    in Time-Frequency Signal Processing (Vol. 10, pp. 179-204). CRC Press.
+        Time-Frequency reassignment: From principles to algorithms. In Applications
+        in Time-Frequency Signal Processing (Vol. 10, pp. 179-204). CRC Press.
 
     .. [2] Fulop, S. A., & Fitz, K. (2006). Algorithms for computing the
-    time-corrected instantaneous frequency (reassigned) spectrogram, with
-    applications. The Journal of the Acoustical Society of America, 119(1),
-    360. doi:10.1121/1.2133000
+        time-corrected instantaneous frequency (reassigned) spectrogram, with
+        applications. The Journal of the Acoustical Society of America, 119(1),
+        360. doi:10.1121/1.2133000
 
     .. [3] Auger, F., Flandrin, P., Lin, Y.-T., McLaughlin, S., Meignen, S.,
-    Oberlin, T., & Wu, H.-T. (2013). Time-Frequency Reassignment and
-    Synchrosqueezing: An Overview. IEEE Signal Processing Magazine, 30(6),
-    32-41. doi:10.1109/MSP.2013.2265316
+        Oberlin, T., & Wu, H.-T. (2013). Time-Frequency Reassignment and
+        Synchrosqueezing: An Overview. IEEE Signal Processing Magazine, 30(6),
+        32-41. doi:10.1109/MSP.2013.2265316
 
     .. [4] Hainsworth, S., Macleod, M. (2003). Time-frequency reassignment: a
-    review and analysis. Tech. Rep. CUED/FINFENG/TR.459, Cambridge University
-    Engineering Department
+        review and analysis. Tech. Rep. CUED/FINFENG/TR.459, Cambridge University
+        Engineering Department
 
     Parameters
     ----------
@@ -1070,7 +1080,6 @@ def reassigned_spectrogram(y, sr=22050, S=None, n_fft=2048, hop_length=None,
     ...     left=0.1, bottom=0.05, right=0.95, top=0.95, hspace=0.5
     ... )
     >>> plt.show()
-
     """
 
     if not six.callable(ref_power) and ref_power < 0:

--- a/librosa/display.py
+++ b/librosa/display.py
@@ -476,9 +476,7 @@ def waveplot(y, sr=22050, max_points=5e4, x_axis='time', offset=0.0,
 
     kwargs.setdefault('color', next(axes._get_lines.prop_cycler)['color'])
 
-    locs = offset + core.frames_to_time(np.arange(len(y_top)),
-                                        sr=sr,
-                                        hop_length=hop_length)
+    locs = offset + core.times_like(y_top, sr=sr, hop_length=hop_length)
 
     out = axes.fill_between(locs, y_bottom, y_top, **kwargs)
 

--- a/librosa/onset.py
+++ b/librosa/onset.py
@@ -114,7 +114,7 @@ def onset_detect(y=None, sr=22050, onset_envelope=None, hop_length=512,
     Or use a pre-computed onset envelope
 
     >>> o_env = librosa.onset.onset_strength(y, sr=sr)
-    >>> times = librosa.frames_to_time(np.arange(len(o_env)), sr=sr)
+    >>> times = librosa.times_like(o_env, sr=sr)
     >>> onset_frames = librosa.onset.onset_detect(onset_envelope=o_env, sr=sr)
 
 
@@ -277,7 +277,7 @@ def onset_strength(y=None, sr=22050, S=None, lag=1, max_size=1,
     >>> y, sr = librosa.load(librosa.util.example_audio_file(),
     ...                      duration=10.0)
     >>> D = np.abs(librosa.stft(y))
-    >>> times = librosa.frames_to_time(np.arange(D.shape[1]))
+    >>> times = librosa.times_like(D)
     >>> plt.figure()
     >>> ax1 = plt.subplot(2, 1, 1)
     >>> librosa.display.specshow(librosa.amplitude_to_db(D, ref=np.max),

--- a/librosa/sequence.py
+++ b/librosa/sequence.py
@@ -976,9 +976,11 @@ def viterbi_discriminative(prob, transition, p_state=None, p_init=None, return_l
 
     >>> # Load in audio and make features
     >>> y, sr = librosa.load(librosa.util.example_audio_file())
+    >>> # Suppress percussive elements
+    >>> y = librosa.effects.harmonic(y, margin=4)
     >>> chroma = librosa.feature.chroma_cens(y=y, sr=sr, bins_per_octave=36)
     >>> # Map chroma (observations) to class (state) likelihoods
-    >>> probs = np.exp(weights.dot(chroma))  # P[class | chroma] proportional to exp(template' chroma)
+    >>> probs = np.exp(weights.dot(chroma))  # P[class | chroma] ~= exp(template' chroma)
     >>> probs /= probs.sum(axis=0, keepdims=True)  # probabilities must sum to 1 in each column
     >>> # Compute independent frame-wise estimates
     >>> chords_ind = np.argmax(probs, axis=0)
@@ -1003,10 +1005,13 @@ def viterbi_discriminative(prob, transition, p_state=None, p_init=None, return_l
     >>> plt.figure(figsize=(10, 4))
     >>> librosa.display.specshow(probs, x_axis='time', cmap='gray')
     >>> plt.colorbar()
-    >>> times = librosa.frames_to_time(np.arange(len(chords_vit)))
-    >>> plt.scatter(times, chords_ind + 0.75, color='lime', alpha=0.5, marker='+', s=15, label='Independent')
-    >>> plt.scatter(times, chords_vit + 0.25, color='deeppink', alpha=0.5, marker='o', s=15, label='Viterbi')
-    >>> plt.yticks(0.5 + np.unique(chords_vit), [labels[i] for i in np.unique(chords_vit)], va='center')
+    >>> times = librosa.times_like(chords_vit)
+    >>> plt.scatter(times, chords_ind + 0.75, color='lime', alpha=0.5, marker='+',
+    ...             s=15, label='Independent')
+    >>> plt.scatter(times, chords_vit + 0.25, color='deeppink', alpha=0.5, marker='o',
+    ...             s=15, label='Viterbi')
+    >>> plt.yticks(0.5 + np.unique(chords_vit),
+    ...            [labels[i] for i in np.unique(chords_vit)], va='center')
     >>> plt.legend()
     >>> plt.tight_layout()
     >>> plt.show()

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -907,8 +907,7 @@ def peak_pick(x, pre_max, post_max, pre_avg, post_avg, delta, wait):
            510, 525, 536, 555, 570, 590, 609, 625, 639])
 
     >>> import matplotlib.pyplot as plt
-    >>> times = librosa.frames_to_time(np.arange(len(onset_env)),
-    ...                                sr=sr, hop_length=512)
+    >>> times = librosa.times_like(onset_env, sr=sr, hop_length=512)
     >>> plt.figure()
     >>> ax = plt.subplot(2, 1, 2)
     >>> D = librosa.stft(y)


### PR DESCRIPTION
#### Reference Issue
Fixes #954 


#### What does this implement/fix? Explain your changes.

This PR mostly consists of modernization of docstring examples to use `times_like(X)` instead of the older style of `frames_to_time(np.arange(len(X)))` (or something morally equivalent).

There were a couple of spots in the code (display module, mostly) that also used the old style, and these have been modernized as well.

#### Any other comments?

In addition to modernization, I noticed a few badly formatted docstrings while building docs to test the changes in this PR.  I've fixed those here, even though they're out of the specific scope of #954.

No major CR needs here, IMO.  It should be good to go once CI passes.