### PR TITLE
Added variable-Q filter creation

### DIFF
--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -207,13 +207,14 @@ def test__window():
 
 def test_constant_q():
 
-    def __test(sr, fmin, n_bins, bins_per_octave, tuning, filter_scale,
+    def __test(sr, fmin, n_bins, bins_per_octave, gamma, tuning, filter_scale,
                pad_fft, norm):
 
         F, lengths = librosa.filters.constant_q(sr,
                                                 fmin=fmin,
                                                 n_bins=n_bins,
                                                 bins_per_octave=bins_per_octave,
+                                                gamma=gamma,
                                                 tuning=tuning,
                                                 filter_scale=filter_scale,
                                                 pad_fft=pad_fft,
@@ -241,31 +242,36 @@ def test_constant_q():
     yield (tf, sr, sr/2.0, 1, 12, 0, 1, True, 1)
 
     # with negative fmin
-    yield (tf, sr, -60, 1, 12, 0, 1, True, 1)
+    yield (tf, sr, -60, 1, 12, 0, 0, 1, True, 1)
 
     # with negative bins_per_octave
-    yield (tf, sr, 60, 1, -12, 0, 1, True, 1)
+    yield (tf, sr, 60, 1, -12, 0, 0, 1, True, 1)
+
+    # with negative gamma
+    yield (tf, sr, 60, 1, 12, -1, 0, 1, True, 1)
 
     # with negative bins
-    yield (tf, sr, 60, -1, 12, 0, 1, True, 1)
+    yield (tf, sr, 60, -1, 12, 0, 0, 1, True, 1)
 
     # with negative filter_scale
-    yield (tf, sr, 60, 1, 12, 0, -1, True, 1)
+    yield (tf, sr, 60, 1, 12, 0, 0, -1, True, 1)
 
     # with negative norm
-    yield (tf, sr, 60, 1, 12, 0, 1, True, -1)
+    yield (tf, sr, 60, 1, 12, 0, 0, 1, True, -1)
 
     for fmin in [None, librosa.note_to_hz('C3')]:
         for n_bins in [12, 24]:
             for bins_per_octave in [12, 24]:
-                for tuning in [0, 0.25]:
-                    for filter_scale in [1, 2]:
-                        for norm in [1, 2]:
-                            for pad_fft in [False, True]:
-                                yield (__test, sr, fmin, n_bins,
-                                       bins_per_octave, tuning,
-                                       filter_scale, pad_fft,
-                                       norm)
+                for gamma in [0, 2]:
+                    for tuning in [0, 0.25]:
+                        for filter_scale in [1, 2]:
+                            for norm in [1, 2]:
+                                for pad_fft in [False, True]:
+                                    yield (__test, sr, fmin, n_bins,
+                                           bins_per_octave, gamma,
+                                           tuning, filter_scale,
+                                           pad_fft,
+                                           norm)
 
 
 def test_window_bandwidth():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/master/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
<!-- Example: Fixes #123 -->
N/A

#### What does this implement/fix? Explain your changes.
This adds a new parameter "gamma" to the constant-q filterbank creation (and by extension the calculation of filter lengths). "Gamma" allows us to lower the q-factor towards lower frequencies to a variable degree, while still maintaining an approximately constant q-factor at higher frequencies. Setting "gamma" equal to zero means that the filters created will be constant-q, and leaves the current functionality unchanged. The variable q-factor relaxes the need for large filters at low frequencies that the constant q-factor imposes.

See for more information:
Schörkhuber, Christian, et al. "A Matlab toolbox for efficient perfect reconstruction time-frequency transforms with log-frequency resolution." Audio Engineering Society Conference: 53rd International Conference: Semantic Audio. Audio Engineering Society, 2014.

#### Any other comments?
Forgive me if there is a better way to implement this (such as with separate functions), or if I have missed part of the process of making a contribution or anything required to make the change.
