### PR TITLE
Fix hopsize issue for iirt

### DIFF
--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1298,7 +1298,7 @@ def iirt(y, sr=22050, win_length=2048, hop_length=None, center=True,
 
     # Set the default hop, if it's not already specified
     if hop_length is None:
-        hop_length = int(win_length // 4)
+        hop_length = win_length // 4
 
     # Pad the time series so that frames are centered
     if center:
@@ -1316,7 +1316,7 @@ def iirt(y, sr=22050, win_length=2048, hop_length=None, center=True,
         y_resampled.append(resample(y, sr, cur_sr))
 
     # Compute the number of frames that will fit. The end may get truncated.
-    n_frames = 1 + int((len(y) - win_length) // float(hop_length))
+    n_frames = 1 + (len(y) - win_length) // hop_length
 
     bands_power = []
 
@@ -1332,7 +1332,7 @@ def iirt(y, sr=22050, win_length=2048, hop_length=None, center=True,
             cur_filter_output = scipy.signal.sosfiltfilt(cur_filter,
                                                          y_resampled[cur_sr_idx])
 
-        factor = float(sr) / float(cur_sr)
+        factor = sr / cur_sr
         hop_length_STMSP = hop_length / factor
         win_length_STMSP_round = int(round(win_length / factor))
 

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1316,7 +1316,7 @@ def iirt(y, sr=22050, win_length=2048, hop_length=None, center=True,
         y_resampled.append(resample(y, sr, cur_sr))
 
     # Compute the number of frames that will fit. The end may get truncated.
-    n_frames = 1 + (len(y) - win_length) // hop_length
+    n_frames = int(1 + (len(y) - win_length) // hop_length)
 
     bands_power = []
 

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1336,6 +1336,8 @@ def iirt(y, sr=22050, win_length=2048, hop_length=None, center=True,
         hop_length_STMSP = hop_length / factor
         win_length_STMSP_round = int(round(win_length / factor))
 
+        # hop_length_STMSP is used here as a floating-point number.
+        # The discretization happens at the end to avoid accumulated rounding errors.
         start_idx = np.arange(0, len(cur_filter_output)-win_length_STMSP_round, hop_length_STMSP)
         if len(start_idx) < n_frames:
             min_length = int(np.ceil(n_frames * hop_length_STMSP)) + win_length_STMSP_round

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1363,10 +1363,10 @@ def test_iirt_peaks():
 
     win_length = 200
     hop_length = 50
-    center_freqs = librosa.midi_to_hz(np.arange(30, 85))
-    sample_rates = np.asarray(len(np.arange(30, 36)) * [1000, ] +
-                                  len(np.arange(36, 70)) * [1750, ] +
-                                  len(np.arange(70, 85)) * [4000, ])
+    center_freqs = librosa.midi_to_hz(np.arange(40, 95))
+    sample_rates = np.asarray(len(np.arange(40, 46)) * [1000, ] +
+                                  len(np.arange(46, 80)) * [1750, ] +
+                                  len(np.arange(80, 95)) * [4000, ])
 
     X = librosa.iirt(x, center_freqs=center_freqs, sample_rates=sample_rates,
                      win_length=win_length, hop_length=hop_length)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1350,6 +1350,29 @@ def test_iirt_flayout1(y_44100):
     librosa.iirt(y, hop_length=2205, win_length=4410, flayout="foo")
 
 
+def test_iirt_peaks():
+    # Test for PR #1157
+
+    Fs = 22050
+    length = 180
+    click_times = [10, 50, 90, 130, 170]
+
+    x = np.zeros(length * Fs)
+    for click in click_times:
+        x[click * Fs] = 1
+
+    win_length = 2048
+    hop_length = 512
+    X = librosa.iirt(x, win_length=win_length, hop_length=hop_length)
+
+    for cur_band in X:
+        cur_peaks = scipy.signal.find_peaks(cur_band, prominence=1e-5)[0]
+        assert len(cur_peaks) == 5
+
+        cur_peak_times = cur_peaks * 512 / Fs
+        assert all(abs(cur_peak_times - click_times) < (win_length / Fs))
+
+
 @pytest.fixture(scope="module")
 def S_pcen():
     return np.abs(np.random.randn(9, 30))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1369,7 +1369,7 @@ def test_iirt_peaks():
         cur_peaks = scipy.signal.find_peaks(cur_band, prominence=1e-5)[0]
         assert len(cur_peaks) == 5
 
-        cur_peak_times = cur_peaks * 512 / Fs
+        cur_peak_times = cur_peaks * hop_length / Fs
         assert all(abs(cur_peak_times - click_times) < (win_length / Fs))
 
 


### PR DESCRIPTION
We found a severe bug in the iirt function.

Three different sample rates are used to compute the bands for iirt. For each sample rate, a distinct hop size is used to compute the short-time mean-square power (STMSP). Without this bug fix, the hop sizes were rounded and then applied, which is problematic. The rounding error leads to increasing shifts that are different for each of the three sample rates. As a consequence, for longer waveforms, the three frequency bands are out of sync. We solved this by computing the start indices for the windows before rounding.

The following code example illustrates the issue:

    import numpy as np
    import librosa
    from matplotlib import pyplot as plt

    Fs = 22050
    x = librosa.clicks([10, 50, 90, 130, 170], sr=Fs, length=180*Fs)
    X = librosa.iirt(x)

    plt.figure(figsize=(10, 4))
    plt.imshow(np.log(X + 1e-7), aspect='auto', origin='lower', cmap='gray_r', extent=[0, 180, 24, 108])
    plt.colorbar()
    plt.xlabel('Time (seconds)')
    plt.ylabel('Pitch')

The result without the bug fix:
![old](https://user-images.githubusercontent.com/5499717/84139996-2f3fba80-aa51-11ea-9dd6-68a97f68c89a.png)


The result with the bug fix:
![new](https://user-images.githubusercontent.com/5499717/84140010-34046e80-aa51-11ea-8b40-6561e897da46.png)

Thanks to @ahnonay, who found the issue! Also, ping to @stefan-balke who might be interested.