### PR TITLE
onset and chroma do not use kwarg-getting

### DIFF
--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -1059,7 +1059,8 @@ def zero_crossing_rate(y, frame_length=2048, hop_length=512, center=True,
 # -- Chroma --#
 def chroma_stft(y=None, sr=22050, S=None, norm=np.inf, n_fft=2048,
                 hop_length=512, win_length=None, window='hann', center=True,
-                pad_mode='reflect', tuning=None, **kwargs):
+                pad_mode='reflect', tuning=None, n_chroma=12,
+                **kwargs):
     """Compute a chromagram from a waveform or power spectrogram.
 
     This implementation is derived from `chromagram_E` [1]_
@@ -1118,6 +1119,9 @@ def chroma_stft(y=None, sr=22050, S=None, norm=np.inf, n_fft=2048,
     tuning : float [scalar] or None.
         Deviation from A440 tuning in fractional chroma bins.
         If `None`, it is automatically estimated.
+
+    n_chroma : int > 0 [scalar]
+        Number of chroma bins to produce (12 by default).
 
     kwargs : additional keyword arguments
         Arguments to parameterize chroma filters.
@@ -1181,13 +1185,11 @@ def chroma_stft(y=None, sr=22050, S=None, norm=np.inf, n_fft=2048,
                             win_length=win_length, window=window, center=center,
                             pad_mode=pad_mode)
 
-    n_chroma = kwargs.get('n_chroma', 12)
-
     if tuning is None:
         tuning = estimate_tuning(S=S, sr=sr, bins_per_octave=n_chroma)
 
     # Get the filter bank
-    chromafb = filters.chroma(sr, n_fft, tuning=tuning, **kwargs)
+    chromafb = filters.chroma(sr, n_fft, tuning=tuning, n_chroma=n_chroma, **kwargs)
 
     # Compute raw chroma
     raw_chroma = np.dot(chromafb, S)

--- a/librosa/onset.py
+++ b/librosa/onset.py
@@ -407,9 +407,9 @@ def onset_backtrack(events, energy):
 
 
 @cache(level=30)
-def onset_strength_multi(y=None, sr=22050, S=None, lag=1, max_size=1,
-                         ref=None, detrend=False, center=True, feature=None,
-                         aggregate=None, channels=None, **kwargs):
+def onset_strength_multi(y=None, sr=22050, S=None, n_fft=2048, hop_length=512,
+                         lag=1, max_size=1, ref=None, detrend=False, center=True,
+                         feature=None, aggregate=None, channels=None, **kwargs):
     """Compute a spectral flux onset strength envelope across multiple channels.
 
     Onset strength for channel `i` at time `t` is determined by:
@@ -427,6 +427,12 @@ def onset_strength_multi(y=None, sr=22050, S=None, lag=1, max_size=1,
 
     S        : np.ndarray [shape=(d, m)]
         pre-computed (log-power) spectrogram
+
+    n_fft : int > 0 [scalar]
+        FFT window size for use in `feature()` if `S` is not provided.
+
+    hop_length : int > 0 [scalar]
+        hop length for use in `feature()` if `S` is not provided.
 
     lag      : int > 0
         time lag for computing differences
@@ -527,15 +533,10 @@ def onset_strength_multi(y=None, sr=22050, S=None, lag=1, max_size=1,
 
     # First, compute mel spectrogram
     if S is None:
-        S = np.abs(feature(y=y, sr=sr, **kwargs))
+        S = np.abs(feature(y=y, sr=sr, n_fft=n_fft, hop_length=hop_length, **kwargs))
 
         # Convert to dBs
         S = core.power_to_db(S)
-
-    # Retrieve the n_fft and hop_length,
-    # or default values for onsets if not provided
-    n_fft = kwargs.get('n_fft', 2048)
-    hop_length = kwargs.get('hop_length', 512)
 
     # Ensure that S is at least 2-d
     S = np.atleast_2d(S)


### PR DESCRIPTION
#### Reference Issue
Fixes #989 


#### What does this implement/fix? Explain your changes.

This PR promotes spectrogram parameters in `onset` module to function-level parameters, rather than being pulled out of `kwargs`.

Similarly, `n_chroma` is now a proper argument to `feature.chroma_stft`.

This should resolve issues related to preset-overrides for default parameters.

The documentation has been updated accordingly.  These changes do not constitute a substantial change to the API, though some keyword parameter orderings have shifted.