### PR TITLE
added SRC samplerate dispatch to resample

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ jobs:
     include:
         - python: 3.6
           os: linux
-          dist: xenial
+          dist: bionic
         - python: 3.7
           os: linux
-          dist: xenial
+          dist: bionic
         - os: osx
           language: generic
           osx_image: xcode11

--- a/.travis_dependencies.sh
+++ b/.travis_dependencies.sh
@@ -26,10 +26,12 @@ if [ ! -d "$src" ]; then
         if [ "$TRAVIS_OS_NAME" = "osx" ]; then
             wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
             # Platform-specific dependencies
+            brew update
             brew install libsamplerate
         fi
         if [ "$TRAVIS_OS_NAME" = "linux" ]; then
             wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+            sudo apt update
             sudo apt install libsamplerate0
         fi
         # Install both environments

--- a/.travis_dependencies.sh
+++ b/.travis_dependencies.sh
@@ -25,6 +25,8 @@ if [ ! -d "$src" ]; then
         # Download miniconda packages
         if [ "$TRAVIS_OS_NAME" = "osx" ]; then
             wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
+            # Platform-specific dependencies
+            sudo apt install libsamplerate0
         fi
         if [ "$TRAVIS_OS_NAME" = "linux" ]; then
             wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;

--- a/.travis_dependencies.sh
+++ b/.travis_dependencies.sh
@@ -30,7 +30,7 @@ if [ ! -d "$src" ]; then
         fi
         if [ "$TRAVIS_OS_NAME" = "linux" ]; then
             wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-            apt install libsamplerate0
+            sudo apt install libsamplerate0
         fi
         # Install both environments
         bash miniconda.sh -b -p $src

--- a/.travis_dependencies.sh
+++ b/.travis_dependencies.sh
@@ -26,11 +26,11 @@ if [ ! -d "$src" ]; then
         if [ "$TRAVIS_OS_NAME" = "osx" ]; then
             wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
             # Platform-specific dependencies
-            sudo apt install libsamplerate0
+            brew install libsamplerate
         fi
         if [ "$TRAVIS_OS_NAME" = "linux" ]; then
             wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-            brew install libsamplerate
+            apt install libsamplerate0
         fi
         # Install both environments
         bash miniconda.sh -b -p $src

--- a/.travis_dependencies.sh
+++ b/.travis_dependencies.sh
@@ -30,6 +30,7 @@ if [ ! -d "$src" ]; then
         fi
         if [ "$TRAVIS_OS_NAME" = "linux" ]; then
             wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+            brew install libsamplerate
         fi
         # Install both environments
         bash miniconda.sh -b -p $src

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,6 @@ install:
   - conda info -a
   - conda install -c conda-forge ffmpeg
   - pip install -e .[tests]
-  - conda install freetype==2.9
 
 test_script:
   - pytest

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,6 +73,7 @@ sphinx_gallery_conf = {
             'sklearn': 'https://scikit-learn.org/stable',
             'resampy': 'https://resampy.readthedocs.io/en/latest/',
             'pyrubberband': 'https://pyrubberband.readthedocs.io/en/stable/',
+            'samplerate': 'https://python-samplerate.readthedocs.io/en/latest/'
         }
     }
 

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -455,6 +455,11 @@ def resample(y, orig_sr, target_sr, res_type='kaiser_best', fix=True, scale=Fals
 
             To use `scipy.signal.resample_poly`, set `res_type='polyphase'`.
 
+            To use `samplerate.resample`, use the following:
+                - `linear`: linear interpolation
+                - `zero_order_hold`: zero-order hold sampling
+                - `sinc_best`, `sinc_medium`, `sinc_fastest`: for high, medium, and low-quality sinc interpolation
+
         .. note::
             When using `res_type='polyphase'`, only integer sampling rates are
             supported.
@@ -487,6 +492,7 @@ def resample(y, orig_sr, target_sr, res_type='kaiser_best', fix=True, scale=Fals
     librosa.util.fix_length
     scipy.signal.resample
     resampy.resample
+    samplerate.resample
 
     Notes
     -----
@@ -525,6 +531,10 @@ def resample(y, orig_sr, target_sr, res_type='kaiser_best', fix=True, scale=Fals
         target_sr = int(target_sr)
         gcd = np.gcd(orig_sr, target_sr)
         y_hat = scipy.signal.resample_poly(y, target_sr // gcd, orig_sr // gcd, axis=-1)
+    elif res_type in ('linear', 'zero_order_hold', 'sinc_best', 'sinc_fastest', 'sinc_medium'):
+        import samplerate
+        # We have to transpose here to match libsamplerate
+        y_hat = samplerate.resample(y.T, ratio, converter_type=res_type).T
     else:
         y_hat = resampy.resample(y, orig_sr, target_sr, filter=res_type, axis=-1)
 

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -455,10 +455,10 @@ def resample(y, orig_sr, target_sr, res_type='kaiser_best', fix=True, scale=Fals
 
             To use `scipy.signal.resample_poly`, set `res_type='polyphase'`.
 
-            To use `samplerate.resample`, use the following:
-                - `linear`: linear interpolation
-                - `zero_order_hold`: zero-order hold sampling
-                - `sinc_best`, `sinc_medium`, `sinc_fastest`: for high, medium, and low-quality sinc interpolation
+            To use `samplerate.resample`, set any of the following:
+                - `res_type='linear'`: linear interpolation
+                - `res_type='zero_order_hold'`: zero-order hold sampling
+                - `res_type='sinc_best'`, `'sinc_medium'`, or `'sinc_fastest'`: for high, medium, and low-quality sinc interpolation
 
         .. note::
             When using `res_type='polyphase'`, only integer sampling rates are

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -432,6 +432,10 @@ def to_mono(y):
 def resample(y, orig_sr, target_sr, res_type='kaiser_best', fix=True, scale=False, **kwargs):
     """Resample a time series from orig_sr to target_sr
 
+    By default, this uses a high-quality (but relatively slow) method ('kaiser_best')
+    for band-limited sinc interpolation.  The alternate `res_type` values listed below
+    offer different trade-offs of speed and quality.
+
     Parameters
     ----------
     y : np.ndarray [shape=(n,) or shape=(2, n)]
@@ -451,14 +455,15 @@ def resample(y, orig_sr, target_sr, res_type='kaiser_best', fix=True, scale=Fals
 
             To use a faster method, set `res_type='kaiser_fast'`.
 
-            To use `scipy.signal.resample`, set `res_type='fft'` or `res_type='scipy'`.
+            To use `scipy.signal.resample`, set `res_type='fft'` or `res_type='scipy'`. (slow)
 
-            To use `scipy.signal.resample_poly`, set `res_type='polyphase'`.
+            To use `scipy.signal.resample_poly`, set `res_type='polyphase'`. (fast)
 
             To use `samplerate.resample`, set any of the following:
-                - `res_type='linear'`: linear interpolation
-                - `res_type='zero_order_hold'`: zero-order hold sampling
-                - `res_type='sinc_best'`, `'sinc_medium'`, or `'sinc_fastest'`: for high, medium, and low-quality sinc interpolation
+                - `res_type='linear'`: linear interpolation (fast)
+                - `res_type='zero_order_hold'`: repeat the last value between samples (very fast)
+                - `res_type='sinc_best'`, `'sinc_medium'`, or `'sinc_fastest'`: for high-, medium-,
+                    and low-quality sinc interpolation
 
         .. note::
             When using `res_type='polyphase'`, only integer sampling rates are

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,8 @@ setup(
                   'pytest-mpl',
                   'pytest-cov',
                   'pytest',
-                  'contextlib2'],
+                  'contextlib2',
+                  'samplerate'],
         'display': ['matplotlib >= 1.5'],
     }
 )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -103,11 +103,25 @@ def resample_mono(resample_audio):
     y = librosa.to_mono(y)
     return (y, sr)
 
-@pytest.mark.parametrize('sr_out', [8000, 22050])
-@pytest.mark.parametrize('res_type', ['kaiser_best', 'kaiser_fast', 'scipy', 'fft', 'polyphase', 'linear',
-                                      'sinc_best', 'sinc_fastest', 'sinc_medium', 'zero_order_hold'])
-@pytest.mark.parametrize('fix', [False, True])
-def test_resample_mono(resample_audio, sr_out, res_type, fix):
+
+@pytest.mark.parametrize("sr_out", [8000, 22050])
+@pytest.mark.parametrize(
+    "res_type",
+    [
+        "kaiser_best",
+        "kaiser_fast",
+        "scipy",
+        "fft",
+        "polyphase",
+        "linear",
+        "sinc_best",
+        "sinc_fastest",
+        "sinc_medium",
+        "zero_order_hold",
+    ],
+)
+@pytest.mark.parametrize("fix", [False, True])
+def test_resample_mono(resample_mono, sr_out, res_type, fix):
 
     y, sr_in = resample_mono
     y = librosa.to_mono(y)
@@ -130,10 +144,23 @@ def test_resample_mono(resample_audio, sr_out, res_type, fix):
     assert np.abs(y2.shape[-1] - target_length) <= 1
 
 
-@pytest.mark.parametrize('sr_out', [8000, 22050])
-@pytest.mark.parametrize('res_type', ['kaiser_best', 'kaiser_fast', 'scipy', 'fft', 'polyphase', 'linear',
-                                      'sinc_best', 'sinc_fastest', 'sinc_medium', 'zero_order_hold'])
-@pytest.mark.parametrize('fix', [False, True])
+@pytest.mark.parametrize("sr_out", [8000, 22050])
+@pytest.mark.parametrize(
+    "res_type",
+    [
+        "kaiser_best",
+        "kaiser_fast",
+        "scipy",
+        "fft",
+        "polyphase",
+        "linear",
+        "sinc_best",
+        "sinc_fastest",
+        "sinc_medium",
+        "zero_order_hold",
+    ],
+)
+@pytest.mark.parametrize("fix", [False, True])
 def test_resample_stereo(resample_audio, sr_out, res_type, fix):
 
     y, sr_in = resample_audio
@@ -158,9 +185,9 @@ def test_resample_stereo(resample_audio, sr_out, res_type, fix):
     assert np.abs(y2.shape[-1] - target_length) <= 1
 
 
-@pytest.mark.parametrize("res_type", ["fft", "kaiser_best", "kaiser_fast",
-    "polyphase", 'sinc_best', 'sinc_fastest', 'sinc_medium',
-                     'linear', 'zero_order_hold'])
+@pytest.mark.parametrize(
+    "res_type", ["fft", "kaiser_best", "kaiser_fast", "polyphase", "sinc_best", "sinc_fastest", "sinc_medium"]
+)
 @pytest.mark.parametrize("sr_out", [11025, 22050, 44100])
 def test_resample_scale(resample_mono, res_type, sr_out):
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -103,11 +103,11 @@ def resample_mono(resample_audio):
     y = librosa.to_mono(y)
     return (y, sr)
 
-
-@pytest.mark.parametrize("sr_out", [8000, 22050])
-@pytest.mark.parametrize("res_type", ["kaiser_best", "kaiser_fast", "scipy", "fft", "polyphase"])
-@pytest.mark.parametrize("fix", [False, True])
-def test_resample_mono(resample_mono, sr_out, res_type, fix):
+@pytest.mark.parametrize('sr_out', [8000, 22050])
+@pytest.mark.parametrize('res_type', ['kaiser_best', 'kaiser_fast', 'scipy', 'fft', 'polyphase', 'linear',
+                                      'sinc_best', 'sinc_fastest', 'sinc_medium', 'zero_order_hold'])
+@pytest.mark.parametrize('fix', [False, True])
+def test_resample_mono(resample_audio, sr_out, res_type, fix):
 
     y, sr_in = resample_mono
     y = librosa.to_mono(y)
@@ -130,9 +130,10 @@ def test_resample_mono(resample_mono, sr_out, res_type, fix):
     assert np.abs(y2.shape[-1] - target_length) <= 1
 
 
-@pytest.mark.parametrize("sr_out", [8000, 22050])
-@pytest.mark.parametrize("res_type", ["kaiser_best", "kaiser_fast", "scipy", "fft", "polyphase"])
-@pytest.mark.parametrize("fix", [False, True])
+@pytest.mark.parametrize('sr_out', [8000, 22050])
+@pytest.mark.parametrize('res_type', ['kaiser_best', 'kaiser_fast', 'scipy', 'fft', 'polyphase', 'linear',
+                                      'sinc_best', 'sinc_fastest', 'sinc_medium', 'zero_order_hold'])
+@pytest.mark.parametrize('fix', [False, True])
 def test_resample_stereo(resample_audio, sr_out, res_type, fix):
 
     y, sr_in = resample_audio
@@ -157,7 +158,9 @@ def test_resample_stereo(resample_audio, sr_out, res_type, fix):
     assert np.abs(y2.shape[-1] - target_length) <= 1
 
 
-@pytest.mark.parametrize("res_type", ["fft", "kaiser_best", "kaiser_fast", "polyphase"])
+@pytest.mark.parametrize("res_type", ["fft", "kaiser_best", "kaiser_fast",
+    "polyphase", 'sinc_best', 'sinc_fastest', 'sinc_medium',
+                     'linear', 'zero_order_hold'])
 @pytest.mark.parametrize("sr_out", [11025, 22050, 44100])
 def test_resample_scale(resample_mono, res_type, sr_out):
 


### PR DESCRIPTION
#### Reference Issue
Fixes #1047 


#### What does this implement/fix? Explain your changes.

This PR re-introduces support for libsamplerate as a sample-rate conversion backend.  New `res_type` values are supported to map onto libsamplerate's modes.

Functionally, I don't think there's anything to do here.  We should perhaps have a conversation about packaging, dependencies, and possible deprecation of resampy though.

