### PR TITLE
Remove unused variables and imports

### DIFF
--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -16,7 +16,7 @@ from .fft import get_fftlib
 from .audio import resample
 from .._cache import cache
 from .. import util
-from ..util.exceptions import ParameterErrors
+from ..util.exceptions import ParameterError
 from ..filters import get_window, semitone_filterbank
 from ..filters import window_sumsquare
 

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -16,8 +16,7 @@ from .fft import get_fftlib
 from .audio import resample
 from .._cache import cache
 from .. import util
-from ..util.exceptions import ParameterError
-from ..util.decorators import deprecated
+from ..util.exceptions import ParameterErrors
 from ..filters import get_window, semitone_filterbank
 from ..filters import window_sumsquare
 

--- a/librosa/feature/utils.py
+++ b/librosa/feature/utils.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 """Feature manipulation utilities"""
 
-from warnings import warn
 import numpy as np
 import scipy.signal
 

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -49,7 +49,6 @@ from .util.exceptions import ParameterError
 
 from .core.time_frequency import note_to_hz, hz_to_midi, midi_to_hz, hz_to_octs
 from .core.time_frequency import fft_frequencies, mel_frequencies
-from .util.deprecation import Deprecated
 
 __all__ = ['mel',
            'chroma',

--- a/librosa/segment.py
+++ b/librosa/segment.py
@@ -648,8 +648,6 @@ def lag_to_recurrence(lag, axis=-1):
     # Since lag must be 2-dimensional, abs(axis) = axis
     t = lag.shape[axis]
 
-    sparse = scipy.sparse.issparse(lag)
-
     rec = util.shear(lag, factor=+1, axis=axis)
 
     sub_slice = [slice(None)] * rec.ndim

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -11,7 +11,6 @@ from numpy.lib.stride_tricks import as_strided
 
 from .._cache import cache
 from .exceptions import ParameterError
-from .decorators import deprecated
 
 # Constrain STFT block sizes to 256 KB
 MAX_MEM_BLOCK = 2**8 * 2**10


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

I wrote this PR after running pyflakes on the librosa source.

I found a few unused imports, mostly `Deprecated`, so related to #830 
I also found an unused boolean `sparse` in `lag_to_recurrence`, so related to #949 


