### PR TITLE
Fix librosa.feature.rms #1040

### DIFF
--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -766,7 +766,7 @@ def spectral_flatness(y=None, S=None, n_fft=2048, hop_length=512,
 
 
 def rms(y=None, S=None, frame_length=2048, hop_length=512,
-        center=True, pad_mode='reflect', odd_n_fft=False):
+        center=True, pad_mode='reflect'):
     '''Compute root-mean-square (RMS) value for each frame, either from the
     audio samples `y` or from a spectrogram `S`.
 

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -865,12 +865,13 @@ def rms(y=None, S=None, frame_length=2048, hop_length=512,
         # power spectrogram
         x = np.abs(S) ** 2
 
-        # Recover negative frequency bins' power
-        end = None if frame_length % 2 else -1
-        x[1:end] *= 2
+        # Adjust the DC and sr/2 component
+        x[0] *= 0.5
+        if frame_length % 2 == 0:
+            x[-1] *= 0.5
 
         # Calculate power
-        power = np.sum(x, axis=0, keepdims=True) / frame_length**2
+        power = 2 * np.sum(x, axis=0, keepdims=True) / frame_length**2
     else:
         raise ValueError('Either `y` or `S` must be input.')
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -407,11 +407,11 @@ def test_rms():
         S = np.ones((n, 5))
 
         # RMSE of an all-ones band is 1
-        rms = librosa.feature.rms(S=S)
+        frame_length = 2 * (n - 1)
+        rms = librosa.feature.rms(S=S, frame_length=frame_length)
+        assert np.allclose(rms, np.ones_like(rms) / np.sqrt(frame_length), atol=1e-2)
 
-        assert np.allclose(rms, np.ones_like(rms) / np.sqrt(2 * (n - 1)), atol=1e-2)
-
-    def __test_consistency(frame_length, hop_length, center, odd_n_fft):
+    def __test_consistency(frame_length, hop_length, center):
         y1, sr = librosa.load(__EXAMPLE_FILE, sr=None)
         np.random.seed(0)
         y2 = np.random.rand(100000)  # The mean value, i.e. DC component, is about 0.5
@@ -436,11 +436,11 @@ def test_rms():
 
         # Try both RMS methods.
         rms1 = librosa.feature.rms(S=S1, frame_length=frame_length,
-                                   hop_length=hop_length, odd_n_fft=odd_n_fft)
+                                   hop_length=hop_length)
         rms2 = librosa.feature.rms(y=y1, frame_length=frame_length,
                                    hop_length=hop_length, center=center)
         rms3 = librosa.feature.rms(S=S2, frame_length=frame_length,
-                                   hop_length=hop_length, odd_n_fft=odd_n_fft)
+                                   hop_length=hop_length)
         rms4 = librosa.feature.rms(y=y2, frame_length=frame_length,
                                    hop_length=hop_length, center=center)
 
@@ -454,8 +454,7 @@ def test_rms():
     for frame_length in [2048, 2049, 4096, 4097]:
         for hop_length in [128, 512, 1024]:
             for center in [False, True]:
-                odd_n_fft = True if frame_length % 2 else False
-                yield __test_consistency, frame_length, hop_length, center, odd_n_fft
+                yield __test_consistency, frame_length, hop_length, center
 
     for n in range(10, 100, 10):
         yield __test, n

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -411,35 +411,51 @@ def test_rms():
 
         assert np.allclose(rms, np.ones_like(rms) / np.sqrt(2 * (n - 1)), atol=1e-2)
 
-    def __test_consistency(frame_length, hop_length, center):
-        y, sr = librosa.load(__EXAMPLE_FILE, sr=None)
+    def __test_consistency(frame_length, hop_length, center, odd_n_fft):
+        y1, sr = librosa.load(__EXAMPLE_FILE, sr=None)
+        np.random.seed(0)
+        y2 = np.random.rand(100000)  # The mean value, i.e. DC component, is about 0.5
 
         # Ensure audio is divisible into frame size.
-        y = librosa.util.fix_length(y, y.size - y.size % frame_length)
-        assert y.size % frame_length == 0
+        y1 = librosa.util.fix_length(y1, y1.size - y1.size % frame_length)
+        y2 = librosa.util.fix_length(y2, y2.size - y2.size % frame_length)
+        assert y1.size % frame_length == 0
+        assert y2.size % frame_length == 0
 
         # STFT magnitudes with a constant windowing function and no centering.
-        S = librosa.magphase(librosa.stft(y,
+        S1 = librosa.magphase(librosa.stft(y1,
+                                          n_fft=frame_length,
+                                          hop_length=hop_length,
+                                          window=np.ones,
+                                          center=center))[0]
+        S2 = librosa.magphase(librosa.stft(y2,
                                           n_fft=frame_length,
                                           hop_length=hop_length,
                                           window=np.ones,
                                           center=center))[0]
 
         # Try both RMS methods.
-        rms1 = librosa.feature.rms(S=S, frame_length=frame_length,
-                                   hop_length=hop_length)
-        rms2 = librosa.feature.rms(y=y, frame_length=frame_length,
+        rms1 = librosa.feature.rms(S=S1, frame_length=frame_length,
+                                   hop_length=hop_length, odd_n_fft=odd_n_fft)
+        rms2 = librosa.feature.rms(y=y1, frame_length=frame_length,
+                                   hop_length=hop_length, center=center)
+        rms3 = librosa.feature.rms(S=S2, frame_length=frame_length,
+                                   hop_length=hop_length, odd_n_fft=odd_n_fft)
+        rms4 = librosa.feature.rms(y=y2, frame_length=frame_length,
                                    hop_length=hop_length, center=center)
 
         assert rms1.shape == rms2.shape
+        assert rms3.shape == rms4.shape
 
         # Ensure results are similar.
         np.testing.assert_allclose(rms1, rms2, atol=5e-4)
+        np.testing.assert_allclose(rms3, rms4, atol=5e-4)
 
-    for frame_length in [2048, 4096]:
+    for frame_length in [2048, 2049, 4096, 4097]:
         for hop_length in [128, 512, 1024]:
             for center in [False, True]:
-                yield __test_consistency, frame_length, hop_length, center
+                odd_n_fft = True if frame_length % 2 else False
+                yield __test_consistency, frame_length, hop_length, center, odd_n_fft
 
     for n in range(10, 100, 10):
         yield __test, n


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/master/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
<!-- Example: Fixes #123 -->
Fixes #1040

#### What does this implement/fix? Explain your changes.
I changed the calculation algorithm of `librosa.feature.rms` when giving `S` (not `y`).
In order to satisfy Parseval's equation, the negative frequency bins' power is correctly handled.
Since the calculation formula is slightly different when `n_fft` is odd and even, the new argument `odd_n_fft` is added.
This argument specifies whether or not the `n_fft` used when computing `S` is odd.
(`odd_n_fft` does nothing when `y` is given.)

Here is a sample snippet.
```python
import librosa

frame_length_even = 2048
frame_length_odd = 2049
hop_length = 512
center = True

# make a wave and its spectrogram 
y = np.random.rand(3000)  # wave 
S_even = librosa.magphase(librosa.stft(y,  # spectrogram 
        n_fft=frame_length_even, 
        hop_length=hop_length, 
        window=np.ones))[0]
S_odd = librosa.magphase(librosa.stft(y,  # spectrogram 
        n_fft=frame_length_odd, 
        hop_length=hop_length, 
        window=np.ones))[0] 

# calculate RMS 
rms_even_y = librosa.feature.rms(y=y, frame_length=frame_length_even, hop_length=hop_length, center=center)
rms_even_S = librosa.feature.rms(S=S_even, center=center)
rms_odd_y = librosa.feature.rms(y=y, frame_length=frame_length_odd, hop_length=hop_length, center=center)
rms_odd_S = librosa.feature.rms(S=S_odd, center=center, odd_n_fft=True)
rms_odd_S_mistake = librosa.feature.rms(S=S_odd, center=center)  # mistake
print(rms_even_y, ': rms_even_y')  
print(rms_even_S, ': rms_even_S')  
print(rms_odd_y, ': rms_odd_y')  
print(rms_odd_S, ': rms_odd_S') 
print(rms_odd_S_mistake, ': rms_odd_S_mistake')
```

Output:
```
[[0.56467811 0.56795336 0.57112578 0.57611183 0.57552133 0.57208155]] : rms_even_y
[[0.5646781  0.56795336 0.57112576 0.57611182 0.57552133 0.57208155]] : rms_even_S
[[0.56471934 0.56805793 0.57113983 0.57632674 0.57539677 0.572001  ]] : rms_odd_y
[[0.56471935 0.56805794 0.57113982 0.57632676 0.57539679 0.57200101]] : rms_odd_S
[[0.56488239 0.56820956 0.57133744 0.57660026 0.57567047 0.5722761 ]] : rms_odd_S_mistake
```

#### Any other comments?
I changed the test code `test_rms()` in `test_features.py`.
