### PR TITLE
return D_steps for backtracking by user

### DIFF
--- a/librosa/sequence.py
+++ b/librosa/sequence.py
@@ -107,17 +107,17 @@ def dtw(X=None, Y=None, C=None, metric='euclidean', step_sizes_sigma=None,
 
     Returns
     -------
-    D : np.ndarray [shape=(N,M)]
+    D : np.ndarray [shape=(N, M)]
         accumulated cost matrix.
-        D[N,M] is the total alignment cost.
+        D[N, M] is the total alignment cost.
         When doing subsequence DTW, D[N,:] indicates a matching function.
 
-    wp : np.ndarray [shape=(N,2)]
+    wp : np.ndarray [shape=(N, 2)]
         Warping path with index pairs.
-        Each row of the array contains an index pair n,m).
+        Each row of the array contains an index pair (n, m).
         Only returned when ``backtrack`` is True.
 
-    steps : np.ndarray [shape=(N,M)]
+    steps : np.ndarray [shape=(N, M)]
         Step matrix, containing the indices of the used steps from the cost
         accumulation step.
         Only returned when ``return_steps`` is True.
@@ -351,12 +351,12 @@ def __dtw_calc_accu_cost(C, D, steps, step_sizes_sigma,
 
     Returns
     -------
-    D : np.ndarray [shape=(N,M)]
+    D : np.ndarray [shape=(N, M)]
         accumulated cost matrix.
-        D[N,M] is the total alignment cost.
+        D[N, M] is the total alignment cost.
         When doing subsequence DTW, D[N,:] indicates a matching function.
 
-    steps : np.ndarray [shape=(N,M)]
+    steps : np.ndarray [shape=(N, M)]
         Step matrix, containing the indices of the used steps from the cost
         accumulation step.
 
@@ -414,7 +414,7 @@ def __dtw_backtracking(steps, step_sizes_sigma, subseq, start=None):  # pragma: 
     wp : list [shape=(N,)]
         Warping path with index pairs.
         Each list entry contains an index pair
-        (n,m) as a tuple
+        (n, m) as a tuple
 
     See Also
     --------
@@ -426,7 +426,7 @@ def __dtw_backtracking(steps, step_sizes_sigma, subseq, start=None):  # pragma: 
         cur_idx = (steps.shape[0] - 1, start)
 
     wp = []
-    # Set starting point D(N,M) and append it to the path
+    # Set starting point D(N, M) and append it to the path
     wp.append((cur_idx[0], cur_idx[1]))
 
     # Loop backwards.
@@ -478,7 +478,7 @@ def dtw_backtracking(steps, step_sizes_sigma=None, subseq=False, start=None):
     wp : list [shape=(N,)]
         Warping path with index pairs.
         Each list entry contains an index pair
-        (n,m) as a tuple
+        (n, m) as a tuple
 
     See Also
     --------
@@ -1308,7 +1308,7 @@ def viterbi_binary(prob, transition, p_state=None, p_init=None, return_logp=Fals
     if transition.shape == (2, 2):
         transition = np.tile(transition, (n_states, 1, 1))
     elif transition.shape != (n_states, 2, 2):
-        raise ParameterError('transition.shape={}, must be (2,2) or '
+        raise ParameterError('transition.shape={}, must be (2, 2) or '
                              '(n_states, 2, 2)={}'.format(transition.shape, (n_states)))
 
     if np.any(transition < 0) or not np.allclose(transition.sum(axis=-1), 1):

--- a/librosa/sequence.py
+++ b/librosa/sequence.py
@@ -102,8 +102,8 @@ def dtw(X=None, Y=None, C=None, metric='euclidean', step_sizes_sigma=None,
         ``int(radius*min(C.shape))``.
 
     return_D_steps : bool
-        If true, the functions returns ``D_steps``, the step matrix,
-        containg the indices of the used steps from the cost accumulation step.
+        If true, the function returns ``D_steps``, the step matrix, containing
+        the indices of the used steps from the cost accumulation step.
 
     Returns
     -------
@@ -118,7 +118,7 @@ def dtw(X=None, Y=None, C=None, metric='euclidean', step_sizes_sigma=None,
         Only returned when ``backtrack`` is True.
 
     D_steps : np.ndarray [shape=(N,M)]
-        Step matrix, containg the indices of the used steps from the cost
+        Step matrix, containing the indices of the used steps from the cost
         accumulation step.
         Only returned when ``return_D_steps`` is True.
 
@@ -332,7 +332,7 @@ def __dtw_calc_accu_cost(C, D, D_steps, step_sizes_sigma,
         accumulated cost matrix
 
     D_steps : np.ndarray [shape=(N, M)]
-        Step matrix, containg the indices of the used steps from the cost
+        Step matrix, containing the indices of the used steps from the cost
         accumulation step.
 
     step_sizes_sigma : np.ndarray [shape=[n, 2]]
@@ -358,7 +358,7 @@ def __dtw_calc_accu_cost(C, D, D_steps, step_sizes_sigma,
         When doing subsequence DTW, D[N,:] indicates a matching function.
 
     D_steps : np.ndarray [shape=(N,M)]
-        Step matrix, containg the indices of the used steps from the cost
+        Step matrix, containing the indices of the used steps from the cost
         accumulation step.
 
     See Also
@@ -398,7 +398,7 @@ def __dtw_backtracking(D_steps, step_sizes_sigma, subseq, start=None):  # pragma
     Parameters
     ----------
     D_steps : np.ndarray [shape=(N, M)]
-        Step matrix, containg the indices of the used steps from the cost
+        Step matrix, containing the indices of the used steps from the cost
         accumulation step.
 
     step_sizes_sigma : np.ndarray [shape=[n, 2]]
@@ -462,7 +462,7 @@ def dtw_backtracking(D_steps, step_sizes_sigma=None, subseq=False, start=None):
     Parameters
     ----------
     D_steps : np.ndarray [shape=(N, M)]
-        Step matrix, containg the indices of the used steps from the cost
+        Step matrix, containing the indices of the used steps from the cost
         accumulation step.
 
     step_sizes_sigma : np.ndarray [shape=[n, 2]]

--- a/librosa/sequence.py
+++ b/librosa/sequence.py
@@ -307,8 +307,10 @@ def dtw(X=None, Y=None, C=None, metric='euclidean', step_sizes_sigma=None,
     if return_D_steps:
         return_values.append(D_steps)
 
-    return tuple(return_values)
-
+    if len(return_values) > 1:
+        return tuple(return_values)
+    else:
+        return return_values[0]
 
 
 


### PR DESCRIPTION
I want to propose a new feature for DTW, which is helpful for subsequence DTW. Currently, only the optimal warping path is returned by the DTW function. However, it can also be useful to compute more than one path. For example, in the case of audio matching, one may be interested in multiple matching subsequences. For that purpose, one has to perform backtracking not only from the global minimum of the matching function but from several local minima.

To achieve the feature, ...
* ... the `dtw` function now has an optional keyword `return_D_steps` for returning the step size matrix.
* ... I wrote a function `dtw_backtracking` that is a wrapper for `__dtw_backtracking` to handle the step sizes.
* ... the `__dtw_backtracking` function now gets an argument `start_m`, which is the start position for backtracking.

The following code example illustrates the new feature:
```python
import numpy as np
import librosa
from matplotlib import pyplot as plt
from scipy.spatial.distance import cdist

dim = 24
X_len = 10

X = np.random.random((dim, X_len))
Y = np.random.random((dim, 100))

Y[:, 10:10+X_len] = X
Y[:, 80:80+X_len] = X

C = cdist(X.T, Y.T, metric='cosine')
D, D_steps = librosa.sequence.dtw(C=C, backtrack=False, subseq=True, return_D_steps=True)

matching_curve = D[-1, :]
idx_sort = np.argsort(matching_curve)

wp1 = librosa.sequence.dtw_backtracking(D_steps, subseq=True, start_m=idx_sort[0])
wp2 = librosa.sequence.dtw_backtracking(D_steps, subseq=True, start_m=idx_sort[1])

plt.figure(figsize=(10, 4))
plt.imshow(C, aspect='auto', origin='lower', cmap='gray')
plt.ylabel('Sequence X')
plt.xlabel('Sequence Y')
plt.plot(wp1[:, 1], wp1[:, 0], 'r:o', label='Warping Path 1')
plt.plot(wp2[:, 1], wp2[:, 0], 'b:o', label='Warping Path 2')
plt.legend()
plt.colorbar()
```
![dtw](https://user-images.githubusercontent.com/5499717/84768169-13e62980-afd4-11ea-9393-935139198d8f.png)
