### PR TITLE
add B, C, D, Z weightings

### DIFF
--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1590,7 +1590,7 @@ def db_to_amplitude(S_db, ref=1.0):
 def perceptual_weighting(S, frequencies, kind='A', **kwargs):
     '''Perceptual weighting of a power spectrogram:
 
-    `S_p[f] = A_weighting(f) + 10*log(S[f] / ref)`
+    `S_p[f] = frequency_weighting(f, 'A') + 10*log(S[f] / ref)`
 
     Parameters
     ----------
@@ -1599,6 +1599,10 @@ def perceptual_weighting(S, frequencies, kind='A', **kwargs):
 
     frequencies : np.ndarray [shape=(d,)]
         Center frequency for each row of `S`
+
+    kind : str
+        The frequency weighting curve to use.
+        e.g. `'A'`, `'B'`, `'C'`, `'D'`, `None or 'Z'`
 
     kwargs : additional keyword arguments
         Additional keyword arguments to `power_to_db`.

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1587,7 +1587,7 @@ def db_to_amplitude(S_db, ref=1.0):
 
 
 @cache(level=30)
-def perceptual_weighting(S, frequencies, **kwargs):
+def perceptual_weighting(S, frequencies, kind='A', **kwargs):
     '''Perceptual weighting of a power spectrogram:
 
     `S_p[f] = A_weighting(f) + 10*log(S[f] / ref)`
@@ -1654,7 +1654,8 @@ def perceptual_weighting(S, frequencies, **kwargs):
     >>> plt.show()
     '''
 
-    offset = time_frequency.A_weighting(frequencies).reshape((-1, 1))
+    offset = time_frequency.frequency_weighting(
+        frequencies, kind=kind).reshape((-1, 1))
 
     return offset + power_to_db(S, **kwargs)
 

--- a/librosa/core/time_frequency.py
+++ b/librosa/core/time_frequency.py
@@ -1474,6 +1474,7 @@ WEIGHTING_FUNCTIONS = {
     'C': C_weighting,
     'D': D_weighting,
     'Z': Z_weighting,
+    None: Z_weighting,
 }
 
 

--- a/librosa/core/time_frequency.py
+++ b/librosa/core/time_frequency.py
@@ -1346,7 +1346,7 @@ def B_weighting(f_sq):     # pylint: disable=invalid-name
     >>> plt.show()
 
     '''
-    const = np.array([12200, 20.6, 158.5]) ** 2.
+    const = np.array([12194, 20.6, 158.5]) ** 2.
     return 0.17 + 20.0 * (
         np.log10(const[0])
         + 1.5 * np.log10(f_sq)

--- a/librosa/core/time_frequency.py
+++ b/librosa/core/time_frequency.py
@@ -1518,7 +1518,9 @@ def frequency_weighting(frequencies, kind='A', **kw):
     >>> plt.show()
 
     '''
-    return WEIGHTING_FUNCTIONS[kind.upper()](frequencies, **kw)
+    if isinstance(kind, str):
+        kind = kind.upper()
+    return WEIGHTING_FUNCTIONS[kind](frequencies, **kw)
 
 
 def multi_frequency_weighting(frequencies, kinds='ZAC', **kw):

--- a/tests/test_time_frequency.py
+++ b/tests/test_time_frequency.py
@@ -362,7 +362,6 @@ def test_B_weighting(min_db):
 
     # Check that 1KHz is around 0dB
     b_khz = librosa.B_weighting(1000.0, min_db=min_db)
-    print(b_khz)
     assert np.allclose(b_khz, 0, atol=1e-3)
 
     b_range = librosa.B_weighting(np.linspace(2e1, 2e4), min_db=min_db)
@@ -376,7 +375,6 @@ def test_C_weighting(min_db):
 
     # Check that 1KHz is around 0dB
     c_khz = librosa.C_weighting(1000.0, min_db=min_db)
-    print(c_khz)
     assert np.allclose(c_khz, 0, atol=1e-3)
 
     c_range = librosa.B_weighting(np.linspace(2e1, 2e4), min_db=min_db)
@@ -390,7 +388,6 @@ def test_D_weighting(min_db):
 
     # Check that 1KHz is around 0dB
     d_khz = librosa.D_weighting(1000.0, min_db=min_db)
-    print(d_khz)
     assert np.allclose(d_khz, 0, atol=1e-3)
 
     d_range = librosa.D_weighting(np.linspace(2e1, 2e4), min_db=min_db)
@@ -418,7 +415,7 @@ def test_frequency_weighting(kind):
 
 @pytest.mark.parametrize(
     "kinds", ['AZC', ['A', 'Z', 'C']])
-def test_frequency_weighting(kinds):
+def test_multi_frequency_weighting(kinds):
     freq = np.linspace(2e1, 2e4)
     assert np.allclose(
         librosa.multi_frequency_weighting(freq, kinds),

--- a/tests/test_time_frequency.py
+++ b/tests/test_time_frequency.py
@@ -357,6 +357,79 @@ def test_A_weighting(min_db):
         assert not np.any(a_range < min_db)
 
 
+@pytest.mark.parametrize("min_db", [None, -40, -80])
+def test_B_weighting(min_db):
+
+    # Check that 1KHz is around 0dB
+    b_khz = librosa.B_weighting(1000.0, min_db=min_db)
+    print(b_khz)
+    assert np.allclose(b_khz, 0, atol=1e-3)
+
+    b_range = librosa.B_weighting(np.linspace(2e1, 2e4), min_db=min_db)
+    # Check that the db cap works
+    if min_db is not None:
+        assert not np.any(b_range < min_db)
+
+
+@pytest.mark.parametrize("min_db", [None, -40, -80])
+def test_C_weighting(min_db):
+
+    # Check that 1KHz is around 0dB
+    c_khz = librosa.C_weighting(1000.0, min_db=min_db)
+    print(c_khz)
+    assert np.allclose(c_khz, 0, atol=1e-3)
+
+    c_range = librosa.B_weighting(np.linspace(2e1, 2e4), min_db=min_db)
+    # Check that the db cap works
+    if min_db is not None:
+        assert not np.any(c_range < min_db)
+
+
+@pytest.mark.parametrize("min_db", [None, -40, -80])
+def test_D_weighting(min_db):
+
+    # Check that 1KHz is around 0dB
+    d_khz = librosa.D_weighting(1000.0, min_db=min_db)
+    print(d_khz)
+    assert np.allclose(d_khz, 0, atol=1e-3)
+
+    d_range = librosa.D_weighting(np.linspace(2e1, 2e4), min_db=min_db)
+    # Check that the db cap works
+    if min_db is not None:
+        assert not np.any(d_range < min_db)
+
+
+@pytest.mark.parametrize("min_db", [None, -40, -80])
+def test_Z_weighting(min_db):
+    # Check that 1KHz is around 0dB
+    d_khz = librosa.Z_weighting(np.linspace(2e1, 2e4), min_db=min_db)
+    assert np.allclose(d_khz, 0, atol=1e-3)
+
+
+@pytest.mark.parametrize(
+    "kind", list(librosa.core.time_frequency.WEIGHTING_FUNCTIONS))
+def test_frequency_weighting(kind):
+    freq = np.linspace(2e1, 2e4)
+    assert np.allclose(
+        librosa.frequency_weighting(freq, kind),
+        librosa.core.time_frequency.WEIGHTING_FUNCTIONS[kind](freq),
+        0, atol=1e-3)
+
+
+@pytest.mark.parametrize(
+    "kinds", ['AZC', ['A', 'Z', 'C']])
+def test_frequency_weighting(kinds):
+    freq = np.linspace(2e1, 2e4)
+    assert np.allclose(
+        librosa.multi_frequency_weighting(freq, kinds),
+        np.stack([
+            librosa.A_weighting(freq),
+            librosa.Z_weighting(freq),
+            librosa.C_weighting(freq),
+        ]),
+        0, atol=1e-3)
+
+
 def test_samples_like():
 
     X = np.ones((3, 4, 5))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/master/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
<!-- Example: Fixes #123 -->
Implements #1007 

#### What does this implement/fix? Explain your changes.
Currently only A weighting is implemented. This adds on B, C, D, and Z weighting as well.

It also adds helpers:
 - `frequency_weighting(frequencies, 'C')` - choose weighting from string (case insensitive). Use `None` or `'Z'` for unweighted.
 - `multi_frequency_weighting(frequencies, 'ACZ')` - multiple weightings from string/list - name might change tho

#### Notes
 - This is the source I used for the equations/constants. I was having trouble finding the actual source specification without going thru a paywall. If we find better sourced constants I'm happy to update them. (https://en.wikipedia.org/wiki/A-weighting#Function_realisation_of_some_common_weightings) I've compared against other plots online and it seems like they check out tho

 - There is a discrepancy between the constants currently in librosa and the ones on the wiki page. In `A_weighting` librosa uses 12200 whereas the wiki page uses 12194. The difference tops out around 0.0085db (checked up to 2e15) so the difference is completely insignificant, but I just wanted to document it. B and C use 12194. I was tempted to change A too, but maybe some silly person is relying on 3 decimals of precision for their dBs so I held off.

