### PR TITLE
Optimize stft - skip window multiplication for identity windows

### DIFF
--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -222,10 +222,11 @@ def stft(y, n_fft=2048, hop_length=None, win_length=None, window='hann',
     n_columns = int(util.MAX_MEM_BLOCK / (stft_matrix.shape[0] *
                                           stft_matrix.itemsize))
 
-    if window == "ones" :
+    if window in ['boxcar', 'box', 'ones', 'rect', 'rectangular']:
         for bl_s in range(0, stft_matrix.shape[1], n_columns):
             bl_t = min(bl_s + n_columns, stft_matrix.shape[1])
-            stft_matrix[:, bl_s:bl_t] = fft.rfft(y_frames[:, bl_s:bl_t], axis=0)
+            stft_matrix[:, bl_s:bl_t] = fft.rfft(y_frames[:, bl_s:bl_t],
+                                                 axis=0)
     else:
         fft_window = get_window(window, win_length, fftbins=True)
 
@@ -241,6 +242,7 @@ def stft(y, n_fft=2048, hop_length=None, win_length=None, window='hann',
                                                  y_frames[:, bl_s:bl_t],
                                                  axis=0)
     return stft_matrix
+
 
 @cache(level=30)
 def istft(stft_matrix, hop_length=None, win_length=None, window='hann',

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -213,7 +213,7 @@ def test_stft():
 
         if DATA['hann_w'][0, 0] == 0:
             # Set window to ones, swap back to nfft
-            window = np.ones
+            window = 'ones'
             win_length = None
 
         else:


### PR DESCRIPTION
#### Reference Issue
Fixes #986.

#### What does this implement/fix? Explain your changes.

This change skips window multiplication during stft when the window is the identity, thus avoids a possibly expensive array copy operation.


#### Any other comments?
Microbenchmarking is hard - I created a script so I can test out the speed improvement. I tried interleaving the new/old function calls to average out external factors.

This is the output:

```
Original:
Max: 0.09029326800000015s
Min: 0.04929946500000071s
Avg: 0.054472541203333356s

Optimized:
Max: 0.10773746899999992s
Min: 0.045211178999999824s
Avg: 0.04973186985666671s
Optimized wins 272/300 times (0.9066666666666666%)
```

On average the optimized version takes ~91.30% the time when tested with random 1000000 element arrays.

The execution times in a scatterplot, red are the original and blue the optimized:

![bench](https://user-images.githubusercontent.com/940823/65294315-3b36c580-db2c-11e9-9975-48283313dfed.png)


The correctness are covered by existing tests.