### PR TITLE
Key support for note conversion and display

### DIFF
--- a/librosa/core/time_frequency.py
+++ b/librosa/core/time_frequency.py
@@ -569,24 +569,24 @@ def midi_to_note(midi, octave=True, cents=False, key='C:maj', unicode=True):
 
     >>> librosa.midi_to_note(37)
     'C♯2'
-    
+
     >>> librosa.midi_to_note(37, unicode=False)
     'C#2'
-    
+
     >>> librosa.midi_to_note(-2)
     'A♯-2'
-    
+
     >>> librosa.midi_to_note(104.7)
     'A7'
-    
+
     >>> librosa.midi_to_note(104.7, cents=True)
     'A7-30'
-    
+
     >>> librosa.midi_to_note(list(range(12, 24)))
     ['C0', 'C♯0', 'D0', 'D♯0', 'E0', 'F0', 'F♯0', 'G0', 'G♯0', 'A0', 'A♯0', 'B0']
 
     Use a key signature to resolve enharmonic equivalences
-    >>> librosa.midi_to_note(range(12), key='A:min')
+    >>> librosa.midi_to_note(range(12, 24), key='F:min')
     ['C0', 'D♭0', 'D0', 'E♭0', 'E0', 'F0', 'G♭0', 'G0', 'A♭0', 'A0', 'B♭0', 'B0']
 
     Parameters
@@ -623,7 +623,7 @@ def midi_to_note(midi, octave=True, cents=False, key='C:maj', unicode=True):
     midi_to_hz
     note_to_midi
     hz_to_note
-    key_to_note
+    key_to_notes
     '''
 
     if cents and not octave:
@@ -1716,8 +1716,9 @@ def samples_like(X, hop_length=512, n_fft=None, axis=-1):
 
 
 @cache(level=10)
-def key_to_notes(key, unicode=True): 
-    '''Construct the names for 12 chromatic notes for a given key.
+def key_to_notes(key, unicode=True):
+    '''Lists all 12 note names in the chromatic scale, as spelled according to
+    a given key (major or minor).
 
     This function exists to resolve enharmonic equivalences between different
     spellings for the same pitch (e.g. C♯ vs D♭), and is primarily useful when producing
@@ -1731,8 +1732,7 @@ def key_to_notes(key, unicode=True):
     2. If the tonic does not have an accidental, accidentals will be inferred to minimize
        the total number used for diatonic scale degrees.
 
-    3. If there is a tie (e.g., in the case of C:maj vs A:min), sharps will be preferred
-       for major keys, and flats will be preferred for minor keys.
+    3. If there is a tie (e.g., in the case of C:maj vs A:min), sharps will be preferred.
 
     Parameters
     ----------
@@ -1766,9 +1766,9 @@ def key_to_notes(key, unicode=True):
     >>> librosa.key_to_notes('C:maj')
     ['C', 'C♯', 'D', 'D♯', 'E', 'F', 'F♯', 'G', 'G♯', 'A', 'A♯', 'B']
 
-    `A:min` will use all flats
+    `A:min` has the same notes
     >>> librosa.key_to_notes('A:min')
-    ['C', 'D♭', 'D', 'E♭', 'E', 'F', 'G♭', 'G', 'A♭', 'A', 'B♭', 'B']
+    ['C', 'C♯', 'D', 'D♯', 'E', 'F', 'F♯', 'G', 'G♯', 'A', 'A♯', 'B']
 
     `A♯:min` will use sharps, but spell note 0 (`C`) as `B♯`
     >>> librosa.key_to_notes('A#:min')
@@ -1824,16 +1824,11 @@ def key_to_notes(key, unicode=True):
         # use sharps explicitly
         use_sharps = True
 
-    elif 0 < tonic_number < 6:
+    elif 0 <= tonic_number < 6:
         use_sharps = True
 
     elif tonic_number > 6:
         use_sharps = False
-
-    else:
-        # Equal numbers of sharps and flats for tonics 0 and 6
-        # break ties for major => sharp, minor => flat
-        use_sharps = major
 
     # Basic note sequences for simple keys
     notes_sharp = ['C', 'C♯', 'D', 'D♯', 'E', 'F', 'F♯', 'G', 'G♯', 'A', 'A♯', 'B']

--- a/librosa/core/time_frequency.py
+++ b/librosa/core/time_frequency.py
@@ -496,9 +496,9 @@ def note_to_midi(note, round_midi=True):
     12
     >>> librosa.note_to_midi('C#3')
     49
-    >>> librosa.note_to_midi('C♯3')  # Using unicode sharp
+    >>> librosa.note_to_midi('C♯3')  # Using Unicode sharp
     49
-    >>> librosa.note_to_midi('C♭3')  # Using unicode flat
+    >>> librosa.note_to_midi('C♭3')  # Using Unicode flat
     47
     >>> librosa.note_to_midi('f4')
     65
@@ -586,8 +586,8 @@ def midi_to_note(midi, octave=True, cents=False, key='C:maj', unicode=True):
     ['C0', 'C♯0', 'D0', 'D♯0', 'E0', 'F0', 'F♯0', 'G0', 'G♯0', 'A0', 'A♯0', 'B0']
 
     Use a key signature to resolve enharmonic equivalences
-    >>> librosa.midi_to_note(range(12), key='G♯:maj', octave=False)
-    ['B♯', 'C♯', 'D', 'D♯', 'E', 'E♯', 'F♯', 'F𝄪', 'G♯', 'A', 'A♯', 'B']
+    >>> librosa.midi_to_note(range(12), key='A:min')
+    ['C0', 'D♭0', 'D0', 'E♭0', 'E0', 'F0', 'G♭0', 'G0', 'A♭0', 'A0', 'B♭0', 'B0']
 
     Parameters
     ----------
@@ -605,7 +605,7 @@ def midi_to_note(midi, octave=True, cents=False, key='C:maj', unicode=True):
         A key signature to use when resolving enharmonic equivalences.
 
     unicode: bool
-        If `True` (default), accidentals will use unicode notation: ♭ or ♯ 
+        If `True` (default), accidentals will use Unicode notation: ♭ or ♯ 
         If `False`, accidentals will use ASCII-compatible notation: b or #
 
     Returns
@@ -1745,8 +1745,8 @@ def key_to_notes(key, unicode=True):
         Examples: C:maj, Db:min, A♭:min.
 
     unicode: bool
-        If `True` (default), use unicode symbols (♯𝄪♭𝄫)for accidentals
-        If `False`, unicode symbols will be mapped to low-order ascii representations:
+        If `True` (default), use Unicode symbols (♯𝄪♭𝄫)for accidentals
+        If `False`, Unicode symbols will be mapped to low-order ascii representations:
             ♯ -> #, 𝄪 -> ##, ♭ -> b, 𝄫 -> bb
 
     Returns
@@ -1774,7 +1774,7 @@ def key_to_notes(key, unicode=True):
     >>> librosa.key_to_notes('A#:min')
     ['B♯', 'C♯', 'D', 'D♯', 'E', 'E♯', 'F♯', 'G', 'G♯', 'A', 'A♯', 'B']
 
-    `G♯:maj` will use a double-sharp to spell note 7 (`G`) as an `F𝄪`:
+    `G♯:maj` will use a double-sharp to spell note 7 (`G`) as `F𝄪`:
     >>> librosa.key_to_notes('G#:maj')
     ['B♯', 'C♯', 'D', 'D♯', 'E', 'E♯', 'F♯', 'F𝄪', 'G♯', 'A', 'A♯', 'B']
 
@@ -1872,7 +1872,7 @@ def key_to_notes(key, unicode=True):
     # Finally, apply any unicode down-translation if necessary
     if not unicode:
         translations = str.maketrans({'♯': '#', '𝄪': '##', '♭': 'b', '𝄫': 'bb'})
-        notes = list([n.translate(translations) for n in notes])
+        notes = list(n.translate(translations) for n in notes)
 
     return notes
 

--- a/tests/test_time_frequency.py
+++ b/tests/test_time_frequency.py
@@ -530,3 +530,60 @@ def test_blocks_to_time(blocks, block_length, hop_length, sr):
 
     # Check dtype
     assert np.issubdtype(times.dtype, np.float)
+
+
+@pytest.mark.xfail(raises=librosa.ParameterError)
+def test_key_to_notes_badkey():
+    librosa.key_to_notes('not a key')
+
+
+@pytest.mark.parametrize('key,ref_notes', [
+                                        # Test for implicit accidentals, ties
+                                        ('C:maj', ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B']),
+                                        ('A:min', ['C', 'Db', 'D', 'Eb', 'E', 'F', 'Gb', 'G', 'Ab', 'A', 'Bb', 'B']),
+                                        # Test for implicit accidentals, unambiguous
+                                        ('D:maj', ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B']),
+                                        ('F:min', ['C', 'Db', 'D', 'Eb', 'E', 'F', 'Gb', 'G', 'Ab', 'A', 'Bb', 'B']),
+                                        # Test for proper enharmonics with ties
+                                        ('Eb:min', ['C', 'Db', 'D', 'Eb', 'E', 'F', 'Gb', 'G', 'Ab', 'A', 'Bb', 'Cb']),
+                                        ('D#:min', ['C', 'C#', 'D', 'D#', 'E', 'E#', 'F#', 'G', 'G#', 'A', 'A#', 'B']),
+                                        ('Gb:maj', ['C', 'Db', 'D', 'Eb', 'E', 'F', 'Gb', 'G', 'Ab', 'A', 'Bb', 'Cb']),
+                                        ('F#:maj', ['C', 'C#', 'D', 'D#', 'E', 'E#', 'F#', 'G', 'G#', 'A', 'A#', 'B']),
+                                        # Test for theoretical keys
+                                        ('G#:maj', ['B#', 'C#', 'D', 'D#', 'E', 'E#', 'F#', 'F##', 'G#', 'A', 'A#', 'B']),
+                                        ('Cb:min', ['C', 'Db', 'Ebb', 'Eb', 'Fb', 'F', 'Gb', 'Abb', 'Ab', 'Bbb', 'Bb', 'Cb']),
+                                        # Test the edge case of theoretical sharps
+                                        ('B#:maj', ['B#', 'C#', 'C##', 'D#', 'D##', 'E#', 'F#', 'F##', 'G#', 'G##', 'A#', 'A##']),
+                                    ])
+def test_key_to_notes(key, ref_notes):
+    notes = librosa.key_to_notes(key, unicode=False)
+    assert len(notes) == len(ref_notes)
+    for (n, rn) in zip(notes, ref_notes):
+        assert n == rn
+
+
+@pytest.mark.parametrize('key,ref_notes', [
+                                        ('G#:maj', ['B♯', 'C♯', 'D', 'D♯', 'E', 'E♯', 'F♯', 'F𝄪', 'G♯', 'A', 'A♯', 'B']),
+                                        ('Cb:min', ['C', 'D♭', 'E𝄫', 'E♭', 'F♭', 'F', 'G♭', 'A𝄫', 'A♭', 'B𝄫', 'B♭', 'C♭'])
+                                    ])
+def test_key_to_notes_unicode(key, ref_notes):
+    notes = librosa.key_to_notes(key, unicode=True)
+    assert len(notes) == len(ref_notes)
+    for (n, rn) in zip(notes, ref_notes):
+        assert n == rn
+
+
+@pytest.mark.xfail(raises=librosa.ParameterError)
+def test_key_to_degrees_badkey():
+    librosa.key_to_degrees('not a key')
+
+
+@pytest.mark.parametrize('key,ref_degrees', [('C:maj', [0, 2, 4, 5, 7, 9, 11]),
+                                             ('C:min', [0, 2, 3, 5, 7, 8, 10]),
+                                             ('A:min', [ 9, 11,  0,  2,  4,  5,  7]),
+                                             ('Gb:maj', [ 6,  8, 10, 11,  1,  3,  5])])
+def test_key_to_degrees(key, ref_degrees):
+    degrees = librosa.key_to_degrees(key)
+    assert len(degrees) == len(ref_degrees)
+    for (d, rd) in zip(degrees, ref_degrees):
+        assert d == rd

--- a/tests/test_time_frequency.py
+++ b/tests/test_time_frequency.py
@@ -540,7 +540,7 @@ def test_key_to_notes_badkey():
 @pytest.mark.parametrize('key,ref_notes', [
                                         # Test for implicit accidentals, ties
                                         ('C:maj', ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B']),
-                                        ('A:min', ['C', 'Db', 'D', 'Eb', 'E', 'F', 'Gb', 'G', 'Ab', 'A', 'Bb', 'B']),
+                                        ('A:min', ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B']),
                                         # Test for implicit accidentals, unambiguous
                                         ('D:maj', ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B']),
                                         ('F:min', ['C', 'Db', 'D', 'Eb', 'E', 'F', 'Gb', 'G', 'Ab', 'A', 'Bb', 'B']),


### PR DESCRIPTION
#### Reference Issue
Fixes #1148 


#### What does this implement/fix? Explain your changes.

This PR adds a few new features and extensions:

1. `midi_to_note` now supports a `key=` parameter to handle enharmonic equivalences.
2. New functions in `time_frequency`: `key_to_notes` (generate the note spellings for a given key) and `key_to_degrees` (find the note indices corresponding to diatonic scale degrees for a given key).
3. Accidentals are now written with unicode symbols.  An option `unicode=False` can force a downcast to low-order ascii (`#` or `b`).
4. `display` routines now support `key=` where appropriate.  This comes up in the tick locator for chroma, and formatters for chroma and note.  Affected axis modes are `chroma` and `cqt_note`.


#### Any other comments?

I haven't yet written tests for this.  I want to get the naming and API solid before starting on that, so now would be a good time to chime in on high-level comments.

#### Examples

Here's an example using the default (old-style) display for chroma:
![image](https://user-images.githubusercontent.com/1190540/83553000-94872f00-a4d8-11ea-9e03-c74a45b95736.png)

and the same data with `specshow(..., key='E:maj')`:
![image](https://user-images.githubusercontent.com/1190540/83553026-9e109700-a4d8-11ea-8dd3-03f809dc1811.png)

