### PR TITLE
Compat fix: Fix core.load fallback condition

### DIFF
--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -139,7 +139,7 @@ def load(path, sr=22050, mono=True, offset=0.0, duration=None,
             # Load the target number of frames, and transpose to match librosa form
             y = sf_desc.read(frames=frame_duration, dtype=dtype, always_2d=False).T
 
-    except RuntimeError as exc:
+    except (RuntimeError, OSError) as exc:
 
         # If soundfile failed, try audioread instead
         if isinstance(path, six.string_types):


### PR DESCRIPTION
Property fallback to audioread when OSError is raised in soundfile due to missing libsndfile binary dependency (like https://github.com/bastibe/SoundFile/issues/118)

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/master/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
<!-- Example: Fixes #123 -->

Supports https://github.com/librosa/librosa/issues/845
Ref: https://github.com/librosa/librosa/pull/847

#### What does this implement/fix? Explain your changes.

Fallback to old audioeread backend when `OSError` is raised in sndfile.

#### Any other comments?

I know the notice below, but I'd prefer a non-breaking approach if possible.

https://github.com/librosa/librosa/tree/b1e41e83a9d177d7ca83bf7e0160c5e3c4177e3b#soundfile
> If you're using pip on a Linux environment, you may need to install libsndfile manually. Please refer to the SoundFile installation documentation for details.