### PR TITLE
allow bytes_limit in librosa cache

### DIFF
--- a/librosa/_cache.py
+++ b/librosa/_cache.py
@@ -17,7 +17,6 @@ class CacheManager(object):
     preference for speed vs. storage usage.
     '''
 
-    last_resized_at = 0
     def __init__(self, *args, cache_resize_interval=None, level=10, **kwargs):
         # Initialize the memory object
         self.memory = Memory(*args, **kwargs)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/master/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
<!-- Example: Fixes #123 -->
Addresses #1139 

#### What does this implement/fix? Explain your changes.
I figured it would be worth taking a second to sketch out a possible solution. 

What this does:
 - adds `LIBROSA_CACHE_BYTES_LIMIT` - the maximum cache size. If no bytes_limit is set, then the filesystem won't be checked.
 - adds `LIBROSA_CACHE_RESIZE_INTERVAL` - about how often we should check the cache size. I wasn't sure what a sensible default was so I set 5 minutes by default.
 - simplified `decorator.FunctionMaker(...)` to `functools.wraps`

If you'd rather close, that's fine. I would just feel better if we could set some cache limit.
