### PR TITLE
Fixes #977: Adding reference pitch to tuning conversion utils

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 cache:
+  apt: True
   directories:
   - $HOME/env
+  - $HOME/Library/Caches/Homebrew
 
 language: python
 
@@ -22,12 +24,24 @@ jobs:
           language: generic
           osx_image: xcode11
 
+addons:
+    apt:
+        packages:
+        - libsamplerate0
+
+    homebrew:
+        packages:
+        - libsamplerate
+
 before_install:
     - bash .travis_dependencies.sh
     - export PATH="$HOME/env/miniconda-$TRAVIS_OS_NAME$TRAVIS_PYTHON_VERSION/bin:$PATH";
     - hash -r
     - source activate test-environment
     - conda list
+
+before_cache:
+    - brew cleanup
 
 install:
     # install your own package into the environment

--- a/.travis_dependencies.sh
+++ b/.travis_dependencies.sh
@@ -25,14 +25,9 @@ if [ ! -d "$src" ]; then
         # Download miniconda packages
         if [ "$TRAVIS_OS_NAME" = "osx" ]; then
             wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
-            # Platform-specific dependencies
-            brew update
-            brew install libsamplerate
         fi
         if [ "$TRAVIS_OS_NAME" = "linux" ]; then
             wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-            sudo apt update
-            sudo apt install libsamplerate0
         fi
         # Install both environments
         bash miniconda.sh -b -p $src

--- a/librosa/core/__init__.py
+++ b/librosa/core/__init__.py
@@ -95,6 +95,9 @@ Time and frequency conversion
     mel_to_hz
     octs_to_hz
 
+    A4_to_tuning
+    tuning_to_A4
+
     fft_frequencies
     cqt_frequencies
     mel_frequencies

--- a/librosa/core/time_frequency.py
+++ b/librosa/core/time_frequency.py
@@ -902,21 +902,36 @@ def octs_to_hz(octs, tuning=0.0, bins_per_octave=12):
     return (float(A440) / 16)*(2.0**np.asanyarray(octs))
 
 
-def A4_to_tuning(A, bins_per_octave=12):
-    """Convert reference frequencies to cents (bin fractions).
+def A4_to_tuning(A4, bins_per_octave=12):
+    """Convert a reference pitch frequency (e.g., `A4=435`) to a tuning
+    estimation, in fractions of a bin per octave.
+
+    This is useful for determining the tuning deviation relative to
+    A440 of a given frequency, assuming equal temperament. By default,
+    12 bins per octave are used.
+
+    This method is the inverse of  `tuning_to_A4`.
 
     Examples
     --------
-    >>> librosa.A4_to_tuning()
+    The base case of this method in which A440 yields 0 tuning offset
+    from itself.
+    >>> librosa.A4_to_tuning(440.0)
     0.
+
+    Convert a non-A440 frequency to a tuning offset relative
+    to A440 using the default of 12 bins per octave.
     >>> librosa.A4_to_tuning(432.0)
     -0.318
-    >>> librosa.A4_to_tuning([440.0, 444.0], 24)
+
+    Convert two reference pitch frequencies to corresponding
+    tuning estimations at once, but using 24 bins per octave.
+    >>> librosa.A4_to_tuning([440.0, 444.0], bins_per_octave=24)
     array([   0.,   0.313   ])
 
     Parameters
     ----------
-    A: float or np.ndarray [shape=(n,), dtype=float]
+    A4: float or np.ndarray [shape=(n,), dtype=float]
         Reference frequency(s) corresponding to A4.
 
     bins_per_octave : int > 0
@@ -931,32 +946,48 @@ def A4_to_tuning(A, bins_per_octave=12):
     --------
     tuning_to_A4
     """
-    return bins_per_octave * (np.log2(np.asanyarray(A)) - np.log2(440.0))
+    return bins_per_octave * (np.log2(np.asanyarray(A4)) - np.log2(440.0))
 
 
 def tuning_to_A4(tuning, bins_per_octave=12):
-    """Convert cents (bin fractions) to reference frequencies.
+    """Convert a tuning deviation (from 0) in fractions of a bin per
+    octave (e.g., `tuning=-0.1`) to a reference pitch frequency
+    relative to A440.
+
+    This is useful if you are working in a non-A440 tuning system
+    to determine the reference pitch frequency given a tuning
+    offset and assuming equal temperament. By default, 12 bins per
+    octave are used.
+
+    This method is the inverse of  `A4_to_tuning`.
 
     Examples
     --------
-    >>> librosa.tuning_to_A4()
+    The base case of this method in which a tuning deviation of 0
+    gets us to our A440 reference pitch.
+    >>> librosa.tuning_to_A4(0.0)
     440.
+
+    Convert a nonzero tuning offset to its reference pitch frequency.
     >>> librosa.tuning_to_A4(-0.318)
     431.992
-    >>> librosa.tuning_to_A4([0.1, 0.2, -0.1], 36)
+
+    Convert 3 tuning deviations at once to respective reference
+    pitch frequencies, using 36 bins per octave.
+    >>> librosa.tuning_to_A4([0.1, 0.2, -0.1], bins_per_octave=36)
     array([   440.848,    441.698   439.154])
 
     Parameters
     ----------
     tuning : float or np.ndarray [shape=(n,), dtype=float]
-        Tuning deviation from A440 in (fractional) bins per octave.
+        Tuning deviation from A440 in fractional bins per octave.
 
     bins_per_octave : int > 0
         Number of bins per octave.
 
     Returns
     -------
-    A  : float or np.ndarray [shape=(n,), dtype=float]
+    A4  : float or np.ndarray [shape=(n,), dtype=float]
         Reference frequency corresponding to A4.
 
     See Also

--- a/librosa/core/time_frequency.py
+++ b/librosa/core/time_frequency.py
@@ -17,6 +17,8 @@ __all__ = ['frames_to_samples', 'frames_to_time',
            'hz_to_mel', 'hz_to_octs',
            'mel_to_hz',
            'octs_to_hz',
+           'A4_to_tuning',
+           'tuning_to_A4',
            'fft_frequencies',
            'cqt_frequencies',
            'mel_frequencies',
@@ -307,7 +309,7 @@ def blocks_to_frames(blocks, block_length):
 
     >>> filename = librosa.util.example_audio_file()
     >>> sr = librosa.get_samplerate(filename)
-    >>> stream = librosa.stream(filename, block_length=16, 
+    >>> stream = librosa.stream(filename, block_length=16,
     ...                         frame_length=2048, hop_length=512)
     >>> for n, y in enumerate(stream):
     ...     n_frame = librosa.blocks_to_frames(n, block_length=16)
@@ -350,7 +352,7 @@ def blocks_to_samples(blocks, block_length, hop_length):
 
     >>> filename = librosa.util.example_audio_file()
     >>> sr = librosa.get_samplerate(filename)
-    >>> stream = librosa.stream(filename, block_length=16, 
+    >>> stream = librosa.stream(filename, block_length=16,
     ...                         frame_length=2048, hop_length=512)
     >>> for n, y in enumerate(stream):
     ...     n_sample = librosa.blocks_to_samples(n, block_length=16,
@@ -381,10 +383,10 @@ def blocks_to_time(blocks, block_length, hop_length, sr):
     Returns
     -------
     times : np.ndarray [shape=samples.shape]
-        The time index or indices (in seconds) corresponding to the 
+        The time index or indices (in seconds) corresponding to the
         beginning of each provided block.
 
-        Note that these correspond to the time of the *first* sample 
+        Note that these correspond to the time of the *first* sample
         in each block, and are not frame-centered.
 
     See Also
@@ -398,7 +400,7 @@ def blocks_to_time(blocks, block_length, hop_length, sr):
 
     >>> filename = librosa.util.example_audio_file()
     >>> sr = librosa.get_samplerate(filename)
-    >>> stream = librosa.stream(filename, block_length=16, 
+    >>> stream = librosa.stream(filename, block_length=16,
     ...                         frame_length=2048, hop_length=512)
     >>> for n, y in enumerate(stream):
     ...     n_time = librosa.blocks_to_time(n, block_length=16,
@@ -898,6 +900,70 @@ def octs_to_hz(octs, tuning=0.0, bins_per_octave=12):
     A440 = 440.0 * 2.0**(tuning / bins_per_octave)
 
     return (float(A440) / 16)*(2.0**np.asanyarray(octs))
+
+
+def A4_to_tuning(A, bins_per_octave=12):
+    """Convert reference frequencies to cents (bin fractions).
+
+    Examples
+    --------
+    >>> librosa.A4_to_tuning()
+    0.
+    >>> librosa.A4_to_tuning(432.0)
+    -0.318
+    >>> librosa.A4_to_tuning([440.0, 444.0], 24)
+    array([   0.,   0.313   ])
+
+    Parameters
+    ----------
+    A: float or np.ndarray [shape=(n,), dtype=float]
+        Reference frequency(s) corresponding to A4.
+
+    bins_per_octave : int > 0
+        Number of bins per octave.
+
+    Returns
+    -------
+    tuning   : float or np.ndarray [shape=(n,), dtype=float]
+        Tuning deviation from A440 in (fractional) bins per octave.
+
+    See Also
+    --------
+    tuning_to_A4
+    """
+    return bins_per_octave * (np.log2(np.asanyarray(A)) - np.log2(440.0))
+
+
+def tuning_to_A4(tuning, bins_per_octave=12):
+    """Convert cents (bin fractions) to reference frequencies.
+
+    Examples
+    --------
+    >>> librosa.tuning_to_A4()
+    440.
+    >>> librosa.tuning_to_A4(-0.318)
+    431.992
+    >>> librosa.tuning_to_A4([0.1, 0.2, -0.1], 36)
+    array([   440.848,    441.698   439.154])
+
+    Parameters
+    ----------
+    tuning : float or np.ndarray [shape=(n,), dtype=float]
+        Tuning deviation from A440 in (fractional) bins per octave.
+
+    bins_per_octave : int > 0
+        Number of bins per octave.
+
+    Returns
+    -------
+    A  : float or np.ndarray [shape=(n,), dtype=float]
+        Reference frequency corresponding to A4.
+
+    See Also
+    --------
+    A4_to_tuning
+    """
+    return 440.0 * 2.0**(np.asanyarray(tuning) / bins_per_octave)
 
 
 def fft_frequencies(sr=22050, n_fft=2048):

--- a/librosa/feature/utils.py
+++ b/librosa/feature/utils.py
@@ -4,6 +4,7 @@
 
 import numpy as np
 import scipy.signal
+from numba import jit
 
 from .._cache import cache
 from ..util.exceptions import ParameterError
@@ -135,7 +136,7 @@ def stack_memory(data, n_steps=2, delay=1, **kwargs):
 
     Parameters
     ----------
-    data : np.ndarray [shape=(t,) or (d, t)]
+    data : np.ndarray [shape=(d, t)]
         Input data matrix.  If `data` is a vector (`data.ndim == 1`),
         it will be interpreted as a row matrix and reshaped to `(1, t)`.
 
@@ -219,12 +220,19 @@ def stack_memory(data, n_steps=2, delay=1, **kwargs):
     if n_steps < 1:
         raise ParameterError('n_steps must be a positive integer')
 
+    if data.ndim > 2:
+        raise ParameterError('Input must be at most 2-dimensional. '
+                             'Given data.shape={}'.format(data.shape))
+
     if delay == 0:
         raise ParameterError('delay must be a non-zero integer')
 
     data = np.atleast_2d(data)
-
-    t = data.shape[1]
+    t = data.shape[-1]
+    
+    if t < 1:
+        raise ParameterError('Cannot stack memory when input data has '
+                             'no columns. Given data.shape={}'.format(data.shape))
     kwargs.setdefault('mode', 'constant')
 
     if kwargs['mode'] == 'constant':
@@ -238,13 +246,56 @@ def stack_memory(data, n_steps=2, delay=1, **kwargs):
 
     data = np.pad(data, [(0, 0), padding], **kwargs)
 
-    history = np.vstack([np.roll(data, -i * delay, axis=1) for i in range(n_steps)[::-1]])
+    # Construct the shape of the target array
+    shape = list(data.shape)
+    shape[0] = shape[0] * n_steps
+    shape[1] = t
+    shape = tuple(shape)
 
-    # Trim to original width
+    # Construct the output array to match layout and dtype of input
+    history = np.empty_like(data, shape=shape)
+
+    # Populate the output array
+    __stack(history, data, n_steps, delay)
+
+    return history
+
+
+@jit(nopython=True, cache=True)
+def __stack(history, data, n_steps, delay):
+    '''Memory-stacking helper function.
+
+    Parameters
+    ----------
+    history : output array (2-dimensional)
+
+    data : pre-padded input array (2-dimensional)
+
+    n_steps : int > 0, the number of steps to stack
+
+    delay : int != 0, the amount of delay between steps
+
+    Returns
+    -------
+    None
+        Output is stored directly in the history array
+    '''
+    # Dimension of each copy of the data
+    d = data.shape[0]
+
+    # Total number of time-steps to output
+    t = history.shape[1]
+
     if delay > 0:
-        history = history[:, :t]
+        for step in range(n_steps):
+            q = n_steps - 1 - step
+            # nth block is original shifted left by n*delay steps
+            history[step * d:(step + 1) * d] = data[:, q*delay:q*delay+t]
     else:
-        history = history[:, -t:]
+        # Handle the last block separately to avoid -t:0 empty slices
+        history[-d:, :] = data[:, -t:]
 
-    # Make contiguous
-    return np.asfortranarray(history)
+        for step in range(n_steps-1):
+            # nth block is original shifted right by n*delay steps
+            q = n_steps - 1 - step
+            history[step * d:(step + 1) * d] = data[:, -t + q*delay:q*delay]

--- a/librosa/util/decorators.py
+++ b/librosa/util/decorators.py
@@ -4,9 +4,10 @@
 '''Helpful tools for deprecation'''
 
 import warnings
+from packaging import version
 from decorator import decorator
 import numba
-if (numba.__version__ < '0.49.0'):
+if version.parse(numba.__version__) < version.parse('0.49.0'):
     from numba.decorators import jit as optional_jit
 else:
     from numba.core.decorators import jit as optional_jit

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         'numba >= 0.43.0',
         'soundfile >= 0.9.0',
     ],
+    python_requires='>=3.6',
     extras_require={
         'docs': ['numpydoc', 'sphinx!=1.3.1', 'sphinx_rtd_theme',
                  'matplotlib >= 2.0.0',

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     install_requires=[
         'audioread >= 2.0.0',
         'numpy >= 1.15.0',
+        'packaging >= 18',
         'scipy >= 1.0.0',
         'scikit-learn >= 0.14.0, != 0.19.0',
         'joblib >= 0.14',

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -69,7 +69,7 @@ def test_delta_badwidthaxis(x, width, axis):
     librosa.feature.delta(x, width=width, axis=axis)
 
 
-@pytest.mark.parametrize("data", [np.random.randn(5), np.random.randn(5, 5), np.remainder(np.arange(10000), 24)])
+@pytest.mark.parametrize("data", [np.arange(5.), np.remainder(np.arange(10000), 24)])
 @pytest.mark.parametrize("delay", [-4, -2, -1, 1, 2, 4])
 @pytest.mark.parametrize("n_steps", [1, 2, 3, 300])
 def test_stack_memory(data, n_steps, delay):
@@ -101,6 +101,18 @@ def test_stack_memory(data, n_steps, delay):
 @pytest.mark.parametrize("data", [np.zeros((2, 2))])
 @pytest.mark.xfail(raises=librosa.ParameterError)
 def test_stack_memory_fail(data, n_steps, delay):
+    librosa.feature.stack_memory(data, n_steps=n_steps, delay=delay)
+
+
+@pytest.mark.xfail(raises=librosa.ParameterError)
+def test_stack_memory_ndim_toobig():
+    librosa.feature.stack_memory(np.zeros((2,2,2)), n_steps=3, delay=1)
+
+@pytest.mark.parametrize('data', [np.zeros((2, 0))])
+@pytest.mark.xfail(raises=librosa.ParameterError)
+@pytest.mark.parametrize('delay', [-2, -1, 1, 2])
+@pytest.mark.parametrize('n_steps', [1, 2])
+def test_stack_memory_ndim_badshape(data, delay, n_steps):
     librosa.feature.stack_memory(data, n_steps=n_steps, delay=delay)
 
 

--- a/tests/test_time_frequency.py
+++ b/tests/test_time_frequency.py
@@ -113,7 +113,7 @@ def test_hz_to_octs(tuning, bins_per_octave):
 
 
 @pytest.mark.parametrize(
-    "A,bins_per_octave,tuning",
+    "A4,bins_per_octave,tuning",
     [
         (440.0, 12, 0.0),
         ([440.0, 444.0], 24, [0.0, 0.31335]),
@@ -121,8 +121,8 @@ def test_hz_to_octs(tuning, bins_per_octave):
         (432.0, 36, -0.953)
     ],
 )
-def test_A4_to_tuning(A, bins_per_octave, tuning):
-    tuning_out = librosa.A4_to_tuning(A=A, bins_per_octave=bins_per_octave)
+def test_A4_to_tuning(A4, bins_per_octave, tuning):
+    tuning_out = librosa.A4_to_tuning(A4=A4, bins_per_octave=bins_per_octave)
     assert np.allclose(np.asarray(tuning), tuning_out)
 
 

--- a/tests/test_time_frequency.py
+++ b/tests/test_time_frequency.py
@@ -113,6 +113,34 @@ def test_hz_to_octs(tuning, bins_per_octave):
 
 
 @pytest.mark.parametrize(
+    "A,bins_per_octave,tuning",
+    [
+        (440.0, 12, 0.0),
+        ([440.0, 444.0], 24, [0.0, 0.31335]),
+        ([432.0], 12, [-0.317667]),
+        (432.0, 36, -0.953)
+    ],
+)
+def test_A4_to_tuning(A, bins_per_octave, tuning):
+    tuning_out = librosa.A4_to_tuning(A=A, bins_per_octave=bins_per_octave)
+    assert np.allclose(np.asarray(tuning), tuning_out)
+
+
+@pytest.mark.parametrize(
+    "tuning,bins_per_octave,A4",
+    [
+        (0.0, 12, 440.0),
+        ([-0.2], 24, [437.466]),
+        ([0.1, 0.9], 36, [440.848, 447.691]),
+        (0.0, 24, 440.0)
+    ],
+)
+def test_tuning_to_A4(tuning, bins_per_octave, A4):
+    A4_out = librosa.tuning_to_A4(tuning=tuning, bins_per_octave=bins_per_octave)
+    assert np.allclose(np.asarray(A4), A4_out)
+
+
+@pytest.mark.parametrize(
     "tuning,octave",
     [(None, None), (None, 1), (None, 2), (None, 3), (-25, 1), (-25, 2), (-25, 3), (0, 1), (0, 2), (0, 3)],
 )


### PR DESCRIPTION
#### Reference Issue
Fixes #977 

#### What does this implement/fix? Explain your changes.
- Added `A4_to_tuning` and `tuning_to_A4` conversion functions to allow someone to tune to/work with something besides A440 if desired.
- Added associated unit tests
- In the future, an additional argument could be added to functions such as `midi_to_hz` utilizing these conversion functions, but that's outside of this scope for now.

#### Any other comments?
A few open questions:
- Does it make sense to have these take a `float` or `float or np.ndarray` A4/tuning? Currently wrote them to match the majority of the other unit conversions being  with `float or np.ndarray`.
- In the docstrings, I rounded the example usage results to the thousandths, but there are some small inconsistencies with that in the tests [here ](https://github.com/librosa/librosa/compare/master...jlw365:tuning-conversion-util?expand=1#diff-212b29ab51fbabe0781c6aac7dd4124fR119) - not sure how to handle that.
- I considered adding defaults of `A=440.0` and `tuning=0.0`, but not sure if that makes sense since you wouldn't come to use this anyways if you're doing that?
- Let me know if this wasn't what you had in mind or if I should format any parts here differently; I wasn't super confident in the best style of unit tests that would make sense for these methods.

Thanks!