### PR TITLE
fix wrong output of function stack_memory

### DIFF
--- a/librosa/feature/utils.py
+++ b/librosa/feature/utils.py
@@ -238,11 +238,7 @@ def stack_memory(data, n_steps=2, delay=1, **kwargs):
 
     data = np.pad(data, [(0, 0), padding], **kwargs)
 
-    history = data
-
-    # TODO: this could be more efficient
-    for i in range(1, n_steps):
-        history = np.vstack([np.roll(data, -i * delay, axis=1), history])
+    history = np.vstack([np.roll(data, -i * delay, axis=1) for i in range(n_steps)[::-1]])
 
     # Trim to original width
     if delay > 0:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/master/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
Fixes #1061


#### What does this implement/fix? Explain your changes.
Fixed wrong output of the function `stack_memory` when input array is large. Added the above test case in `test_features.py`

#### Any other comments?
Though this patch didn't use numba to rewrite this function more efficiently (which i tried a bit but it seems some functions is not compatible to jit). The patch fixed the issure #1061 and it's slightly faster.
