### PR TITLE
Tightened requirements on valid_audio

### DIFF
--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -212,7 +212,7 @@ def valid_audio(y, mono=True):
     `(N,)` (number of samples).
 
     If `mono=False`, then `y` may be either monophonic, or have shape
-    `(2, N)` (stereo).
+    `(2, N)` (stereo) or `(K, N)` for `K>=2` for general multi-channel.
 
 
     Parameters

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -206,7 +206,13 @@ def frame(x, frame_length, hop_length, axis=-1):
 
 @cache(level=20)
 def valid_audio(y, mono=True):
-    '''Validate whether a variable contains valid, mono audio data.
+    '''Validate whether a variable contains valid audio data.
+
+    If `mono=True`, then `y` is only considered valid if it has shape
+    `(N,)` (number of samples).
+
+    If `mono=False`, then `y` may be either monophonic, or have shape
+    `(2, N)` (stereo).
 
 
     Parameters
@@ -215,7 +221,7 @@ def valid_audio(y, mono=True):
       The input data to validate
 
     mono : bool
-      Whether or not to force monophonic audio
+      Whether or not to require monophonic audio
 
     Returns
     -------
@@ -269,6 +275,9 @@ def valid_audio(y, mono=True):
 
     elif y.ndim > 2 or y.ndim == 0:
         raise ParameterError('Audio data must have shape (samples,) or (channels, samples). '
+                             'Received shape={}'.format(y.shape))
+    elif y.shape[0] < 2:
+        raise ParameterError('Mono data must have shape (samples,). '
                              'Received shape={}'.format(y.shape))
 
     if not np.isfinite(y).all():

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -276,7 +276,7 @@ def valid_audio(y, mono=True):
     elif y.ndim > 2 or y.ndim == 0:
         raise ParameterError('Audio data must have shape (samples,) or (channels, samples). '
                              'Received shape={}'.format(y.shape))
-    elif y.shape[0] < 2:
+    elif y.ndim == 2 and y.shape[0] < 2:
         raise ParameterError('Mono data must have shape (samples,). '
                              'Received shape={}'.format(y.shape))
 

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -53,6 +53,13 @@ def test_valid_stereo():
 
 
 @pytest.mark.xfail(raises=librosa.ParameterError)
+def test_valid_fail_mono_2d():
+    """valid_audio: mono=False, y.shape=(1, N)"""
+    y = np.zeros((10, 1)).T
+    librosa.util.valid_audio(y, mono=False)
+
+
+@pytest.mark.xfail(raises=librosa.ParameterError)
 def test_valid_audio_type():
     """valid_audio: list input"""
     y = list(np.zeros(1000))


### PR DESCRIPTION
#### Reference Issue
Fixes #1122 


#### What does this implement/fix? Explain your changes.

This PR fixes / prevents #1122 by tightening the constraints on `valid_audio`.

Monophonic data must be of shape `(N,)`, multichannel data cannot have shape `(1, N)`. (Only 2 and above are allowed.)

#### Any other comments?

This should be revised when we implement #1130 