### PR TITLE
DTW: Assert certain cost matrix shape for given step sizes

### DIFF
--- a/librosa/sequence.py
+++ b/librosa/sequence.py
@@ -190,6 +190,23 @@ def dtw(X=None, Y=None, C=None, metric='euclidean', step_sizes_sigma=None,
         raise ParameterError('For diagonal matching: Y.shape[1] >= X.shape[1] '
                              '(C.shape[1] >= C.shape[0])')
 
+    # given the step sizes, check of the shape of C is valid
+    with np.errstate(divide='ignore'):
+        step_sizes_ratio = step_sizes_sigma[:, 0] / step_sizes_sigma[:, 1]
+
+    most_horizontal_step_idx = np.argmin(step_sizes_ratio)
+    most_vertical_step_idx = np.argmax(step_sizes_ratio)
+    most_horizontal_step = step_sizes_sigma[most_horizontal_step_idx]
+    most_vertical_step = step_sizes_sigma[most_vertical_step_idx]
+
+    if subseq is False and most_horizontal_step[0] != 0:
+        assert (C.shape[0] / most_horizontal_step[0]) > (C.shape[1] / most_horizontal_step[1]),\
+            'Sequence lengths does not match step sizes'
+
+    if most_vertical_step[1] != 0:
+        assert (C.shape[0] / most_vertical_step[0]) < (C.shape[1] / most_vertical_step[1]),\
+            'Sequence lengths does not match step sizes'
+
     max_0 = step_sizes_sigma[:, 0].max()
     max_1 = step_sizes_sigma[:, 1].max()
 

--- a/librosa/sequence.py
+++ b/librosa/sequence.py
@@ -190,23 +190,6 @@ def dtw(X=None, Y=None, C=None, metric='euclidean', step_sizes_sigma=None,
         raise ParameterError('For diagonal matching: Y.shape[1] >= X.shape[1] '
                              '(C.shape[1] >= C.shape[0])')
 
-    # given the step sizes, check of the shape of C is valid
-    with np.errstate(divide='ignore'):
-        step_sizes_ratio = step_sizes_sigma[:, 0] / step_sizes_sigma[:, 1]
-
-    most_horizontal_step_idx = np.argmin(step_sizes_ratio)
-    most_vertical_step_idx = np.argmax(step_sizes_ratio)
-    most_horizontal_step = step_sizes_sigma[most_horizontal_step_idx]
-    most_vertical_step = step_sizes_sigma[most_vertical_step_idx]
-
-    if subseq is False and most_horizontal_step[0] != 0:
-        assert (C.shape[0] / most_horizontal_step[0]) > (C.shape[1] / most_horizontal_step[1]),\
-            'Sequence lengths does not match step sizes'
-
-    if most_vertical_step[1] != 0:
-        assert (C.shape[0] / most_vertical_step[0]) < (C.shape[1] / most_vertical_step[1]),\
-            'Sequence lengths does not match step sizes'
-
     max_0 = step_sizes_sigma[:, 0].max()
     max_1 = step_sizes_sigma[:, 1].max()
 
@@ -232,6 +215,11 @@ def dtw(X=None, Y=None, C=None, metric='euclidean', step_sizes_sigma=None,
                                       step_sizes_sigma,
                                       weights_mul, weights_add,
                                       max_0, max_1)
+
+    if subseq is False and np.isinf(D[-1, -1]):
+        raise RuntimeError('No valid warping path could be computed for the given step sizes')
+    elif subseq is True and np.all(np.isinf(D[-1, :])):
+        raise RuntimeError('No valid warping path could be computed for the given step sizes')
 
     # delete infinity rows and columns
     D = D[max_0:, max_1:]

--- a/librosa/sequence.py
+++ b/librosa/sequence.py
@@ -216,9 +216,10 @@ def dtw(X=None, Y=None, C=None, metric='euclidean', step_sizes_sigma=None,
                                       weights_mul, weights_add,
                                       max_0, max_1)
 
-    if subseq is False and np.isinf(D[-1, -1]):
-        raise RuntimeError('No valid warping path could be computed for the given step sizes')
-    elif subseq is True and np.all(np.isinf(D[-1, :])):
+    # check for a valid accumulated cost matrix:
+    # 1. for full dtw, the upper right cell (-1, -1) has to be non-inf
+    # 2. for subseq dtw, the upper row has to contain a non-inf cell
+    if np.isinf(D[-1, -1]) and (not subseq or np.all(np.isinf(D[-1, :]))):
         raise RuntimeError('No valid warping path could be computed for the given step sizes')
 
     # delete infinity rows and columns


### PR DESCRIPTION
#### Reference Issue
Related: #1014 and #1031


#### What does this implement/fix? Explain your changes.

For certain non-default step sizes, a valid warping path has a restricted slope. Specifically, this is the case if the step sizes don't contain `[1, 0]` and `[0, 1]`. The steepest vertical step and the flattest horizontal step restrict the possible ratios of the lengths of `X` and `Y`. For example, if we use the step sizes `[[1, 1], [1, 2], [2, 1]]`, then the length of `X` has to be shorter than twice the length of `Y`, and vice versa. This PR asserts for the length of the sequences.

The figure below illustrates the new behavior (created with [this gist](https://gist.github.com/fzalkow/d86a7a6e0fbd18a4218dcece467700bf)) for the step sizes `[[1, 1], [1, 2], [2, 1]]`. You see an alignment for various random sequences. The columns show an increase in the length of `Y` and the rows show an increase in the length of `X`. If a cell in the figure grid is left empty, then an assertion was raised.

The outermost grid cells (far off the diagonal) correspond to a maximal difference between the lengths of `X` and `Y`. For those grid cells the warping path is of maximal slope (either only using `[1, 2]` or only using `[2, 1]`). Previous to this PR, it would have returned a segfault in the cases where now an assertion is raised.

![test](https://user-images.githubusercontent.com/5499717/70319384-73dc6600-1822-11ea-982c-b8649549d2d9.png)
