### PR TITLE
Removed warning filter, py2 deprecation to FutureWarning. fixes #990

### DIFF
--- a/librosa/__init__.py
+++ b/librosa/__init__.py
@@ -4,7 +4,6 @@
 
 import warnings
 import sys
-import re
 from .version import version as __version__
 from .version import show_versions
 
@@ -28,13 +27,9 @@ from .util.exceptions import *  # pylint: disable=wildcard-import
 # Exporting all core functions is okay here: suppress the import warning
 from .core import *  # pylint: disable=wildcard-import
 
-warnings.filterwarnings('always',
-                        category=DeprecationWarning,
-                        module='^{0}'.format(re.escape(__name__)))
-
 # Throw a deprecation warning if we're on legacy python
 if sys.version_info < (3,):
     warnings.warn('You are using librosa with Python 2. '
                   'Please note that librosa 0.7 will be the last version to support '
                   'Python 2, after which it will require Python 3 or later.',
-                  DeprecationWarning)
+                  FutureWarning)


### PR DESCRIPTION
#### Reference Issue
Fixes #990 


#### What does this implement/fix? Explain your changes.
This PR removes the hacky warning filter reset on import.

It also changes the `DeprecationWarning` for python 2.7 users to a `FutureWarning`.

