### PR TITLE
add python_requires to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'numba >= 0.43.0',
         'soundfile >= 0.9.0',
     ],
-    python_requires='>=3.6, <=3.8',
+    python_requires='>=3.6',
     extras_require={
         'docs': ['numpydoc', 'sphinx!=1.3.1', 'sphinx_rtd_theme',
                  'matplotlib >= 2.0.0',

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         'numba >= 0.43.0',
         'soundfile >= 0.9.0',
     ],
+    python_requires='>=3.6, <=3.8',
     extras_require={
         'docs': ['numpydoc', 'sphinx!=1.3.1', 'sphinx_rtd_theme',
                  'matplotlib >= 2.0.0',


### PR DESCRIPTION
add python_requires to setup.py so that unsupported python interpreters don't install librosa by accident.

#### Reference Issue

#### What does this implement/fix? Explain your changes.

This adds the python_requires parameters to setup.py so that pip >= 9.0 doesn't install this package on incompatible python interpreters. I may or may not have discovered the hard way that librosa does not support python 3.5.

#### Any other comments?

According to the docs https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires, this requires setuptools >= 24.2.0 in order to build a package. The docs also say that users with older versions of pip will still be able to download and install the package, but IIUC pip 9.0 is actually the default interpreter for virtualenvs. My guess is that this isn't very many users, but it's not breaking any functionality for older pip versions anyways.