### PR TITLE
Update effects.py to allow n-dimensional pitch shifting

### DIFF
--- a/tests/test_pitch_shift.py
+++ b/tests/test_pitch_shift.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+import warnings
+
+# Disable cache
+import os
+
+try:
+    os.environ.pop("LIBROSA_CACHE_DIR")
+except KeyError:
+    pass
+
+from contextlib2 import nullcontext as dnr
+import numpy as np
+import pytest
+
+import librosa
+
+__EXAMPLE_FILE_STEREO = os.path.join("tests", "data", "test1_44100.wav")
+
+def test_pitch_shift():
+    y, sr = librosa.load(__EXAMPLE_FILE_STEREO, 44100, mono=False)
+    ys = librosa.effects.pitch_shift(y, sr, 5, bins_per_octave=12)
+    orig_duration = librosa.get_duration(y, sr=sr)
+    new_duration = librosa.get_duration(ys, sr=sr)


### PR DESCRIPTION
#### Reference Issue
<!-- Example: Fixes #123 -->
https://github.com/librosa/librosa/issues/1085

#### What does this implement/fix? Explain your changes.
Fix `librosa.effects.pitch_shift` such that it performs pitch shifting on multichannel audio.

Audio loaded with `librosa.load(..., mono=False)` will now have pitch shifting applied to each audio channel. 

The addition of the call to `y.copy()` on line 310 is to prevent the shifted audio material overwriting the sample passed into the function.

#### Any other comments?
The tests are incomplete, but before I write more I'd like some guidance on how best to integrate the test I've written into the existing tests. I'd also like to know about any edge cases I should be considering in writing tests for this feature. 

Any other feedback about the approach I've taken is welcome, too.

