### PR TITLE
Fix power_to_db: #1056

### DIFF
--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1602,7 +1602,7 @@ def power_to_db(S, ref=1.0, amin=1e-10, top_db=80.0):
         warnings.warn('power_to_db was called on complex input so phase '
                       'information will be discarded. To suppress this warning, '
                       'call power_to_db(np.abs(D)**2) instead.')
-        magnitude = np.abs(S)
+        magnitude = np.abs(S) ** 2
     else:
         magnitude = S
 


### PR DESCRIPTION
#### Reference Issue

Fixes #1056 

#### What does this implement/fix? Explain your changes.

When using complex spectrogram as the argument of `librosa.power_to_db`, complex spectrogram is correctly converted into power spectrogram.