### PR TITLE
fixed #978, fft normalization in rms calculation

### DIFF
--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -848,13 +848,20 @@ def rms(y=None, S=None, frame_length=2048, hop_length=512,
         x = util.frame(y,
                        frame_length=frame_length,
                        hop_length=hop_length)
+
+        # No normalization is necessary for time-domain input
+        norm = 1
     elif S is not None:
         x, _ = _spectrogram(y=y, S=S,
                             n_fft=frame_length,
                             hop_length=hop_length)
+
+        # FFT introduces a scaling of n_fft to energy calculations
+        norm = 2 * (x.shape[0] - 1)
     else:
         raise ValueError('Either `y` or `S` must be input.')
-    return np.sqrt(np.mean(np.abs(x)**2, axis=0, keepdims=True))
+
+    return np.sqrt(np.mean(np.abs(x)**2, axis=0, keepdims=True) / norm)
 
 
 def poly_features(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -409,7 +409,7 @@ def test_rms():
         # RMSE of an all-ones band is 1
         rms = librosa.feature.rms(S=S)
 
-        assert np.allclose(rms, np.ones_like(rms))
+        assert np.allclose(rms, np.ones_like(rms) / np.sqrt(2 * (n - 1)), atol=1e-2)
 
     def __test_consistency(frame_length, hop_length, center):
         y, sr = librosa.load(__EXAMPLE_FILE, sr=None)
@@ -432,12 +432,9 @@ def test_rms():
                                    hop_length=hop_length, center=center)
 
         assert rms1.shape == rms2.shape
-        # Normalize envelopes.
-        rms1 /= rms1.max()
-        rms2 /= rms2.max()
 
         # Ensure results are similar.
-        np.testing.assert_allclose(rms1, rms2, rtol=5e-2)
+        np.testing.assert_allclose(rms1, rms2, atol=5e-4)
 
     for frame_length in [2048, 4096]:
         for hop_length in [128, 512, 1024]:


### PR DESCRIPTION
#### Reference Issue
Fixes #978 


#### What does this implement/fix? Explain your changes.

This PR normalizes RMS calculations for spectrogram inputs by `n_fft` so that it's on the same scale as time-domain calculations.

The tests have been amended to be more precise about this as well.

#### Any other comments?

Really, this normalization should have been done by the window length, but this is not generally knowable from spectrogram inputs.