### PR TITLE
Use Numba API location for jit import.

### DIFF
--- a/librosa/util/decorators.py
+++ b/librosa/util/decorators.py
@@ -4,13 +4,8 @@
 '''Helpful tools for deprecation'''
 
 import warnings
-from packaging import version
 from decorator import decorator
-import numba
-if version.parse(numba.__version__) < version.parse('0.49.0'):
-    from numba.decorators import jit as optional_jit
-else:
-    from numba.core.decorators import jit as optional_jit
+from numba import jit as optional_jit
 
 __all__ = ['moved', 'deprecated', 'optional_jit']
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/main/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue

xref: https://github.com/numba/numba/issues/5865. Hopefully the change proposed herein would make it so that  changes in Numba's internals would not impact `librosa`.


#### What does this implement/fix? Explain your changes.
Imports Numba's `jit` decorator from the Numba API location opposed to Numba's internals.

#### Any other comments?

There appears to be no use of `optional_jit` in the code base? Perhaps consider for deprecation/removal?