### PR TITLE
removed contiguity requirement for audio. fixes #1133

### DIFF
--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -236,8 +236,8 @@ def valid_audio(y, mono=True):
             - `y.dtype` is not floating-point
             - `mono == True` and `y.ndim` is not 1
             - `mono == False` and `y.ndim` is not 1 or 2
+            - `mono == False` and `y.ndim == 2` but `y.shape[0] == 1`
             - `np.isfinite(y).all()` is False
-            - `y.flags["F_CONTIGUOUS"]` is False
 
     Notes
     -----
@@ -258,8 +258,6 @@ def valid_audio(y, mono=True):
 
     See also
     --------
-    stack
-    numpy.asfortranarray
     numpy.float32
     '''
 
@@ -276,16 +274,13 @@ def valid_audio(y, mono=True):
     elif y.ndim > 2 or y.ndim == 0:
         raise ParameterError('Audio data must have shape (samples,) or (channels, samples). '
                              'Received shape={}'.format(y.shape))
+
     elif y.ndim == 2 and y.shape[0] < 2:
         raise ParameterError('Mono data must have shape (samples,). '
                              'Received shape={}'.format(y.shape))
 
     if not np.isfinite(y).all():
         raise ParameterError('Audio buffer is not finite everywhere')
-
-    if not y.flags["F_CONTIGUOUS"]:
-        raise ParameterError('Audio buffer is not Fortran-contiguous. '
-            'Use numpy.asfortranarray to ensure Fortran contiguity.')
 
     return True
 

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -91,14 +91,12 @@ def test_valid_audio_ndim(y, mono):
     librosa.util.valid_audio(y, mono=mono)
 
 
-@pytest.mark.xfail(raises=librosa.ParameterError)
 def test_valid_audio_strided():
     """valid_audio: strided"""
     y = np.zeros(1000)[::2]
     librosa.util.valid_audio(y)
 
 
-@pytest.mark.xfail(raises=librosa.ParameterError)
 def test_valid_audio_clang():
     """valid_audio: C-contiguous"""
     y = np.zeros(1000).reshape(2, 500)
@@ -112,11 +110,11 @@ def test_frame_hop():
     librosa.util.frame(y, frame_length=10, hop_length=0)
 
 
-@pytest.mark.xfail(raises=librosa.ParameterError)
 def test_frame_discontiguous():
     """frame: discontiguous input"""
     y = np.zeros((128, 2)).T
-    librosa.util.frame(y[0], frame_length=64, hop_length=64)
+    with pytest.warns(UserWarning):
+        librosa.util.frame(y[0], frame_length=64, hop_length=64)
 
 
 def test_frame_contiguous():


### PR DESCRIPTION
#### Reference Issue
Fixes #1133 


#### What does this implement/fix? Explain your changes.

This PR removes the contiguity requirement for audio buffers.  As mentioned in the parent issue, this was originally put in place to guarantee that framing worked properly.

However, since merging #1125 , we no longer require contiguity (but it is encouraged), so this requirement does not seem necessary anymore.

#### Any other comments?

This PR initiates a long-term plan for #1130 .