### PR TITLE
Remove pre-emphasis glitch

### DIFF
--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -594,7 +594,10 @@ def preemphasis(y, coef=0.97, zi=None, return_zf=False):
         At `coef=1`, the result is the first-order difference of the signal.
 
     zi : number
-        Initial filter state
+        Initial filter state.  When making successive calls to non-overlapping
+        frames, this can be set to the `zf` returned from the previous call.
+
+        By default `zi` is initialized as `2*y[0] - y[1]`.
 
     return_zf : boolean
         If `True`, return the final filter state.
@@ -642,7 +645,10 @@ def preemphasis(y, coef=0.97, zi=None, return_zf=False):
     a = np.asarray([1.0], dtype=y.dtype)
 
     if zi is None:
-        zi = scipy.signal.lfilter_zi(b, a)
+        # Initialize the filter to implement linear extrapolation
+        zi = 2*y[..., 0] - y[..., 1]
+
+    zi = np.atleast_1d(zi)
 
     y_out, z_f = scipy.signal.lfilter(b, a, y,
                                       zi=np.asarray(zi, dtype=y.dtype))

--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -593,9 +593,15 @@ def preemphasis(y, coef=0.97, zi=None, return_zf=False):
 
         At `coef=1`, the result is the first-order difference of the signal.
 
+        The default (0.97) matches the pre-emphasis filter used in the HTK
+        implementation of MFCCs [1]_.
+
+        .. [1] http://htk.eng.cam.ac.uk/
+
     zi : number
         Initial filter state.  When making successive calls to non-overlapping
         frames, this can be set to the `zf` returned from the previous call.
+        (See example below.)
 
         By default `zi` is initialized as `2*y[0] - y[1]`.
 

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -244,7 +244,7 @@ def test_split(y_split_idx, frame_length, hop_length, top_db):
 
 
 @pytest.mark.parametrize("coef", [0.5, 0.99])
-@pytest.mark.parametrize("zi", [None, [0]])
+@pytest.mark.parametrize("zi", [None, 0, [0]])
 @pytest.mark.parametrize("return_zf", [False, True])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_preemphasis(coef, zi, return_zf, dtype):


### PR DESCRIPTION
#### Reference Issue
Fixes #1032 


#### What does this implement/fix? Explain your changes.

This PR implements the linear extrapolation initialization for preemphasis.

As a bonus, scalar inputs are now allowed for `zi` and they should be automatically upcast to match the filter shape.

