### PR TITLE
Display doc updates

### DIFF
--- a/librosa/display.py
+++ b/librosa/display.py
@@ -783,6 +783,7 @@ def __mesh_coords(ax_type, coords, n, **kwargs):
         return coords
 
     coord_map = {'linear': __coord_fft_hz,
+                 'fft': __coord_fft_hz,
                  'hz': __coord_fft_hz,
                  'log': __coord_fft_hz,
                  'mel': __coord_mel_hz,

--- a/librosa/display.py
+++ b/librosa/display.py
@@ -636,7 +636,7 @@ def specshow(data, x_coords=None, y_coords=None,
 
     Examples
     --------
-    Visualize an STFT power spectrum
+    Visualize an STFT power spectrum using default parameters
 
     >>> import matplotlib.pyplot as plt
     >>> y, sr = librosa.load(librosa.util.example_audio_file())
@@ -644,15 +644,18 @@ def specshow(data, x_coords=None, y_coords=None,
 
     >>> D = librosa.amplitude_to_db(np.abs(librosa.stft(y)), ref=np.max)
     >>> plt.subplot(4, 2, 1)
-    >>> librosa.display.specshow(D, y_axis='linear')
+    >>> librosa.display.specshow(D, y_axis='linear', sr=sr)
     >>> plt.colorbar(format='%+2.0f dB')
     >>> plt.title('Linear-frequency power spectrogram')
 
 
-    Or on a logarithmic scale
+    Or on a logarithmic scale, and using a larger hop
 
+    >>> hop_length = 1024
+    >>> D = librosa.amplitude_to_db(np.abs(librosa.stft(y, hop_length=hop_length)),
+    ...                             ref=np.max)
     >>> plt.subplot(4, 2, 2)
-    >>> librosa.display.specshow(D, y_axis='log')
+    >>> librosa.display.specshow(D, y_axis='log', sr=sr, hop_length=hop_length)
     >>> plt.colorbar(format='%+2.0f dB')
     >>> plt.title('Log-frequency power spectrogram')
 

--- a/librosa/display.py
+++ b/librosa/display.py
@@ -548,6 +548,10 @@ def specshow(data, x_coords=None, y_coords=None,
 
         All frequency types are plotted in units of Hz.
 
+        Any spectrogram parameters (hop_length, sr, bins_per_octave, etc.)
+        used to generate the input data should also be provided when
+        calling `specshow`.
+
         Categorical types:
 
         - 'chroma' : pitches are determined by the chroma filters.
@@ -981,7 +985,7 @@ def __coord_mel_hz(n, fmin=0, fmax=11025.0, **_kwargs):
     return basis
 
 
-def __coord_cqt_hz(n, fmin=None, bins_per_octave=12, **_kwargs):
+def __coord_cqt_hz(n, fmin=None, bins_per_octave=12, sr=22050, **_kwargs):
     '''Get CQT bin frequencies'''
     if fmin is None:
         fmin = core.note_to_hz('C1')
@@ -990,9 +994,15 @@ def __coord_cqt_hz(n, fmin=None, bins_per_octave=12, **_kwargs):
     fmin = fmin * 2.0**(_kwargs.get('tuning', 0.0) / bins_per_octave)
 
     # we drop by half a bin so that CQT bins are centered vertically
-    return core.cqt_frequencies(n+1,
-                                fmin=fmin / 2.0**(0.5/bins_per_octave),
-                                bins_per_octave=bins_per_octave)
+    freqs = core.cqt_frequencies(n+1,
+                                 fmin=fmin / 2.0**(0.5/bins_per_octave),
+                                 bins_per_octave=bins_per_octave)
+
+    if np.any(freqs > 0.5 * sr):
+        warnings.warn('Frequency axis exceeds Nyquist. '
+                      'Did you remember to set all spectrogram parameters in specshow?')
+
+    return freqs
 
 
 def __coord_chroma(n, bins_per_octave=12, **_kwargs):

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -542,3 +542,16 @@ def test_sharex_waveplot_ms(y, sr, S_abs):
     librosa.display.specshow(librosa.amplitude_to_db(S_abs, ref=np.max), x_axis="ms")
     plt.xlabel("")  # hide the x label here, which is not propagated automatically
     return plt.gcf()
+
+
+@pytest.mark.parametrize('format_str', ['cqt_hz', 'cqt_note'])
+def test_axis_bound_warning(format_str):
+    
+    with pytest.warns(UserWarning):
+        # set sr=22050
+        # fmin= 11025
+        # 72 bins
+        # 12 bins per octave
+
+        librosa.display.specshow(np.zeros((72, 3)), y_axis=format_str,
+                                 fmin=11025, sr=22050, bins_per_octave=12)


### PR DESCRIPTION
#### Reference Issue
Fixes #1135 
Fixes #1136 


#### What does this implement/fix? Explain your changes.
- Adds `fft` mode to axis types in specshow (to fit documentation)
- Expands documentation about axis decoration with spectrograms
- Adds a warning to `cqt_hz` decoration if it looks like the user messed up (frequencies exceed nyquist).

#### Any other comments?

The other frequency ranges (mel, linear) can't trigger the Nyquist exception because they're limited by construction.

The other cqt mode (`cqt_note`) inherits the warning from `cqt_hz` by default, as it uses the same axis generator and only changes the formatting.  Warning tests are included for both

I think this is good to go.  If anyone wants to CR, please do so, but otherwise I see no barrier to merging.