### PR TITLE
Ensure fortran-ordering of audio buffers after resampling

### DIFF
--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -535,7 +535,7 @@ def resample(y, orig_sr, target_sr, res_type='kaiser_best', fix=True, scale=Fals
     if scale:
         y_hat /= np.sqrt(ratio)
 
-    return np.asfortranarray(y_hat)
+    return np.asfortranarray(y_hat, dtype=y.dtype)
 
 
 def get_duration(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -535,7 +535,7 @@ def resample(y, orig_sr, target_sr, res_type='kaiser_best', fix=True, scale=Fals
     if scale:
         y_hat /= np.sqrt(ratio)
 
-    return np.ascontiguousarray(y_hat, dtype=y.dtype)
+    return np.asfortranarray(y_hat)
 
 
 def get_duration(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'joblib >= 0.12',
         'decorator >= 3.0.0',
         'six >= 1.3',
-        'resampy >= 0.2.0',
+        'resampy >= 0.2.2',
         'numba >= 0.43.0',
         'soundfile >= 0.9.0',
     ],


### PR DESCRIPTION
#### Reference Issue
Fixes #959 

#### What does this implement/fix? Explain your changes.

This PR fixes multi-channel resampling to always produce fortran-ordered audio buffers.

Resampy does this by default (if the input is fortran-ordered), scipy resamplers do not, so we force it on output.

#### Any other comments?

The minimum version requirement for resampy has been incremented to 0.2.2.

The tests for resample have been restructured to be a bit more pytesthonic.