### PR TITLE
update numba calls for version 0.50.0

### DIFF
--- a/librosa/util/decorators.py
+++ b/librosa/util/decorators.py
@@ -5,7 +5,7 @@
 
 import warnings
 from decorator import decorator
-from numba.decorators import jit as optional_jit
+from numba.core.decorators import jit as optional_jit
 
 __all__ = ['moved', 'deprecated', 'optional_jit']
 

--- a/librosa/util/decorators.py
+++ b/librosa/util/decorators.py
@@ -5,7 +5,11 @@
 
 import warnings
 from decorator import decorator
-from numba.core.decorators import jit as optional_jit
+import numba
+if (numba.__version__ < '0.49.0'):
+    from numba.decorators import jit as optional_jit
+else:
+    from numba.core.decorators import jit as optional_jit
 
 __all__ = ['moved', 'deprecated', 'optional_jit']
 


### PR DESCRIPTION
compatibility with version 0.50.0

--tested with SV2TTS

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/master/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
<!-- Example: Fixes #123 -->


#### What does this implement/fix? Explain your changes.
numba version 0.50.0 uses a different structure for import

#### Any other comments?
Tested the change with SV2TTS. Everything worked as normal.
