### PR TITLE
Update setup.py (joblib>=0.14) for python 3.82

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'numpy >= 1.15.0',
         'scipy >= 1.0.0',
         'scikit-learn >= 0.14.0, != 0.19.0',
-        'joblib >= 0.12',
+        'joblib >= 0.14',
         'decorator >= 3.0.0',
         'resampy >= 0.2.2',
         'numba >= 0.43.0',


### PR DESCRIPTION
Updating requirement to 'joblib >= 0.14' since `joblib 0.12` produces a `TypeError` (on `iOS 10.14.6`, with `python 3.82` at least). See [issue](https://github.com/librosa/librosa/issues/1090).

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/master/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
<!-- Example: Fixes #123 -->


#### What does this implement/fix? Explain your changes.


#### Any other comments?

