### PR TITLE
removed optional_jit decorator, should have been purged in 0.7

### DIFF
--- a/librosa/util/decorators.py
+++ b/librosa/util/decorators.py
@@ -5,9 +5,8 @@
 
 import warnings
 from decorator import decorator
-from numba import jit as optional_jit
 
-__all__ = ['moved', 'deprecated', 'optional_jit']
+__all__ = ['moved', 'deprecated']
 
 
 def moved(moved_from, version, version_removed):


### PR DESCRIPTION
#### Reference Issue

#625 - we should have removed this function last year in the 0.7 release, but missed it due to a lack of a deprecation decorator.


#### What does this implement/fix? Explain your changes.

Removes the hold-over `optional_jit` alias from the 0.6 days.

#### Any other comments?

No need for CR here.