### PR TITLE
 add liftering support to MFCC inversion 

### DIFF
--- a/librosa/feature/inverse.py
+++ b/librosa/feature/inverse.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 '''Feature inversion'''
 
+import warnings
 import numpy as np
 import scipy.fftpack
 

--- a/librosa/feature/inverse.py
+++ b/librosa/feature/inverse.py
@@ -224,7 +224,7 @@ def mfcc_to_mel(mfcc, n_mels=128, dct_type=2, norm='ortho', ref=1.0, lifter=0):
             * np.sin(np.pi * np.arange(1, 1 + n_mfcc, dtype=mfcc.dtype) / lifter)[:, np.newaxis]
 
         # avoid division of zero by zero errors
-        mfcc = np.nan_to_num(mfcc, nan=1.)
+        mfcc[np.isnan(mfcc)] = 1.
 
     elif lifter != 0:
         raise ParameterError('MFCC to MEL lifter={} must be a non-negative number'.format(lifter))

--- a/librosa/feature/inverse.py
+++ b/librosa/feature/inverse.py
@@ -221,10 +221,13 @@ def mfcc_to_mel(mfcc, n_mels=128, dct_type=2, norm='ortho', ref=1.0, lifter=0):
         n_mfcc = mfcc.shape[0]
         idx = np.arange(1, 1 + n_mfcc, dtype=mfcc.dtype)
         lifter_sine = 1 + (lifter / 2) * np.sin(np.pi * idx / lifter)[:, np.newaxis]
-        lifter_sine = np.where(lifter_sine == 0, np.finfo(float).eps, lifter_sine)
-        mfcc = np.where(mfcc == 0, np.finfo(float).eps, mfcc) 
-        liftered_mfcc = mfcc / lifter_sine
-        mfcc = liftered_mfcc
+
+        # check lifter array for critical values
+        if (lifter_sine == 0).any():
+            warnings.warn("Warning: lifter array includes critial values that will likely to invoke underflow.")
+
+        # lifter mfcc values
+        mfcc = mfcc / lifter_sine
 
     elif lifter != 0:
         raise ParameterError('MFCC to mel lifter={} must be a non-negative number'.format(lifter))

--- a/librosa/feature/inverse.py
+++ b/librosa/feature/inverse.py
@@ -221,7 +221,9 @@ def mfcc_to_mel(mfcc, n_mels=128, dct_type=2, norm='ortho', ref=1.0, lifter=0):
         n_mfcc = mfcc.shape[0]
         idx = np.arange(1, 1 + n_mfcc, dtype=mfcc.dtype)
         lifter_sine = 1 + (lifter / 2) * np.sin(np.pi * idx / lifter)[:, np.newaxis]
-        liftered_mfcc = np.where(mfcc == 0, np.finfo(float).eps, mfcc) / lifter_sine
+        lifter_sine = np.where(lifter_sine == 0, np.finfo(float).eps, lifter_sine)
+        mfcc = np.where(mfcc == 0, np.finfo(float).eps, mfcc) 
+        liftered_mfcc = mfcc / lifter_sine
         mfcc = liftered_mfcc
 
     elif lifter != 0:

--- a/librosa/feature/inverse.py
+++ b/librosa/feature/inverse.py
@@ -222,11 +222,14 @@ def mfcc_to_mel(mfcc, n_mels=128, dct_type=2, norm='ortho', ref=1.0, lifter=0):
         n_mfcc = mfcc.shape[0]
         mfcc /= 1 + (lifter / 2) \
             * np.sin(np.pi * np.arange(1, 1 + n_mfcc, dtype=mfcc.dtype) / lifter)[:, np.newaxis]
+
+        # avoid division of zero by zero errors
+        mfcc = np.nan_to_num(mfcc, nan=1.)
+
     elif lifter != 0:
-        raise ParameterError('MFCC to MEL inv_lifter={} must be a non-negative number'.format(lifter))
+        raise ParameterError('MFCC to MEL lifter={} must be a non-negative number'.format(lifter))
 
     logmel = scipy.fftpack.idct(mfcc, axis=0, type=dct_type, norm=norm, n=n_mels)
-
     return db_to_power(logmel, ref=ref)
 
 

--- a/librosa/feature/inverse.py
+++ b/librosa/feature/inverse.py
@@ -256,6 +256,10 @@ def mfcc_to_audio(mfcc, n_mels=128, dct_type=2, norm='ortho', ref=1.0, inv_lifte
     ref : number or callable
         Reference power for (inverse) decibel calculation
 
+    inv_lifter : number >= 0
+        If `inv_lifter>0`, apply *inverse-liftering* (inverse cepstral filtering):
+        `M[n, :] <- M[n, :] / (1 + sin(pi * (n + 1) / inv_lifter)) * inv_lifter / 2`
+
     kwargs : additional keyword arguments
         Parameters to pass through to `mel_to_audio`
 

--- a/librosa/feature/inverse.py
+++ b/librosa/feature/inverse.py
@@ -9,6 +9,7 @@ import scipy.fftpack
 from ..util.exceptions import ParameterError
 from ..core.spectrum import griffinlim
 from ..core.spectrum import db_to_power
+from ..util.utils import tiny
 from .. import filters
 from ..util import nnls
 
@@ -227,7 +228,7 @@ def mfcc_to_mel(mfcc, n_mels=128, dct_type=2, norm='ortho', ref=1.0, lifter=0):
                           category=UserWarning)
         
         # lifter mfcc values
-        mfcc = mfcc / lifter_sine
+        mfcc = mfcc / (lifter_sine + tiny(mfcc))
         
     elif lifter != 0:
         raise ParameterError('MFCC to mel lifter must be a non-negative number.')

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -945,6 +945,7 @@ def test_mel_to_audio():
     assert librosa.util.valid_audio(y_inv)
 
 
+@pytest.mark.xfail(raises=FloatingPointError)
 @pytest.mark.parametrize('n_mfcc', [13, 20])
 @pytest.mark.parametrize('n_mels', [64, 128])
 @pytest.mark.parametrize('dct_type', [2, 3])

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -987,9 +987,9 @@ def test_mfcc_to_mel(n_mfcc, n_mels, dct_type, lifter):
     # check if mfcc_to_mel works correctly with lifter
     ones = np.ones(mfcc.shape)
     idx = np.arange(1, 1 + n_mfcc, dtype=mfcc.dtype)
-    lifter_vec = 1 + (lifter / 2) * np.sin(np.pi * idx / lifter)[:, np.newaxis]
+    lifter_sine = 1 + (lifter / 2) * np.sin(np.pi * idx / lifter)[:, np.newaxis]
 
-    mel_recover = librosa.feature.inverse.mfcc_to_mel(ones * lifter_vec,
+    mel_recover = librosa.feature.inverse.mfcc_to_mel(ones * lifter_sine,
                                                       n_mels=n_mels,
                                                       dct_type=dct_type,
                                                       lifter=lifter)

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -52,10 +52,10 @@ def test_delta(xin, width, slope, order, axis, bias):
 #    if width < 3 or np.mod(width, 2) != 1 or width > x.shape[axis]:
 #        pytest.raises(librosa.ParameterError)
 
-    delta   = librosa.feature.delta(x,
-                                    width=width,
-                                    order=order,
-                                    axis=axis)
+    delta = librosa.feature.delta(x,
+                                  width=width,
+                                  order=order,
+                                  axis=axis)
 
     # Check that trimming matches the expected shape
     assert x.shape == delta.shape
@@ -64,8 +64,8 @@ def test_delta(xin, width, slope, order, axis, bias):
     # (x + delta)[t] should approximate x[t+1] if x is actually linear
     slice_orig = [slice(None)] * x.ndim
     slice_out = [slice(None)] * delta.ndim
-    slice_orig[axis] = slice(width//2 + 1, -width//2 + 1)
-    slice_out[axis] = slice(width//2, -width//2)
+    slice_orig[axis] = slice(width // 2 + 1, -width // 2 + 1)
+    slice_out[axis] = slice(width // 2, -width // 2)
     assert np.allclose((x + delta)[tuple(slice_out)], x[tuple(slice_orig)])
 
 
@@ -334,7 +334,7 @@ def test_spectral_contrast_errors():
     yield __test, S, 0, 200, 6, 0.02
 
     # ill-shaped frequency set: wrong-length vector
-    yield __test, S, np.zeros((S.shape[0]+1,)), 200, 6, 0.02
+    yield __test, S, np.zeros((S.shape[0] + 1,)), 200, 6, 0.02
 
     # ill-shaped frequency set: matrix
     yield __test, S, np.zeros(S.shape), 200, 6, 0.02
@@ -362,6 +362,7 @@ def test_spectral_flatness_synthetic():
 
     # to construct a spectrogram
     n_fft = 2048
+
     def __test(y, S, flatness_ref):
         flatness = librosa.feature.spectral_flatness(y=y,
                                                      S=S,
@@ -455,7 +456,7 @@ def test_zcr_synthetic():
 
         # We don't care too much about the edges if there's padding
         if center:
-            zcr = zcr[:, frame_length//2:-frame_length//2]
+            zcr = zcr[:, frame_length // 2:-frame_length // 2]
 
         # We'll allow 1% relative error
         assert np.allclose(zcr, rate, rtol=1e-2)
@@ -465,7 +466,7 @@ def test_zcr_synthetic():
         y = np.ones(sr)
         y[::period] = -1
         # Every sign flip induces two crossings
-        rate = 2./period
+        rate = 2. / period
         # 1+2**k so that we get both sides of the last crossing
         for frame_length in [513, 2049]:
             for hop_length in [128, 256]:
@@ -498,7 +499,7 @@ def test_poly_features_synthetic():
 
     for order in range(1, 3):
         freq = librosa.fft_frequencies(sr=sr, n_fft=n_fft)
-        coeffs = np.atleast_1d(np.arange(1, 1+order))
+        coeffs = np.atleast_1d(np.arange(1, 1 + order))
 
         # First test: vanilla
         S = __make_data(coeffs, freq)
@@ -513,7 +514,7 @@ def test_poly_features_synthetic():
         yield __test, S, coeffs, freq
 
         # And multi-dimensional
-        freq = np.cumsum(np.abs(np.random.randn(1 + n_fft//2, 2)), axis=0)
+        freq = np.cumsum(np.abs(np.random.randn(1 + n_fft // 2, 2)), axis=0)
         S = __make_data(coeffs, freq)
         yield __test, S, coeffs, freq
 
@@ -640,7 +641,7 @@ def test_tempogram_odf():
 
         idx = 0
         if center:
-            idx = len(odf)//2
+            idx = len(odf) // 2
 
         assert np.allclose(odf_ac, tempogram[:, idx])
 
@@ -807,7 +808,7 @@ def test_fourier_tempogram_invert(sr, hop_length, win_length, center, window):
     if center:
         sl = slice(None)
     else:
-        sl = slice(win_length//2, - win_length//2)
+        sl = slice(win_length // 2, - win_length // 2)
 
     odf_inv = librosa.istft(tempogram, hop_length=1, center=center, window=window,
                             length=len(odf))
@@ -892,7 +893,7 @@ def test_mel_to_stft(power, dtype, n_fft):
     # Make a random mel spectrum, 4 frames
     mel_basis = librosa.filters.mel(22050, n_fft, n_mels=128, dtype=dtype)
 
-    stft_orig = np.random.randn(n_fft//2 + 1, 4) ** power
+    stft_orig = np.random.randn(n_fft // 2 + 1, 4) ** power
     mels = mel_basis.dot(stft_orig.astype(dtype))
 
     stft = librosa.feature.inverse.mel_to_stft(mels, power=power, n_fft=n_fft)
@@ -904,7 +905,7 @@ def test_mel_to_stft(power, dtype, n_fft):
     assert np.all(stft >= 0)
 
     # Check that the shape is good
-    assert stft.shape[0] == n_fft //2 + 1
+    assert stft.shape[0] == n_fft // 2 + 1
 
     # Check that the approximation is good in RMSE terms
     assert np.sqrt(np.mean((mel_basis.dot(stft**power) - mels)**2)) <= 5e-2
@@ -934,7 +935,7 @@ def test_mfcc_to_mel(n_mfcc, n_mels, dct_type):
                                 n_mels=n_mels, n_mfcc=n_mfcc, dct_type=dct_type)
 
     melspec = librosa.feature.melspectrogram(y=y, sr=22050, n_mels=n_mels)
-    
+
     mel_recover = librosa.feature.inverse.mfcc_to_mel(mfcc, n_mels=n_mels,
                                                       dct_type=dct_type)
 
@@ -943,6 +944,24 @@ def test_mfcc_to_mel(n_mfcc, n_mels, dct_type):
 
     # Check non-negativity
     assert np.all(mel_recover >= 0)
+
+    # check lifter Parameter error
+    with pytest.raises(librosa.ParameterError):
+        mel_recover = librosa.feature.inverse.mfcc_to_mel(mfcc, n_mels=n_mels,
+                                                          dct_type=dct_type,
+                                                          lifter=-1)
+
+    # check that runtime warnings are triggered when appropriate
+    with pytest.warns(RuntimeWarning):
+        librosa.feature.inverse.mfcc_to_mel(mfcc * 10**3,
+                                            n_mels=n_mels,
+                                            dct_type=dct_type,
+                                            lifter=10**-3)
+
+    # check if mfcc_to_mel it works correctly with lifter
+    librosa.feature.inverse.mfcc_to_mel(mfcc, n_mels=n_mels,
+                                        dct_type=dct_type,
+                                        lifter=1)
 
 
 @pytest.mark.parametrize('n_mfcc', [13, 20])

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -939,7 +939,6 @@ def test_mel_to_audio():
     assert librosa.util.valid_audio(y_inv)
 
 
-@pytest.mark.xfail(raises=FloatingPointError)
 @pytest.mark.parametrize('n_mfcc', [13, 20])
 @pytest.mark.parametrize('n_mels', [64, 128])
 @pytest.mark.parametrize('dct_type', [2, 3])

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -6,6 +6,7 @@ import warnings
 import numpy as np
 
 import pytest
+
 import librosa
 
 from test_core import load, srand
@@ -27,32 +28,34 @@ warnings.filterwarnings('module', '.*', FutureWarning, 'scipy.*')
 @pytest.mark.parametrize('slope', np.linspace(-2, 2, num=6))
 @pytest.mark.parametrize('xin', [np.vstack([np.arange(100.0)] * 3)])
 @pytest.mark.parametrize('order', [1, pytest.mark.xfail(0)])
-@pytest.mark.parametrize('width, axis', [
-    pytest.mark.xfail((-1, 0)),
-    pytest.mark.xfail((-1, 1)),
-    pytest.mark.xfail((0, 0)),
-    pytest.mark.xfail((0, 1)),
-    pytest.mark.xfail((1, 0)),
-    pytest.mark.xfail((1, 1)),
-    pytest.mark.xfail((2, 0)),
-    pytest.mark.xfail((2, 1)), (3, 0), (3, 1),
-    pytest.mark.xfail((4, 0)),
-    pytest.mark.xfail((4, 1)), (5, 1),
-    pytest.mark.xfail((5, 0)),
-    pytest.mark.xfail((6, 0)),
-    pytest.mark.xfail((6, 1)),
-    pytest.mark.xfail((7, 0)), (7, 1)
-])
+@pytest.mark.parametrize('width, axis', [pytest.mark.xfail((-1, 0)),
+                                         pytest.mark.xfail((-1, 1)),
+                                         pytest.mark.xfail((0, 0)),
+                                         pytest.mark.xfail((0, 1)),
+                                         pytest.mark.xfail((1, 0)),
+                                         pytest.mark.xfail((1, 1)),
+                                         pytest.mark.xfail((2, 0)),
+                                         pytest.mark.xfail((2, 1)),
+                                         (3, 0), (3, 1),
+                                         pytest.mark.xfail((4, 0)),
+                                         pytest.mark.xfail((4, 1)),
+                                         (5, 1), pytest.mark.xfail((5, 0)),
+                                         pytest.mark.xfail((6, 0)),
+                                         pytest.mark.xfail((6, 1)),
+                                         pytest.mark.xfail((7, 0)), (7, 1)])
 @pytest.mark.parametrize('bias', [-10, 0, 10])
 def test_delta(xin, width, slope, order, axis, bias):
 
     x = slope * xin + bias
 
     # Note: this test currently only checks first-order differences
-    #    if width < 3 or np.mod(width, 2) != 1 or width > x.shape[axis]:
-    #        pytest.raises(librosa.ParameterError)
+#    if width < 3 or np.mod(width, 2) != 1 or width > x.shape[axis]:
+#        pytest.raises(librosa.ParameterError)
 
-    delta = librosa.feature.delta(x, width=width, order=order, axis=axis)
+    delta   = librosa.feature.delta(x,
+                                    width=width,
+                                    order=order,
+                                    axis=axis)
 
     # Check that trimming matches the expected shape
     assert x.shape == delta.shape
@@ -61,12 +64,13 @@ def test_delta(xin, width, slope, order, axis, bias):
     # (x + delta)[t] should approximate x[t+1] if x is actually linear
     slice_orig = [slice(None)] * x.ndim
     slice_out = [slice(None)] * delta.ndim
-    slice_orig[axis] = slice(width // 2 + 1, -width // 2 + 1)
-    slice_out[axis] = slice(width // 2, -width // 2)
+    slice_orig[axis] = slice(width//2 + 1, -width//2 + 1)
+    slice_out[axis] = slice(width//2, -width//2)
     assert np.allclose((x + delta)[tuple(slice_out)], x[tuple(slice_orig)])
 
 
 def test_stack_memory():
+
     def __test(n_steps, delay, data):
         data_stack = librosa.feature.stack_memory(data,
                                                   n_steps=n_steps,
@@ -86,7 +90,7 @@ def test_stack_memory():
         for i in range(d):
             for step in range(1, n_steps):
                 if delay > 0:
-                    assert np.allclose(data[i, :-step * delay],
+                    assert np.allclose(data[i, :- step * delay],
                                        data_stack[step * d + i, step * delay:])
                 else:
                     assert np.allclose(data[i, -step * delay:],
@@ -95,17 +99,15 @@ def test_stack_memory():
     srand()
 
     for ndim in [1, 2]:
-        data = np.random.randn(*([5] * ndim))
+        data = np.random.randn(* ([5] * ndim))
 
         for n_steps in [-1, 0, 1, 2, 3, 4]:
             for delay in [-4, -2, -1, 0, 1, 2, 4]:
                 tf = __test
                 if n_steps < 1:
-                    tf = pytest.mark.xfail(__test,
-                                           raises=librosa.ParameterError)
+                    tf = pytest.mark.xfail(__test, raises=librosa.ParameterError)
                 if delay == 0:
-                    tf = pytest.mark.xfail(__test,
-                                           raises=librosa.ParameterError)
+                    tf = pytest.mark.xfail(__test, raises=librosa.ParameterError)
                 yield tf, n_steps, delay, data
 
 
@@ -145,18 +147,20 @@ def test_spectral_centroid_synthetic():
 
 
 def test_spectral_centroid_errors():
+
     @pytest.mark.xfail(raises=librosa.ParameterError)
     def __test(S):
         librosa.feature.spectral_centroid(S=S)
 
-    S = -np.ones((513, 10))
+    S = - np.ones((513, 10))
     yield __test, S
 
-    S = -np.ones((513, 10)) * 1.j
+    S = - np.ones((513, 10)) * 1.j
     yield __test, S
 
 
 def test_spectral_centroid_empty():
+
     def __test(y, sr, S):
         cent = librosa.feature.spectral_centroid(y=y, sr=sr, S=S)
         assert not np.any(cent)
@@ -239,14 +243,15 @@ def test_spectral_bandwidth_onecol():
 
 
 def test_spectral_bandwidth_errors():
+
     @pytest.mark.xfail(raises=librosa.ParameterError)
     def __test(S):
         librosa.feature.spectral_bandwidth(S=S)
 
-    S = -np.ones((513, 10))
+    S = - np.ones((513, 10))
     yield __test, S
 
-    S = -np.ones((513, 10)) * 1.j
+    S = - np.ones((513, 10)) * 1.j
     yield __test, S
 
 
@@ -259,9 +264,7 @@ def test_spectral_rolloff_synthetic():
 
     def __test(S, freq, pct):
 
-        rolloff = librosa.feature.spectral_rolloff(S=S,
-                                                   sr=sr,
-                                                   freq=freq,
+        rolloff = librosa.feature.spectral_rolloff(S=S, sr=sr, freq=freq,
                                                    roll_percent=pct)
 
         if freq is None:
@@ -286,14 +289,15 @@ def test_spectral_rolloff_synthetic():
 
 
 def test_spectral_rolloff_errors():
+
     @pytest.mark.xfail(raises=librosa.ParameterError)
     def __test(S, p):
         librosa.feature.spectral_rolloff(S=S, roll_percent=p)
 
-    S = -np.ones((513, 10))
+    S = - np.ones((513, 10))
     yield __test, S, 0.95
 
-    S = -np.ones((513, 10)) * 1.j
+    S = - np.ones((513, 10)) * 1.j
     yield __test, S, 0.95
 
     S = np.ones((513, 10))
@@ -315,6 +319,7 @@ def test_spectral_contrast_log():
 
 
 def test_spectral_contrast_errors():
+
     @pytest.mark.xfail(raises=librosa.ParameterError)
     def __test(S, freq, fmin, n_bands, quantile):
         librosa.feature.spectral_contrast(S=S,
@@ -329,7 +334,7 @@ def test_spectral_contrast_errors():
     yield __test, S, 0, 200, 6, 0.02
 
     # ill-shaped frequency set: wrong-length vector
-    yield __test, S, np.zeros((S.shape[0] + 1, )), 200, 6, 0.02
+    yield __test, S, np.zeros((S.shape[0]+1,)), 200, 6, 0.02
 
     # ill-shaped frequency set: matrix
     yield __test, S, np.zeros(S.shape), 200, 6, 0.02
@@ -357,7 +362,6 @@ def test_spectral_flatness_synthetic():
 
     # to construct a spectrogram
     n_fft = 2048
-
     def __test(y, S, flatness_ref):
         flatness = librosa.feature.spectral_flatness(y=y,
                                                      S=S,
@@ -382,9 +386,11 @@ def test_spectral_flatness_synthetic():
 
 
 def test_spectral_flatness_errors():
+
     @pytest.mark.xfail(raises=librosa.ParameterError)
     def __test(S, amin):
-        librosa.feature.spectral_flatness(S=S, amin=amin)
+        librosa.feature.spectral_flatness(S=S,
+                                          amin=amin)
 
     S = np.ones((1025, 10))
 
@@ -396,46 +402,56 @@ def test_spectral_flatness_errors():
 
 
 def test_rms():
+
     def __test(n):
         S = np.ones((n, 5))
 
         # RMSE of an all-ones band is 1
-        rms = librosa.feature.rms(S=S)
-
-        assert np.allclose(rms,
-                           np.ones_like(rms) / np.sqrt(2 * (n - 1)),
-                           atol=1e-2)
+        frame_length = 2 * (n - 1)
+        rms = librosa.feature.rms(S=S, frame_length=frame_length)
+        assert np.allclose(rms, np.ones_like(rms) / np.sqrt(frame_length), atol=1e-2)
 
     def __test_consistency(frame_length, hop_length, center):
-        y, sr = librosa.load(__EXAMPLE_FILE, sr=None)
+        y1, sr = librosa.load(__EXAMPLE_FILE, sr=None)
+        np.random.seed(0)
+        y2 = np.random.rand(100000)  # The mean value, i.e. DC component, is about 0.5
 
         # Ensure audio is divisible into frame size.
-        y = librosa.util.fix_length(y, y.size - y.size % frame_length)
-        assert y.size % frame_length == 0
+        y1 = librosa.util.fix_length(y1, y1.size - y1.size % frame_length)
+        y2 = librosa.util.fix_length(y2, y2.size - y2.size % frame_length)
+        assert y1.size % frame_length == 0
+        assert y2.size % frame_length == 0
 
         # STFT magnitudes with a constant windowing function and no centering.
-        S = librosa.magphase(
-            librosa.stft(y,
-                         n_fft=frame_length,
-                         hop_length=hop_length,
-                         window=np.ones,
-                         center=center))[0]
+        S1 = librosa.magphase(librosa.stft(y1,
+                                          n_fft=frame_length,
+                                          hop_length=hop_length,
+                                          window=np.ones,
+                                          center=center))[0]
+        S2 = librosa.magphase(librosa.stft(y2,
+                                          n_fft=frame_length,
+                                          hop_length=hop_length,
+                                          window=np.ones,
+                                          center=center))[0]
 
         # Try both RMS methods.
-        rms1 = librosa.feature.rms(S=S,
-                                   frame_length=frame_length,
+        rms1 = librosa.feature.rms(S=S1, frame_length=frame_length,
                                    hop_length=hop_length)
-        rms2 = librosa.feature.rms(y=y,
-                                   frame_length=frame_length,
-                                   hop_length=hop_length,
-                                   center=center)
+        rms2 = librosa.feature.rms(y=y1, frame_length=frame_length,
+                                   hop_length=hop_length, center=center)
+        rms3 = librosa.feature.rms(S=S2, frame_length=frame_length,
+                                   hop_length=hop_length)
+        rms4 = librosa.feature.rms(y=y2, frame_length=frame_length,
+                                   hop_length=hop_length, center=center)
 
         assert rms1.shape == rms2.shape
+        assert rms3.shape == rms4.shape
 
         # Ensure results are similar.
         np.testing.assert_allclose(rms1, rms2, atol=5e-4)
+        np.testing.assert_allclose(rms3, rms4, atol=5e-4)
 
-    for frame_length in [2048, 4096]:
+    for frame_length in [2048, 2049, 4096, 4097]:
         for hop_length in [128, 512, 1024]:
             for center in [False, True]:
                 yield __test_consistency, frame_length, hop_length, center
@@ -445,6 +461,7 @@ def test_rms():
 
 
 def test_zcr_synthetic():
+
     def __test_zcr(rate, y, frame_length, hop_length, center):
         zcr = librosa.feature.zero_crossing_rate(y,
                                                  frame_length=frame_length,
@@ -453,7 +470,7 @@ def test_zcr_synthetic():
 
         # We don't care too much about the edges if there's padding
         if center:
-            zcr = zcr[:, frame_length // 2:-frame_length // 2]
+            zcr = zcr[:, frame_length//2:-frame_length//2]
 
         # We'll allow 1% relative error
         assert np.allclose(zcr, rate, rtol=1e-2)
@@ -463,7 +480,7 @@ def test_zcr_synthetic():
         y = np.ones(sr)
         y[::period] = -1
         # Every sign flip induces two crossings
-        rate = 2. / period
+        rate = 2./period
         # 1+2**k so that we get both sides of the last crossing
         for frame_length in [513, 2049]:
             for hop_length in [128, 256]:
@@ -480,11 +497,8 @@ def test_poly_features_synthetic():
     def __test(S, coeffs, freq):
 
         order = coeffs.shape[0] - 1
-        p = librosa.feature.poly_features(S=S,
-                                          sr=sr,
-                                          n_fft=n_fft,
-                                          order=order,
-                                          freq=freq)
+        p = librosa.feature.poly_features(S=S, sr=sr, n_fft=n_fft,
+                                          order=order, freq=freq)
 
         for i in range(S.shape[-1]):
             assert np.allclose(coeffs, p[::-1, i].squeeze())
@@ -499,7 +513,7 @@ def test_poly_features_synthetic():
 
     for order in range(1, 3):
         freq = librosa.fft_frequencies(sr=sr, n_fft=n_fft)
-        coeffs = np.atleast_1d(np.arange(1, 1 + order))
+        coeffs = np.atleast_1d(np.arange(1, 1+order))
 
         # First test: vanilla
         S = __make_data(coeffs, freq)
@@ -514,17 +528,15 @@ def test_poly_features_synthetic():
         yield __test, S, coeffs, freq
 
         # And multi-dimensional
-        freq = np.cumsum(np.abs(np.random.randn(1 + n_fft // 2, 2)), axis=0)
+        freq = np.cumsum(np.abs(np.random.randn(1 + n_fft//2, 2)), axis=0)
         S = __make_data(coeffs, freq)
         yield __test, S, coeffs, freq
 
 
 def test_tonnetz():
     y, sr = librosa.load(librosa.util.example_audio_file())
-    tonnetz_chroma = np.load(
-        os.path.join('tests', "data", "feature-tonnetz-chroma.npy"))
-    tonnetz_msaf = np.load(
-        os.path.join('tests', "data", "feature-tonnetz-msaf.npy"))
+    tonnetz_chroma = np.load(os.path.join('tests', "data", "feature-tonnetz-chroma.npy"))
+    tonnetz_msaf = np.load(os.path.join('tests', "data", "feature-tonnetz-msaf.npy"))
 
     # Use cqt chroma
     def __audio():
@@ -548,8 +560,7 @@ def test_tonnetz():
         # skip the equivalence check
 
     # Call the function with not enough parameters
-    yield pytest.mark.xfail(librosa.feature.tonnetz,
-                            raises=librosa.ParameterError)
+    yield pytest.mark.xfail(librosa.feature.tonnetz, raises=librosa.ParameterError)
     yield __audio
     yield __stft
     yield __cqt
@@ -557,8 +568,7 @@ def test_tonnetz():
 
 def test_tempogram_fail():
     @pytest.mark.xfail(raises=librosa.ParameterError)
-    def __test(y, sr, onset_envelope, hop_length, win_length, center, window,
-               norm):
+    def __test(y, sr, onset_envelope, hop_length, win_length, center, window, norm):
 
         librosa.feature.tempogram(y=y,
                                   sr=sr,
@@ -583,34 +593,29 @@ def test_tempogram_fail():
         yield __test, y, sr, None, hop_length, win_length, True, 'hann', np.inf
 
     # Fail when len(window) != win_length
-    yield __test, y, sr, None, hop_length, 384, True, np.ones(win_length +
-                                                              1), np.inf
+    yield __test, y, sr, None, hop_length, 384, True, np.ones(win_length + 1), np.inf
 
 
 def test_tempogram_audio():
     def __test(y, sr, oenv, hop_length):
 
         # Get the tempogram from audio
-        t1 = librosa.feature.tempogram(y=y,
-                                       sr=sr,
+        t1 = librosa.feature.tempogram(y=y, sr=sr,
                                        onset_envelope=None,
                                        hop_length=hop_length)
 
         # Get the tempogram from oenv
-        t2 = librosa.feature.tempogram(y=None,
-                                       sr=sr,
+        t2 = librosa.feature.tempogram(y=None, sr=sr,
                                        onset_envelope=oenv,
                                        hop_length=hop_length)
 
         # Make sure it works when both are provided
-        t3 = librosa.feature.tempogram(y=y,
-                                       sr=sr,
+        t3 = librosa.feature.tempogram(y=y, sr=sr,
                                        onset_envelope=oenv,
                                        hop_length=hop_length)
 
         # And that oenv overrides y
-        t4 = librosa.feature.tempogram(y=0 * y,
-                                       sr=sr,
+        t4 = librosa.feature.tempogram(y=0 * y, sr=sr,
                                        onset_envelope=oenv,
                                        hop_length=hop_length)
 
@@ -621,7 +626,9 @@ def test_tempogram_audio():
     y, sr = librosa.load(__EXAMPLE_FILE)
 
     for hop_length in [512, 1024]:
-        oenv = librosa.onset.onset_strength(y=y, sr=sr, hop_length=hop_length)
+        oenv = librosa.onset.onset_strength(y=y,
+                                            sr=sr,
+                                            hop_length=hop_length)
 
         yield __test, y, sr, oenv, hop_length
 
@@ -648,7 +655,7 @@ def test_tempogram_odf():
 
         idx = 0
         if center:
-            idx = len(odf) // 2
+            idx = len(odf)//2
 
         assert np.allclose(odf_ac, tempogram[:, idx])
 
@@ -758,26 +765,22 @@ def test_fourier_tempogram_audio():
     def __test(y, sr, oenv, hop_length):
 
         # Get the tempogram from audio
-        t1 = librosa.feature.fourier_tempogram(y=y,
-                                               sr=sr,
+        t1 = librosa.feature.fourier_tempogram(y=y, sr=sr,
                                                onset_envelope=None,
                                                hop_length=hop_length)
 
         # Get the tempogram from oenv
-        t2 = librosa.feature.fourier_tempogram(y=None,
-                                               sr=sr,
+        t2 = librosa.feature.fourier_tempogram(y=None, sr=sr,
                                                onset_envelope=oenv,
                                                hop_length=hop_length)
 
         # Make sure it works when both are provided
-        t3 = librosa.feature.fourier_tempogram(y=y,
-                                               sr=sr,
+        t3 = librosa.feature.fourier_tempogram(y=y, sr=sr,
                                                onset_envelope=oenv,
                                                hop_length=hop_length)
 
         # And that oenv overrides y
-        t4 = librosa.feature.fourier_tempogram(y=0 * y,
-                                               sr=sr,
+        t4 = librosa.feature.fourier_tempogram(y=0 * y, sr=sr,
                                                onset_envelope=oenv,
                                                hop_length=hop_length)
 
@@ -789,7 +792,9 @@ def test_fourier_tempogram_audio():
     y, sr = librosa.load(__EXAMPLE_FILE)
 
     for hop_length in [512, 1024]:
-        oenv = librosa.onset.onset_strength(y=y, sr=sr, hop_length=hop_length)
+        oenv = librosa.onset.onset_strength(y=y,
+                                            sr=sr,
+                                            hop_length=hop_length)
 
         yield __test, y, sr, oenv, hop_length
 
@@ -817,12 +822,9 @@ def test_fourier_tempogram_invert(sr, hop_length, win_length, center, window):
     if center:
         sl = slice(None)
     else:
-        sl = slice(win_length // 2, -win_length // 2)
+        sl = slice(win_length//2, - win_length//2)
 
-    odf_inv = librosa.istft(tempogram,
-                            hop_length=1,
-                            center=center,
-                            window=window,
+    odf_inv = librosa.istft(tempogram, hop_length=1, center=center, window=window,
                             length=len(odf))
     assert np.allclose(odf_inv[sl], odf[sl], atol=1e-6)
 
@@ -831,10 +833,9 @@ def test_cens():
     # load CQT data from Chroma Toolbox
     ct_cqt = load(os.path.join('tests', 'data', 'features-CT-cqt.mat'))
 
-    fn_ct_chroma_cens = [
-        'features-CT-CENS_9-2.mat', 'features-CT-CENS_21-5.mat',
-        'features-CT-CENS_41-1.mat'
-    ]
+    fn_ct_chroma_cens = ['features-CT-CENS_9-2.mat',
+                         'features-CT-CENS_21-5.mat',
+                         'features-CT-CENS_41-1.mat']
 
     cens_params = [(9, 2), (21, 5), (41, 1)]
 
@@ -843,38 +844,31 @@ def test_cens():
         downsample_smooth = cens_params[cur_test_case][1]
 
         # plug into librosa cens computation
-        lr_chroma_cens = librosa.feature.chroma_cens(
-            C=ct_cqt['f_cqt'],
-            win_len_smooth=win_len_smooth,
-            fmin=librosa.core.midi_to_hz(1),
-            bins_per_octave=12,
-            n_octaves=10)
+        lr_chroma_cens = librosa.feature.chroma_cens(C=ct_cqt['f_cqt'],
+                                                     win_len_smooth=win_len_smooth,
+                                                     fmin=librosa.core.midi_to_hz(1),
+                                                     bins_per_octave=12,
+                                                     n_octaves=10)
 
         # leaving out frames to match chroma toolbox behaviour
         # lr_chroma_cens = librosa.resample(lr_chroma_cens, orig_sr=1, target_sr=1/downsample_smooth)
         lr_chroma_cens = lr_chroma_cens[:, ::downsample_smooth]
 
         # load CENS-41-1 features
-        ct_chroma_cens = load(
-            os.path.join('tests', 'data', cur_fn_ct_chroma_cens))
+        ct_chroma_cens = load(os.path.join('tests', 'data', cur_fn_ct_chroma_cens))
 
         maxdev = np.abs(ct_chroma_cens['f_CENS'] - lr_chroma_cens)
-        assert np.allclose(ct_chroma_cens['f_CENS'],
-                           lr_chroma_cens,
-                           rtol=1e-15,
-                           atol=1e-15), maxdev
+        assert np.allclose(ct_chroma_cens['f_CENS'], lr_chroma_cens, rtol=1e-15, atol=1e-15), maxdev
 
 
 def test_mfcc():
+
     def __test(dct_type, norm, n_mfcc, lifter, S):
 
         E_total = np.sum(S, axis=0)
 
-        mfcc = librosa.feature.mfcc(S=S,
-                                    dct_type=dct_type,
-                                    norm=norm,
-                                    n_mfcc=n_mfcc,
-                                    lifter=lifter)
+        mfcc = librosa.feature.mfcc(S=S, dct_type=dct_type, norm=norm,
+                                    n_mfcc=n_mfcc, lifter=lifter)
 
         assert mfcc.shape[0] == n_mfcc
         assert mfcc.shape[1] == S.shape[1]
@@ -913,7 +907,7 @@ def test_mel_to_stft(power, dtype, n_fft):
     # Make a random mel spectrum, 4 frames
     mel_basis = librosa.filters.mel(22050, n_fft, n_mels=128, dtype=dtype)
 
-    stft_orig = np.random.randn(n_fft // 2 + 1, 4)**power
+    stft_orig = np.random.randn(n_fft//2 + 1, 4) ** power
     mels = mel_basis.dot(stft_orig.astype(dtype))
 
     stft = librosa.feature.inverse.mel_to_stft(mels, power=power, n_fft=n_fft)
@@ -925,7 +919,7 @@ def test_mel_to_stft(power, dtype, n_fft):
     assert np.all(stft >= 0)
 
     # Check that the shape is good
-    assert stft.shape[0] == n_fft // 2 + 1
+    assert stft.shape[0] == n_fft //2 + 1
 
     # Check that the approximation is good in RMSE terms
     assert np.sqrt(np.mean((mel_basis.dot(stft**power) - mels)**2)) <= 5e-2
@@ -949,7 +943,7 @@ def test_mel_to_audio():
 @pytest.mark.parametrize('n_mfcc', [13, 20])
 @pytest.mark.parametrize('n_mels', [64, 128])
 @pytest.mark.parametrize('dct_type', [2, 3])
-@pytest.mark.parametrize('lifter', [-3, -2, -1, 0, 1, 2, 3, 10])
+@pytest.mark.parametrize('lifter', [-1, 0, 1, 2, 3])
 def test_mfcc_to_mel(n_mfcc, n_mels, dct_type, lifter):
     y = librosa.tone(440.0, sr=22050, duration=1)
     mfcc = librosa.feature.mfcc(y=y,
@@ -1015,18 +1009,16 @@ def test_mfcc_to_mel(n_mfcc, n_mels, dct_type, lifter):
 @pytest.mark.parametrize('n_mfcc', [13, 20])
 @pytest.mark.parametrize('n_mels', [64, 128])
 @pytest.mark.parametrize('dct_type', [2, 3])
-def test_mfcc_to_audio(n_mfcc, n_mels, dct_type):
+@pytest.mark.parametrize('lifter', [0, 3])
+def test_mfcc_to_audio(n_mfcc, n_mels, dct_type, lifter):
     y = librosa.tone(440.0, sr=22050, duration=1)
 
-    mfcc = librosa.feature.mfcc(y=y,
-                                sr=22050,
-                                n_mels=n_mels,
-                                n_mfcc=n_mfcc,
-                                dct_type=dct_type)
+    mfcc = librosa.feature.mfcc(y=y, sr=22050,
+                                n_mels=n_mels, n_mfcc=n_mfcc, dct_type=dct_type)
 
-    y_inv = librosa.feature.inverse.mfcc_to_audio(mfcc,
-                                                  n_mels=n_mels,
+    y_inv = librosa.feature.inverse.mfcc_to_audio(mfcc, n_mels=n_mels,
                                                   dct_type=dct_type,
+                                                  lifter=lifter,
                                                   length=len(y))
 
     # Sanity check the length

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -948,57 +948,67 @@ def test_mel_to_audio():
 @pytest.mark.parametrize('n_mfcc', [13, 20])
 @pytest.mark.parametrize('n_mels', [64, 128])
 @pytest.mark.parametrize('dct_type', [2, 3])
-@pytest.mark.parametrize('lifter', [1, 2, 3])
+@pytest.mark.parametrize('lifter', [-3, -2, -1, 0, 1, 2, 3, 10])
 def test_mfcc_to_mel(n_mfcc, n_mels, dct_type, lifter):
     y = librosa.tone(440.0, sr=22050, duration=1)
-
     mfcc = librosa.feature.mfcc(y=y,
                                 sr=22050,
                                 n_mels=n_mels,
                                 n_mfcc=n_mfcc,
                                 dct_type=dct_type)
 
-    melspec = librosa.feature.melspectrogram(y=y, sr=22050, n_mels=n_mels)
 
-    mel_recover = librosa.feature.inverse.mfcc_to_mel(mfcc,
-                                                      n_mels=n_mels,
-                                                      dct_type=dct_type)
+    # check lifter parameter error
+    if lifter < 0:
+        with pytest.raises(librosa.ParameterError):
+            librosa.feature.inverse.mfcc_to_mel(mfcc * 10**3,
+                                                n_mels=n_mels,
+                                                dct_type=dct_type,
+                                                lifter=lifter)
 
-    # Quick shape check
-    assert melspec.shape == mel_recover.shape
+    # check no lifter computations
+    elif lifter == 0:
+            melspec = librosa.feature.melspectrogram(y=y, sr=22050,
+                                                      n_mels=n_mels)
 
-    # Check non-negativity
-    assert np.all(mel_recover >= 0)
+            mel_recover = librosa.feature.inverse.mfcc_to_mel(mfcc,
+                                                              n_mels=n_mels,
+                                                              dct_type=dct_type)
+            # Quick shape check
+            assert melspec.shape == mel_recover.shape
 
-    # check lifter Parameter error
-    with pytest.raises(librosa.ParameterError):
-        mel_recover = librosa.feature.inverse.mfcc_to_mel(mfcc,
-                                                          n_mels=n_mels,
-                                                          dct_type=dct_type,
-                                                          lifter=-1)
+            # Check non-negativity
+            assert np.all(mel_recover >= 0)
 
     # check that runtime warnings are triggered when appropriate
-    with pytest.warns(RuntimeWarning):
-        librosa.feature.inverse.mfcc_to_mel(mfcc * 10**3,
-                                            n_mels=n_mels,
-                                            dct_type=dct_type,
-                                            lifter=10**-3)
+    elif lifter == 2:
+        with pytest.warns(UserWarning):
+            librosa.feature.inverse.mfcc_to_mel(mfcc * 10**3,
+                                                n_mels=n_mels,
+                                                dct_type=dct_type,
+                                                lifter=lifter)
 
     # check if mfcc_to_mel works correctly with lifter
-    ones = np.ones(mfcc.shape)
-    idx = np.arange(1, 1 + n_mfcc, dtype=mfcc.dtype)
-    lifter_sine = 1 + (lifter / 2) * np.sin(np.pi * idx / lifter)[:, np.newaxis]
+    else:
+        ones = np.ones(mfcc.shape, dtype=mfcc.dtype)
+        n_mfcc = mfcc.shape[0]
+        idx = np.arange(1, 1 + n_mfcc, dtype=mfcc.dtype)
+        lifter_sine = 1 + lifter * 0.5 * np.sin(np.pi * idx / lifter)[:, np.newaxis]
 
-    mel_recover = librosa.feature.inverse.mfcc_to_mel(ones * lifter_sine,
-                                                      n_mels=n_mels,
-                                                      dct_type=dct_type,
-                                                      lifter=lifter)
-    mel_expected = librosa.feature.inverse.mfcc_to_mel(ones,
-                                                       n_mels=n_mels,
-                                                       dct_type=dct_type,
-                                                       lifter=0)
+        # compute the recovered mel
+        mel_recover = librosa.feature.inverse.mfcc_to_mel(ones * lifter_sine,
+                                                          n_mels=n_mels,
+                                                          dct_type=dct_type,
+                                                          lifter=lifter)
+        
+        # compute the expected mel
+        mel_expected = librosa.feature.inverse.mfcc_to_mel(ones,
+                                                           n_mels=n_mels,
+                                                           dct_type=dct_type,
+                                                           lifter=0)
 
-    np.testing.assert_almost_equal(mel_recover, mel_expected, 3)
+        # assert equality of expected and recovered mels
+        np.testing.assert_almost_equal(mel_recover, mel_expected, 3)
 
 
 @pytest.mark.parametrize('n_mfcc', [13, 20])

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -27,34 +27,32 @@ warnings.filterwarnings('module', '.*', FutureWarning, 'scipy.*')
 @pytest.mark.parametrize('slope', np.linspace(-2, 2, num=6))
 @pytest.mark.parametrize('xin', [np.vstack([np.arange(100.0)] * 3)])
 @pytest.mark.parametrize('order', [1, pytest.mark.xfail(0)])
-@pytest.mark.parametrize('width, axis', [pytest.mark.xfail((-1, 0)),
-                                         pytest.mark.xfail((-1, 1)),
-                                         pytest.mark.xfail((0, 0)),
-                                         pytest.mark.xfail((0, 1)),
-                                         pytest.mark.xfail((1, 0)),
-                                         pytest.mark.xfail((1, 1)),
-                                         pytest.mark.xfail((2, 0)),
-                                         pytest.mark.xfail((2, 1)),
-                                         (3, 0), (3, 1),
-                                         pytest.mark.xfail((4, 0)),
-                                         pytest.mark.xfail((4, 1)),
-                                         (5, 1), pytest.mark.xfail((5, 0)),
-                                         pytest.mark.xfail((6, 0)),
-                                         pytest.mark.xfail((6, 1)),
-                                         pytest.mark.xfail((7, 0)), (7, 1)])
+@pytest.mark.parametrize('width, axis', [
+    pytest.mark.xfail((-1, 0)),
+    pytest.mark.xfail((-1, 1)),
+    pytest.mark.xfail((0, 0)),
+    pytest.mark.xfail((0, 1)),
+    pytest.mark.xfail((1, 0)),
+    pytest.mark.xfail((1, 1)),
+    pytest.mark.xfail((2, 0)),
+    pytest.mark.xfail((2, 1)), (3, 0), (3, 1),
+    pytest.mark.xfail((4, 0)),
+    pytest.mark.xfail((4, 1)), (5, 1),
+    pytest.mark.xfail((5, 0)),
+    pytest.mark.xfail((6, 0)),
+    pytest.mark.xfail((6, 1)),
+    pytest.mark.xfail((7, 0)), (7, 1)
+])
 @pytest.mark.parametrize('bias', [-10, 0, 10])
 def test_delta(xin, width, slope, order, axis, bias):
 
     x = slope * xin + bias
 
     # Note: this test currently only checks first-order differences
-#    if width < 3 or np.mod(width, 2) != 1 or width > x.shape[axis]:
-#        pytest.raises(librosa.ParameterError)
+    #    if width < 3 or np.mod(width, 2) != 1 or width > x.shape[axis]:
+    #        pytest.raises(librosa.ParameterError)
 
-    delta = librosa.feature.delta(x,
-                                  width=width,
-                                  order=order,
-                                  axis=axis)
+    delta = librosa.feature.delta(x, width=width, order=order, axis=axis)
 
     # Check that trimming matches the expected shape
     assert x.shape == delta.shape
@@ -69,7 +67,6 @@ def test_delta(xin, width, slope, order, axis, bias):
 
 
 def test_stack_memory():
-
     def __test(n_steps, delay, data):
         data_stack = librosa.feature.stack_memory(data,
                                                   n_steps=n_steps,
@@ -89,7 +86,7 @@ def test_stack_memory():
         for i in range(d):
             for step in range(1, n_steps):
                 if delay > 0:
-                    assert np.allclose(data[i, :- step * delay],
+                    assert np.allclose(data[i, :-step * delay],
                                        data_stack[step * d + i, step * delay:])
                 else:
                     assert np.allclose(data[i, -step * delay:],
@@ -98,15 +95,17 @@ def test_stack_memory():
     srand()
 
     for ndim in [1, 2]:
-        data = np.random.randn(* ([5] * ndim))
+        data = np.random.randn(*([5] * ndim))
 
         for n_steps in [-1, 0, 1, 2, 3, 4]:
             for delay in [-4, -2, -1, 0, 1, 2, 4]:
                 tf = __test
                 if n_steps < 1:
-                    tf = pytest.mark.xfail(__test, raises=librosa.ParameterError)
+                    tf = pytest.mark.xfail(__test,
+                                           raises=librosa.ParameterError)
                 if delay == 0:
-                    tf = pytest.mark.xfail(__test, raises=librosa.ParameterError)
+                    tf = pytest.mark.xfail(__test,
+                                           raises=librosa.ParameterError)
                 yield tf, n_steps, delay, data
 
 
@@ -146,20 +145,18 @@ def test_spectral_centroid_synthetic():
 
 
 def test_spectral_centroid_errors():
-
     @pytest.mark.xfail(raises=librosa.ParameterError)
     def __test(S):
         librosa.feature.spectral_centroid(S=S)
 
-    S = - np.ones((513, 10))
+    S = -np.ones((513, 10))
     yield __test, S
 
-    S = - np.ones((513, 10)) * 1.j
+    S = -np.ones((513, 10)) * 1.j
     yield __test, S
 
 
 def test_spectral_centroid_empty():
-
     def __test(y, sr, S):
         cent = librosa.feature.spectral_centroid(y=y, sr=sr, S=S)
         assert not np.any(cent)
@@ -242,15 +239,14 @@ def test_spectral_bandwidth_onecol():
 
 
 def test_spectral_bandwidth_errors():
-
     @pytest.mark.xfail(raises=librosa.ParameterError)
     def __test(S):
         librosa.feature.spectral_bandwidth(S=S)
 
-    S = - np.ones((513, 10))
+    S = -np.ones((513, 10))
     yield __test, S
 
-    S = - np.ones((513, 10)) * 1.j
+    S = -np.ones((513, 10)) * 1.j
     yield __test, S
 
 
@@ -263,7 +259,9 @@ def test_spectral_rolloff_synthetic():
 
     def __test(S, freq, pct):
 
-        rolloff = librosa.feature.spectral_rolloff(S=S, sr=sr, freq=freq,
+        rolloff = librosa.feature.spectral_rolloff(S=S,
+                                                   sr=sr,
+                                                   freq=freq,
                                                    roll_percent=pct)
 
         if freq is None:
@@ -288,15 +286,14 @@ def test_spectral_rolloff_synthetic():
 
 
 def test_spectral_rolloff_errors():
-
     @pytest.mark.xfail(raises=librosa.ParameterError)
     def __test(S, p):
         librosa.feature.spectral_rolloff(S=S, roll_percent=p)
 
-    S = - np.ones((513, 10))
+    S = -np.ones((513, 10))
     yield __test, S, 0.95
 
-    S = - np.ones((513, 10)) * 1.j
+    S = -np.ones((513, 10)) * 1.j
     yield __test, S, 0.95
 
     S = np.ones((513, 10))
@@ -318,7 +315,6 @@ def test_spectral_contrast_log():
 
 
 def test_spectral_contrast_errors():
-
     @pytest.mark.xfail(raises=librosa.ParameterError)
     def __test(S, freq, fmin, n_bands, quantile):
         librosa.feature.spectral_contrast(S=S,
@@ -333,7 +329,7 @@ def test_spectral_contrast_errors():
     yield __test, S, 0, 200, 6, 0.02
 
     # ill-shaped frequency set: wrong-length vector
-    yield __test, S, np.zeros((S.shape[0] + 1,)), 200, 6, 0.02
+    yield __test, S, np.zeros((S.shape[0] + 1, )), 200, 6, 0.02
 
     # ill-shaped frequency set: matrix
     yield __test, S, np.zeros(S.shape), 200, 6, 0.02
@@ -386,11 +382,9 @@ def test_spectral_flatness_synthetic():
 
 
 def test_spectral_flatness_errors():
-
     @pytest.mark.xfail(raises=librosa.ParameterError)
     def __test(S, amin):
-        librosa.feature.spectral_flatness(S=S,
-                                          amin=amin)
+        librosa.feature.spectral_flatness(S=S, amin=amin)
 
     S = np.ones((1025, 10))
 
@@ -402,14 +396,15 @@ def test_spectral_flatness_errors():
 
 
 def test_rms():
-
     def __test(n):
         S = np.ones((n, 5))
 
         # RMSE of an all-ones band is 1
         rms = librosa.feature.rms(S=S)
 
-        assert np.allclose(rms, np.ones_like(rms) / np.sqrt(2 * (n - 1)), atol=1e-2)
+        assert np.allclose(rms,
+                           np.ones_like(rms) / np.sqrt(2 * (n - 1)),
+                           atol=1e-2)
 
     def __test_consistency(frame_length, hop_length, center):
         y, sr = librosa.load(__EXAMPLE_FILE, sr=None)
@@ -419,17 +414,21 @@ def test_rms():
         assert y.size % frame_length == 0
 
         # STFT magnitudes with a constant windowing function and no centering.
-        S = librosa.magphase(librosa.stft(y,
-                                          n_fft=frame_length,
-                                          hop_length=hop_length,
-                                          window=np.ones,
-                                          center=center))[0]
+        S = librosa.magphase(
+            librosa.stft(y,
+                         n_fft=frame_length,
+                         hop_length=hop_length,
+                         window=np.ones,
+                         center=center))[0]
 
         # Try both RMS methods.
-        rms1 = librosa.feature.rms(S=S, frame_length=frame_length,
+        rms1 = librosa.feature.rms(S=S,
+                                   frame_length=frame_length,
                                    hop_length=hop_length)
-        rms2 = librosa.feature.rms(y=y, frame_length=frame_length,
-                                   hop_length=hop_length, center=center)
+        rms2 = librosa.feature.rms(y=y,
+                                   frame_length=frame_length,
+                                   hop_length=hop_length,
+                                   center=center)
 
         assert rms1.shape == rms2.shape
 
@@ -446,7 +445,6 @@ def test_rms():
 
 
 def test_zcr_synthetic():
-
     def __test_zcr(rate, y, frame_length, hop_length, center):
         zcr = librosa.feature.zero_crossing_rate(y,
                                                  frame_length=frame_length,
@@ -482,8 +480,11 @@ def test_poly_features_synthetic():
     def __test(S, coeffs, freq):
 
         order = coeffs.shape[0] - 1
-        p = librosa.feature.poly_features(S=S, sr=sr, n_fft=n_fft,
-                                          order=order, freq=freq)
+        p = librosa.feature.poly_features(S=S,
+                                          sr=sr,
+                                          n_fft=n_fft,
+                                          order=order,
+                                          freq=freq)
 
         for i in range(S.shape[-1]):
             assert np.allclose(coeffs, p[::-1, i].squeeze())
@@ -520,8 +521,10 @@ def test_poly_features_synthetic():
 
 def test_tonnetz():
     y, sr = librosa.load(librosa.util.example_audio_file())
-    tonnetz_chroma = np.load(os.path.join('tests', "data", "feature-tonnetz-chroma.npy"))
-    tonnetz_msaf = np.load(os.path.join('tests', "data", "feature-tonnetz-msaf.npy"))
+    tonnetz_chroma = np.load(
+        os.path.join('tests', "data", "feature-tonnetz-chroma.npy"))
+    tonnetz_msaf = np.load(
+        os.path.join('tests', "data", "feature-tonnetz-msaf.npy"))
 
     # Use cqt chroma
     def __audio():
@@ -545,7 +548,8 @@ def test_tonnetz():
         # skip the equivalence check
 
     # Call the function with not enough parameters
-    yield pytest.mark.xfail(librosa.feature.tonnetz, raises=librosa.ParameterError)
+    yield pytest.mark.xfail(librosa.feature.tonnetz,
+                            raises=librosa.ParameterError)
     yield __audio
     yield __stft
     yield __cqt
@@ -553,7 +557,8 @@ def test_tonnetz():
 
 def test_tempogram_fail():
     @pytest.mark.xfail(raises=librosa.ParameterError)
-    def __test(y, sr, onset_envelope, hop_length, win_length, center, window, norm):
+    def __test(y, sr, onset_envelope, hop_length, win_length, center, window,
+               norm):
 
         librosa.feature.tempogram(y=y,
                                   sr=sr,
@@ -578,29 +583,34 @@ def test_tempogram_fail():
         yield __test, y, sr, None, hop_length, win_length, True, 'hann', np.inf
 
     # Fail when len(window) != win_length
-    yield __test, y, sr, None, hop_length, 384, True, np.ones(win_length + 1), np.inf
+    yield __test, y, sr, None, hop_length, 384, True, np.ones(win_length +
+                                                              1), np.inf
 
 
 def test_tempogram_audio():
     def __test(y, sr, oenv, hop_length):
 
         # Get the tempogram from audio
-        t1 = librosa.feature.tempogram(y=y, sr=sr,
+        t1 = librosa.feature.tempogram(y=y,
+                                       sr=sr,
                                        onset_envelope=None,
                                        hop_length=hop_length)
 
         # Get the tempogram from oenv
-        t2 = librosa.feature.tempogram(y=None, sr=sr,
+        t2 = librosa.feature.tempogram(y=None,
+                                       sr=sr,
                                        onset_envelope=oenv,
                                        hop_length=hop_length)
 
         # Make sure it works when both are provided
-        t3 = librosa.feature.tempogram(y=y, sr=sr,
+        t3 = librosa.feature.tempogram(y=y,
+                                       sr=sr,
                                        onset_envelope=oenv,
                                        hop_length=hop_length)
 
         # And that oenv overrides y
-        t4 = librosa.feature.tempogram(y=0 * y, sr=sr,
+        t4 = librosa.feature.tempogram(y=0 * y,
+                                       sr=sr,
                                        onset_envelope=oenv,
                                        hop_length=hop_length)
 
@@ -611,9 +621,7 @@ def test_tempogram_audio():
     y, sr = librosa.load(__EXAMPLE_FILE)
 
     for hop_length in [512, 1024]:
-        oenv = librosa.onset.onset_strength(y=y,
-                                            sr=sr,
-                                            hop_length=hop_length)
+        oenv = librosa.onset.onset_strength(y=y, sr=sr, hop_length=hop_length)
 
         yield __test, y, sr, oenv, hop_length
 
@@ -750,22 +758,26 @@ def test_fourier_tempogram_audio():
     def __test(y, sr, oenv, hop_length):
 
         # Get the tempogram from audio
-        t1 = librosa.feature.fourier_tempogram(y=y, sr=sr,
+        t1 = librosa.feature.fourier_tempogram(y=y,
+                                               sr=sr,
                                                onset_envelope=None,
                                                hop_length=hop_length)
 
         # Get the tempogram from oenv
-        t2 = librosa.feature.fourier_tempogram(y=None, sr=sr,
+        t2 = librosa.feature.fourier_tempogram(y=None,
+                                               sr=sr,
                                                onset_envelope=oenv,
                                                hop_length=hop_length)
 
         # Make sure it works when both are provided
-        t3 = librosa.feature.fourier_tempogram(y=y, sr=sr,
+        t3 = librosa.feature.fourier_tempogram(y=y,
+                                               sr=sr,
                                                onset_envelope=oenv,
                                                hop_length=hop_length)
 
         # And that oenv overrides y
-        t4 = librosa.feature.fourier_tempogram(y=0 * y, sr=sr,
+        t4 = librosa.feature.fourier_tempogram(y=0 * y,
+                                               sr=sr,
                                                onset_envelope=oenv,
                                                hop_length=hop_length)
 
@@ -777,9 +789,7 @@ def test_fourier_tempogram_audio():
     y, sr = librosa.load(__EXAMPLE_FILE)
 
     for hop_length in [512, 1024]:
-        oenv = librosa.onset.onset_strength(y=y,
-                                            sr=sr,
-                                            hop_length=hop_length)
+        oenv = librosa.onset.onset_strength(y=y, sr=sr, hop_length=hop_length)
 
         yield __test, y, sr, oenv, hop_length
 
@@ -807,9 +817,12 @@ def test_fourier_tempogram_invert(sr, hop_length, win_length, center, window):
     if center:
         sl = slice(None)
     else:
-        sl = slice(win_length // 2, - win_length // 2)
+        sl = slice(win_length // 2, -win_length // 2)
 
-    odf_inv = librosa.istft(tempogram, hop_length=1, center=center, window=window,
+    odf_inv = librosa.istft(tempogram,
+                            hop_length=1,
+                            center=center,
+                            window=window,
                             length=len(odf))
     assert np.allclose(odf_inv[sl], odf[sl], atol=1e-6)
 
@@ -818,9 +831,10 @@ def test_cens():
     # load CQT data from Chroma Toolbox
     ct_cqt = load(os.path.join('tests', 'data', 'features-CT-cqt.mat'))
 
-    fn_ct_chroma_cens = ['features-CT-CENS_9-2.mat',
-                         'features-CT-CENS_21-5.mat',
-                         'features-CT-CENS_41-1.mat']
+    fn_ct_chroma_cens = [
+        'features-CT-CENS_9-2.mat', 'features-CT-CENS_21-5.mat',
+        'features-CT-CENS_41-1.mat'
+    ]
 
     cens_params = [(9, 2), (21, 5), (41, 1)]
 
@@ -829,31 +843,38 @@ def test_cens():
         downsample_smooth = cens_params[cur_test_case][1]
 
         # plug into librosa cens computation
-        lr_chroma_cens = librosa.feature.chroma_cens(C=ct_cqt['f_cqt'],
-                                                     win_len_smooth=win_len_smooth,
-                                                     fmin=librosa.core.midi_to_hz(1),
-                                                     bins_per_octave=12,
-                                                     n_octaves=10)
+        lr_chroma_cens = librosa.feature.chroma_cens(
+            C=ct_cqt['f_cqt'],
+            win_len_smooth=win_len_smooth,
+            fmin=librosa.core.midi_to_hz(1),
+            bins_per_octave=12,
+            n_octaves=10)
 
         # leaving out frames to match chroma toolbox behaviour
         # lr_chroma_cens = librosa.resample(lr_chroma_cens, orig_sr=1, target_sr=1/downsample_smooth)
         lr_chroma_cens = lr_chroma_cens[:, ::downsample_smooth]
 
         # load CENS-41-1 features
-        ct_chroma_cens = load(os.path.join('tests', 'data', cur_fn_ct_chroma_cens))
+        ct_chroma_cens = load(
+            os.path.join('tests', 'data', cur_fn_ct_chroma_cens))
 
         maxdev = np.abs(ct_chroma_cens['f_CENS'] - lr_chroma_cens)
-        assert np.allclose(ct_chroma_cens['f_CENS'], lr_chroma_cens, rtol=1e-15, atol=1e-15), maxdev
+        assert np.allclose(ct_chroma_cens['f_CENS'],
+                           lr_chroma_cens,
+                           rtol=1e-15,
+                           atol=1e-15), maxdev
 
 
 def test_mfcc():
-
     def __test(dct_type, norm, n_mfcc, lifter, S):
 
         E_total = np.sum(S, axis=0)
 
-        mfcc = librosa.feature.mfcc(S=S, dct_type=dct_type, norm=norm,
-                                    n_mfcc=n_mfcc, lifter=lifter)
+        mfcc = librosa.feature.mfcc(S=S,
+                                    dct_type=dct_type,
+                                    norm=norm,
+                                    n_mfcc=n_mfcc,
+                                    lifter=lifter)
 
         assert mfcc.shape[0] == n_mfcc
         assert mfcc.shape[1] == S.shape[1]
@@ -892,7 +913,7 @@ def test_mel_to_stft(power, dtype, n_fft):
     # Make a random mel spectrum, 4 frames
     mel_basis = librosa.filters.mel(22050, n_fft, n_mels=128, dtype=dtype)
 
-    stft_orig = np.random.randn(n_fft // 2 + 1, 4) ** power
+    stft_orig = np.random.randn(n_fft // 2 + 1, 4)**power
     mels = mel_basis.dot(stft_orig.astype(dtype))
 
     stft = librosa.feature.inverse.mel_to_stft(mels, power=power, n_fft=n_fft)
@@ -931,12 +952,16 @@ def test_mel_to_audio():
 def test_mfcc_to_mel(n_mfcc, n_mels, dct_type, lifter):
     y = librosa.tone(440.0, sr=22050, duration=1)
 
-    mfcc = librosa.feature.mfcc(y=y, sr=22050,
-                                n_mels=n_mels, n_mfcc=n_mfcc, dct_type=dct_type)
+    mfcc = librosa.feature.mfcc(y=y,
+                                sr=22050,
+                                n_mels=n_mels,
+                                n_mfcc=n_mfcc,
+                                dct_type=dct_type)
 
     melspec = librosa.feature.melspectrogram(y=y, sr=22050, n_mels=n_mels)
 
-    mel_recover = librosa.feature.inverse.mfcc_to_mel(mfcc, n_mels=n_mels,
+    mel_recover = librosa.feature.inverse.mfcc_to_mel(mfcc,
+                                                      n_mels=n_mels,
                                                       dct_type=dct_type)
 
     # Quick shape check
@@ -947,7 +972,8 @@ def test_mfcc_to_mel(n_mfcc, n_mels, dct_type, lifter):
 
     # check lifter Parameter error
     with pytest.raises(librosa.ParameterError):
-        mel_recover = librosa.feature.inverse.mfcc_to_mel(mfcc, n_mels=n_mels,
+        mel_recover = librosa.feature.inverse.mfcc_to_mel(mfcc,
+                                                          n_mels=n_mels,
                                                           dct_type=dct_type,
                                                           lifter=-1)
 
@@ -960,10 +986,10 @@ def test_mfcc_to_mel(n_mfcc, n_mels, dct_type, lifter):
 
     # check if mfcc_to_mel works correctly with lifter
     ones = np.ones(mfcc.shape)
-    negate_lifter_vec = 1 + (lifter / 2) * np.sin(np.pi * np.arange(1, 1 +
-                                                                    n_mfcc, dtype=mfcc.dtype) / lifter)[:, np.newaxis]
+    idx = np.arange(1, 1 + n_mfcc, dtype=mfcc.dtype)
+    lifter_vec = 1 + (lifter / 2) * np.sin(np.pi * idx / lifter)[:, np.newaxis]
 
-    mel_recover = librosa.feature.inverse.mfcc_to_mel(ones * negate_lifter_vec,
+    mel_recover = librosa.feature.inverse.mfcc_to_mel(ones * lifter_vec,
                                                       n_mels=n_mels,
                                                       dct_type=dct_type,
                                                       lifter=lifter)
@@ -981,10 +1007,14 @@ def test_mfcc_to_mel(n_mfcc, n_mels, dct_type, lifter):
 def test_mfcc_to_audio(n_mfcc, n_mels, dct_type):
     y = librosa.tone(440.0, sr=22050, duration=1)
 
-    mfcc = librosa.feature.mfcc(y=y, sr=22050,
-                                n_mels=n_mels, n_mfcc=n_mfcc, dct_type=dct_type)
+    mfcc = librosa.feature.mfcc(y=y,
+                                sr=22050,
+                                n_mels=n_mels,
+                                n_mfcc=n_mfcc,
+                                dct_type=dct_type)
 
-    y_inv = librosa.feature.inverse.mfcc_to_audio(mfcc, n_mels=n_mels,
+    y_inv = librosa.feature.inverse.mfcc_to_audio(mfcc,
+                                                  n_mels=n_mels,
                                                   dct_type=dct_type,
                                                   length=len(y))
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/master/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
<!-- Example: Fixes #123 -->
fixes #1006 

#### What does this implement/fix? Explain your changes.
I added a new input variable called `inv_lifter` to [mfcc_to_mel](https://github.com/librosa/librosa/blob/master/librosa/feature/inverse.py#167)  and [mfcc_to_audio](https://github.com/librosa/librosa/blob/master/librosa/feature/inverse.py#217), which is used in a similar fashion to `lifter` in  [mfcc](https://github.com/librosa/librosa/blob/master/librosa/feature/spectral.py#1571).
- if `inv_lifter` is positive, then inverse the liftering by mfcc division.
- if `inv_lifter` is zero, then no inverse liftering is performed.
- if `inv_lifter` is negative, then raise a `ParameterError`.

The docs are adjusted accordingly.
