### PR TITLE
Beat and tempo priors

### DIFF
--- a/librosa/beat.py
+++ b/librosa/beat.py
@@ -51,7 +51,7 @@ def beat_track(y=None, sr=22050, onset_envelope=None, hop_length=512,
         sampling rate of `y`
 
     onset_envelope : np.ndarray [shape=(n,)] or None
-        ((optional) pre-computed onset strength envelope.
+        (optional) pre-computed onset strength envelope.
 
     hop_length : int > 0 [scalar]
         number of audio samples between successive `onset_envelope` values
@@ -71,7 +71,6 @@ def beat_track(y=None, sr=22050, onset_envelope=None, hop_length=512,
 
     prior      : scipy.stats.rv_continuous [optional]
         An optional prior distribution over tempo.
-
         If provided, `start_bpm` will be ignored.
 
     units : {'frames', 'samples', 'time'}
@@ -97,8 +96,7 @@ def beat_track(y=None, sr=22050, onset_envelope=None, hop_length=512,
     Raises
     ------
     ParameterError
-        if neither `y` nor `onset_envelope` are provided
-
+        if neither `y` nor `onset_envelope` are provided,
         or if `units` is not one of 'frames', 'samples', or 'time'
 
     See Also
@@ -245,7 +243,6 @@ def tempo(y=None, sr=22050, onset_envelope=None, hop_length=512, start_bpm=120,
     prior : scipy.stats.rv_continuous [optional]
         A prior distribution over tempo (in beats per minute).
         By default, a pseudo-log-normal prior is used.
-
         If given, `start_bpm` and `std_bpm` will be ignored.
 
     Returns
@@ -365,7 +362,8 @@ def tempo(y=None, sr=22050, onset_envelope=None, hop_length=512, start_bpm=120,
         logprior[:max_idx] = -np.inf
 
     # Get the maximum, weighted by the prior
-    best_period = np.argmax(np.log(tg + 1e-10) + logprior[:, np.newaxis], axis=0)
+    # Using log1p here for numerical stability
+    best_period = np.argmax(np.log1p(1e6 * tg) + logprior[:, np.newaxis], axis=0)
 
     return bpms[best_period]
 
@@ -527,7 +525,7 @@ def plp(y=None, sr=22050, onset_envelope=None, hop_length=512,
         ftgram[tempo_frequencies > tempo_max] = 0
 
     # Step 3: Discard everything below the peak
-    ftmag = np.log(1e-10 + np.abs(ftgram))
+    ftmag = np.log1p(1e6 * np.abs(ftgram))
     if prior is not None:
         ftmag += prior.logpdf(tempo_frequencies)[:, np.newaxis]
 

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -105,9 +105,10 @@ def test_tempo_no_onsets():
                                    hop_length=hop_length,
                                    start_bpm=start_bpm,
                                    aggregate=aggregate)
-        assert np.allclose(tempo, start_bpm)
+        # Depending on bin resolution, we might not be able to match exactly
+        assert np.allclose(tempo, start_bpm, atol=1e0)
 
-    for start_bpm in [40, 60, 120, 240]:
+    for start_bpm in [40, 60, 117, 235]:
         for aggregate in [None, np.mean]:
             yield __test, start_bpm, aggregate
 

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -14,6 +14,7 @@ except:
 import pytest
 
 import numpy as np
+import scipy.stats
 import librosa
 
 from test_core import files, load
@@ -21,54 +22,47 @@ from test_core import files, load
 __EXAMPLE_FILE = os.path.join('tests', 'data', 'test1_22050.wav')
 
 
-def test_onset_strength():
+@pytest.mark.parametrize('infile', files(os.path.join('data', 'beat-onset-*.mat')))
+def test_onset_strength(infile):
 
-    def __test(infile):
-        DATA = load(infile)
+    DATA = load(infile)
 
-        # Compute onset envelope using the same spectrogram
-        onsets = librosa.onset.onset_strength(y=None,
-                                              sr=8000,
-                                              S=DATA['D'],
-                                              lag=1,
-                                              max_size=1,
-                                              center=False,
-                                              detrend=True,
-                                              aggregate=np.mean)
+    # Compute onset envelope using the same spectrogram
+    onsets = librosa.onset.onset_strength(y=None,
+                                          sr=8000,
+                                          S=DATA['D'],
+                                          lag=1,
+                                          max_size=1,
+                                          center=False,
+                                          detrend=True,
+                                          aggregate=np.mean)
 
-        assert np.allclose(onsets[1:], DATA['onsetenv'][0])
-
-        pass
-
-    for infile in files(os.path.join('data','beat-onset-*.mat')):
-        yield (__test, infile)
+    assert np.allclose(onsets[1:], DATA['onsetenv'][0])
 
 
-def test_tempo():
+@pytest.mark.parametrize('tempo', [60, 80, 110, 160])
+@pytest.mark.parametrize('sr', [22050, 44100])
+@pytest.mark.parametrize('hop_length', [512, 1024])
+@pytest.mark.parametrize('ac_size', [4, 8])
+@pytest.mark.parametrize('aggregate', [None, np.mean])
+@pytest.mark.parametrize('prior', [None, scipy.stats.uniform(60, 240)])
+def test_tempo(tempo, sr, hop_length, ac_size, aggregate, prior):
 
-    def __test(tempo, sr, hop_length, ac_size, aggregate, y):
+    y = np.zeros(20 * sr)
+    delay = np.asscalar(librosa.time_to_samples(60./tempo, sr=sr))
+    y[::delay] = 1
 
-        tempo_est = librosa.beat.tempo(y=y, sr=sr, hop_length=hop_length,
-                                       ac_size=ac_size,
-                                       aggregate=aggregate)
+    tempo_est = librosa.beat.tempo(y=y, sr=sr, hop_length=hop_length,
+                                   ac_size=ac_size,
+                                   aggregate=aggregate,
+                                   prior=prior)
 
-        # Being within 5% for the stable frames is close enough
-        if aggregate is None:
-            win_size = int(ac_size * sr // hop_length)
-            assert np.all(np.abs(tempo_est[win_size:-win_size] - tempo) <= 0.05 * tempo)
-        else:
-            assert np.abs(tempo_est - tempo) <= 0.05 * tempo, (tempo, tempo_est)
-
-    for sr in [22050, 44100]:
-        for tempo in [40, 60, 80, 110, 160]:
-            # Make a pulse train at the target tempo
-            y = np.zeros(20 * sr)
-            delay = np.asscalar(librosa.time_to_samples(60./tempo, sr=sr))
-            y[::delay] = 1
-            for hop_length in [512, 1024]:
-                for ac_size in [4, 8]:
-                    for aggregate in [None, np.mean]:
-                        yield __test, tempo, sr, hop_length, ac_size, aggregate, y
+    # Being within 5% for the stable frames is close enough
+    if aggregate is None:
+        win_size = int(ac_size * sr // hop_length)
+        assert np.all(np.abs(tempo_est[win_size:-win_size] - tempo) <= 0.05 * tempo)
+    else:
+        assert np.abs(tempo_est - tempo) <= 0.05 * tempo, (tempo, tempo_est)
 
 
 @pytest.mark.xfail(raises=librosa.ParameterError)
@@ -93,24 +87,19 @@ def test_beat_no_onsets():
     assert len(beats) == 0
 
 
-def test_tempo_no_onsets():
+@pytest.mark.parametrize('start_bpm', [40, 60, 117, 235])
+@pytest.mark.parametrize('aggregate', [None, np.mean])
+@pytest.mark.parametrize('onsets', [np.zeros(30 * 22050 // 512)])
+@pytest.mark.parametrize('sr', [22050])
+@pytest.mark.parametrize('hop_length', [512])
+def test_tempo_no_onsets(start_bpm, aggregate, onsets, sr, hop_length):
 
-    sr = 22050
-    hop_length = 512
-    duration = 30
-    onsets = np.zeros(duration * sr // hop_length)
-
-    def __test(start_bpm, aggregate):
-        tempo = librosa.beat.tempo(onset_envelope=onsets, sr=sr,
-                                   hop_length=hop_length,
-                                   start_bpm=start_bpm,
-                                   aggregate=aggregate)
-        # Depending on bin resolution, we might not be able to match exactly
-        assert np.allclose(tempo, start_bpm, atol=1e0)
-
-    for start_bpm in [40, 60, 117, 235]:
-        for aggregate in [None, np.mean]:
-            yield __test, start_bpm, aggregate
+    tempo = librosa.beat.tempo(onset_envelope=onsets, sr=sr,
+                               hop_length=hop_length,
+                               start_bpm=start_bpm,
+                               aggregate=aggregate)
+    # Depending on bin resolution, we might not be able to match exactly
+    assert np.allclose(tempo, start_bpm, atol=1e0)
 
 
 def test_beat():
@@ -199,7 +188,8 @@ def test_beat_units(sr, hop_length, units):
                                                   (60, None),
                                                   pytest.mark.xfail((120, 80),
                                                       raises=librosa.ParameterError)])
-def test_plp(sr, hop_length, win_length, tempo_min, tempo_max, use_onset):
+@pytest.mark.parametrize('prior', [None, scipy.stats.lognorm(s=1, loc=np.log(120), scale=120)])
+def test_plp(sr, hop_length, win_length, tempo_min, tempo_max, use_onset, prior):
 
     y, sr = librosa.load(__EXAMPLE_FILE, sr=sr)
 
@@ -210,13 +200,15 @@ def test_plp(sr, hop_length, win_length, tempo_min, tempo_max, use_onset):
                                  hop_length=hop_length,
                                  win_length=win_length,
                                  tempo_min=tempo_min,
-                                 tempo_max=tempo_max)
+                                 tempo_max=tempo_max,
+                                 prior=prior)
     else:
         pulse = librosa.beat.plp(y=y, sr=sr,
                                  hop_length=hop_length,
                                  win_length=win_length,
                                  tempo_min=tempo_min,
-                                 tempo_max=tempo_max)
+                                 tempo_max=tempo_max,
+                                 prior=prior)
 
     assert len(pulse) == len(oenv)
 
@@ -227,19 +219,15 @@ def test_plp(sr, hop_length, win_length, tempo_min, tempo_max, use_onset):
 # Beat tracking regression test is no longer enabled due to librosa's
 # corrections
 @pytest.mark.skip
-def deprecated_test_beat():
+@pytest.mark.parametrize('infile', files(os.path.join('data', 'beat-beat-*.mat')))
+def deprecated_test_beat(infile):
 
-    def __test(infile):
+    DATA = load(infile)
 
-        DATA = load(infile)
+    (bpm, beats) = librosa.beat.beat_track(y=None,
+                                           sr=8000,
+                                           hop_length=32,
+                                           onset_envelope=DATA['onsetenv'][0])
 
-        (bpm, beats) = librosa.beat.beat_track(y=None,
-                                               sr=8000,
-                                               hop_length=32,
-                                               onset_envelope=DATA['onsetenv'][0])
-
-        beat_times = librosa.frames_to_time(beats, sr=8000, hop_length=32)
-        assert np.allclose(beat_times, DATA['beats'])
-
-    for infile in files(os.path.join('data','beat-beat-*.mat')):
-        yield (__test, infile)
+    beat_times = librosa.frames_to_time(beats, sr=8000, hop_length=32)
+    assert np.allclose(beat_times, DATA['beats'])

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -110,7 +110,7 @@ def test_beat():
 
     onset_env = librosa.onset.onset_strength(y=y, sr=sr, hop_length=hop_length)
 
-    def __test(with_audio, with_tempo, start_bpm, bpm, trim, tightness):
+    def __test(with_audio, with_tempo, start_bpm, bpm, trim, tightness, prior):
         if with_audio:
             _y = y
             _ons = None
@@ -125,7 +125,8 @@ def test_beat():
                                                start_bpm=start_bpm,
                                                tightness=tightness,
                                                trim=trim,
-                                               bpm=bpm)
+                                               bpm=bpm,
+                                               prior=prior)
 
         assert tempo >= 0
 
@@ -139,18 +140,17 @@ def test_beat():
                 for start_bpm in [-20, 0, 60, 120, 240]:
                     for bpm in [-20, 0, None, 150, 360]:
                         for tightness in [0, 100, 10000]:
+                            for prior in [None, scipy.stats.uniform(60, 240)]:
+                                if (tightness <= 0 or
+                                       (bpm is not None and bpm <= 0) or
+                                       (start_bpm is not None and
+                                       bpm is None and start_bpm <= 0)):
 
-                            if (tightness <= 0 or
-                                (bpm is not None and bpm <= 0) or
-                                (start_bpm is not None and
-                                 bpm is None and
-                                 start_bpm <= 0)):
-
-                                tf = pytest.mark.xfail(__test, raises=librosa.ParameterError)
-                            else:
-                                tf = __test
-                            yield (tf, with_audio, with_tempo,
-                                   start_bpm, bpm, trim, tightness)
+                                    tf = pytest.mark.xfail(__test, raises=librosa.ParameterError)
+                                else:
+                                    tf = __test
+                                yield (tf, with_audio, with_tempo,
+                                        start_bpm, bpm, trim, tightness, prior)
 
 
 @pytest.mark.parametrize('sr', [None, 44100])


### PR DESCRIPTION
#### Reference Issue
Fixes #880 


#### What does this implement/fix? Explain your changes.

This PR adds the ability to specify arbitrary prior distributions in tempo estimation.  This is done by constructing a `scipy.stats` frozen RV object, eg as follows:

```python
>>> prior = scipy.stats.uniform(60, 240)
```
and passing it as a parameter to the estimator:

```python
>>> tempo = librosa.beat.tempo(y=y, sr=sr, prior=prior)
```

To-do:

- [x] tests

#### Any other comments?

This PR also converts the tempo inference to log-probability space.  This should make things a bit more numerically stable going forward.

A few things that cropped up in the development of this PR:

1. The tempo estimator's prior distribution is *almost* log-normal, but not quite.  It's off by a critical scaling factor, and always has been.  I decided against "fixing" this here, for the sake of backwards compatibility of defaults, but it really should be changed in the next major revision.
2. The tempo estimation in general has poor frequency resolution exactly in the range we care about:
```python
In [5]: librosa.tempo_frequencies(384)[:40]                                                                                                                                                   
Out[5]: 
array([          inf, 2583.984375  , 1291.9921875 ,  861.328125  ,
        645.99609375,  516.796875  ,  430.6640625 ,  369.140625  ,
        322.99804688,  287.109375  ,  258.3984375 ,  234.90767045,
        215.33203125,  198.76802885,  184.5703125 ,  172.265625  ,
        161.49902344,  151.99908088,  143.5546875 ,  135.99917763,
        129.19921875,  123.046875  ,  117.45383523,  112.34714674,
        107.66601562,  103.359375  ,   99.38401442,   95.703125  ,
         92.28515625,   89.10290948,   86.1328125 ,   83.35433468,
         80.74951172,   78.30255682,   75.99954044,   73.828125  ,
         71.77734375,   69.83741554,   67.99958882,   66.25600962])
In [6]: librosa.fourier_tempo_frequencies()[:40]                                                                                                                                              
Out[6]: 
array([  0.        ,   6.72912598,  13.45825195,  20.18737793,
        26.91650391,  33.64562988,  40.37475586,  47.10388184,
        53.83300781,  60.56213379,  67.29125977,  74.02038574,
        80.74951172,  87.4786377 ,  94.20776367, 100.93688965,
       107.66601562, 114.3951416 , 121.12426758, 127.85339355,
       134.58251953, 141.31164551, 148.04077148, 154.76989746,
       161.49902344, 168.22814941, 174.95727539, 181.68640137,
       188.41552734, 195.14465332, 201.8737793 , 208.60290527,
       215.33203125, 222.06115723, 228.7902832 , 235.51940918,
       242.24853516, 248.97766113, 255.70678711, 262.43591309])
```
As you can see, those bin spacings are huge under default parameters, and are probably the cause of some sub-optimal tempo estimation performance.  This also should be fixed in a future iteration, but it's out of scope for this PR.

3. The tempo inference in general is not a well-formed probabilistic model.  Rather, we treat (log) tempogram energies as if they were unnormalized probabilities, add the log-prior, and do MAP inference.  This could be improved substantially by defining a proper statistical model of autocorrelation, but again, this is out of scope for this issue.