### PR TITLE
Fixed calculation of maximum filter cutoff

### DIFF
--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -878,9 +878,9 @@ def vqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84, gamma=None,
     fmax_t = np.max(freqs)
 
     # Determine required resampling quality
-    Q = float(filter_scale) / (2.0**(1. / bins_per_octave) - 1)
-
-    filter_cutoff = (fmax_t + gamma) * (1 + 0.5 * filters.window_bandwidth(window) / Q)
+    alpha = (2.0**(1. / bins_per_octave) - 1)
+    Q = float(filter_scale) / alpha
+    filter_cutoff = fmax_t * (1 + 0.5 * filters.window_bandwidth(window) / Q) + 0.5 * gamma
     nyquist = sr / 2.0
 
     auto_resample = False


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/master/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
<!-- Example: Fixes #123 -->
N/A

#### What does this implement/fix? Explain your changes.
In the current code, gamma is added directly to the maximum frequency to calculate filter cutoff.

This results in

filter_cutoff = f_k + gamma + 0.5 * B_k + gamma * 0.5 * B_k / f_k

, whereas my change implements

filter_cutoff = f_k + 0.5 * B_k + 0.5 * gamma

, which I believe is what we want instead.

#### Any other comments?

