### PR TITLE
length of generated tones

### DIFF
--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -1257,8 +1257,7 @@ def tone(frequency, sr=22050, length=None, duration=None, phi=None):
     if phi is None:
         phi = -np.pi * 0.5
 
-    step = 1.0 / sr
-    return np.cos(2 * np.pi * frequency * (np.arange(step * length, step=step)) + phi)
+    return np.cos(2 * np.pi * frequency * np.arange(length) / sr + phi)
 
 
 def chirp(fmin, fmax, sr=22050, length=None, duration=None, linear=False, phi=None):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1364,8 +1364,8 @@ def test_tone():
     yield tf, None, 22050, 22050, 1, None
     yield tf, 440, 22050, None, None, np.pi
 
-    for sr in [11025, 22050]:
-        for length in [None, 22050]:
+    for sr in [11025, 22050, 44100]:
+        for length in [None, 1740, 22050]:
             for duration in [None, 0.5]:
                 for phi in [None, np.pi]:
                     if length is not None or duration is not None:


### PR DESCRIPTION
#### Reference Issue
Fixes #1053 


#### What does this implement/fix? Explain your changes.

This PR fixes an edge case in tone generation, where the length of output signals did not match up exactly.

A unit test has been added to cover the case.

