### PR TITLE
STFT fails for large window sizes

### DIFF
--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -229,6 +229,7 @@ def stft(y, n_fft=2048, hop_length=None, win_length=None, window='hann',
     # how many columns can we fit within MAX_MEM_BLOCK?
     n_columns = int(util.MAX_MEM_BLOCK / (stft_matrix.shape[0] *
                                           stft_matrix.itemsize))
+    n_columns = max(n_columns, 1)
 
     for bl_s in range(0, stft_matrix.shape[1], n_columns):
         bl_t = min(bl_s + n_columns, stft_matrix.shape[1])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -213,6 +213,15 @@ def test_stft(infile):
     assert np.allclose(D, DATA["D"].conj())
 
 
+def test_stft_winsizes():
+    x = np.empty(1000000)
+
+    for power in range(12, 17):
+        N = 2 ** power
+        H = N // 2
+        librosa.stft(x, n_fft=N, hop_length=H, win_length=N)
+
+
 # results for FFT bins containing multiple components will be unstable, as when
 # using higher sampling rates or shorter windows with this test signal
 @pytest.mark.parametrize("center", [False, True])


### PR DESCRIPTION
The STFT fails when using large window sizes. This is due to the computation of `n_columns`, which can be zero. `n_columns` is used as third argument for `range`, which must not be zero. To be honest, I don't fully get the idea of the computation of `n_columns`. I just added a quick fix to enforce that `n_columns` is at least one.

The following code example illustrates the issue:

```python
import numpy as np 
import librosa

x = np.empty(1000000)

for exponent in range(12, 17):
    N = 2 ** exponent
    H = N // 2
    print(N, H)
    X = librosa.stft(x, n_fft=N, hop_length=H, win_length=N)
```

Before this pull request, this code example raised an error: `ValueError: range() arg 3 must not be zero`