### PR TITLE
[CR] Dtype inference and control in CQT

### DIFF
--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -954,7 +954,7 @@ def __trim_stack(cqt_resp, n_bins, dtype):
     # Copy per-octave data into output array
     n = 0
     for c_i in cqt_resp[::-1]:
-        cqt_out[n:min(n + c_i.shape[0], n_bins)] = c_i[:min(c_i.shape[0], n_bins - n)]
+        cqt_out[n:min(n + c_i.shape[0], n_bins)] = c_i[:min(c_i.shape[0], n_bins - n), :max_col]
         n += c_i.shape[0]
 
     return cqt_out

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -330,7 +330,8 @@ def hybrid_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
                                    res_type=res_type,
                                    dtype=dtype)))
 
-    return __trim_stack(cqt_resp, n_bins, dtype)
+    # Propagate dtype from the last component
+    return __trim_stack(cqt_resp, n_bins, cqt_resp[-1].dtype)
 
 
 @cache(level=20)
@@ -948,8 +949,8 @@ def __cqt_filter_fft(sr, fmin, n_bins, bins_per_octave,
 def __trim_stack(cqt_resp, n_bins, dtype):
     '''Helper function to trim and stack a collection of CQT responses'''
 
-    max_col = min(x.shape[1] for x in cqt_resp)
-    cqt_out = np.zeros((n_bins, max_col), dtype=dtype, order='F')
+    max_col = min(c_i.shape[-1] for c_i in cqt_resp)
+    cqt_out = np.empty((n_bins, max_col), dtype=dtype, order='F')
 
     # Copy per-octave data into output array
     n = 0

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -953,10 +953,17 @@ def __trim_stack(cqt_resp, n_bins, dtype):
     cqt_out = np.empty((n_bins, max_col), dtype=dtype, order='F')
 
     # Copy per-octave data into output array
-    n = 0
-    for c_i in cqt_resp[::-1]:
-        cqt_out[n:min(n + c_i.shape[0], n_bins)] = c_i[:min(c_i.shape[0], n_bins - n), :max_col]
-        n += c_i.shape[0]
+    end = n_bins
+    for c_i in cqt_resp:
+        # By default, take the whole octave
+        n_oct = c_i.shape[0]
+        # If the whole octave is more than we can fit,
+        # take the highest bins from c_i
+        if end < n_oct:
+            n_oct = n_oct - end
+
+        cqt_out[end - n_oct:end] = c_i[-n_oct:, :max_col]
+        end -= n_oct
 
     return cqt_out
 

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -960,9 +960,10 @@ def __trim_stack(cqt_resp, n_bins, dtype):
         # If the whole octave is more than we can fit,
         # take the highest bins from c_i
         if end < n_oct:
-            n_oct = n_oct - end
+            cqt_out[:end] = c_i[-end:, :max_col]
+        else:
+            cqt_out[end - n_oct:end] = c_i[:, :max_col]
 
-        cqt_out[end - n_oct:end] = c_i[-n_oct:, :max_col]
         end -= n_oct
 
     return cqt_out

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -27,7 +27,7 @@ __all__ = ['cqt', 'hybrid_cqt', 'pseudo_cqt',
 def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
         bins_per_octave=12, tuning=0.0, filter_scale=1,
         norm=1, sparsity=0.01, window='hann',
-        scale=True, pad_mode='reflect', res_type=None):
+        scale=True, pad_mode='reflect', res_type=None, dtype=None):
     '''Compute the constant-Q transform of an audio signal.
 
     This implementation is based on the recursive sub-sampling method
@@ -106,9 +106,13 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
         but potentially slow FFT-based down-sampling, while `res_type='polyphase'` will
         use a fast, but potentially inaccurate down-sampling.
 
+    dtype : np.dtype
+        The (complex) data type of the output array.  By default, this is inferred to match
+        the numerical precision of the input signal.
+
     Returns
     -------
-    CQT : np.ndarray [shape=(n_bins, t), dtype=np.complex or np.float]
+    CQT : np.ndarray [shape=(n_bins, t)]
         Constant-Q value each frequency at each time.
 
     Raises
@@ -173,14 +177,14 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
                bins_per_octave=bins_per_octave,
                tuning=tuning, filter_scale=filter_scale,
                norm=norm, sparsity=sparsity, window=window, scale=scale,
-               pad_mode=pad_mode, res_type=res_type)
+               pad_mode=pad_mode, res_type=res_type, dtype=dtype)
 
 
 @cache(level=20)
 def hybrid_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
                bins_per_octave=12, tuning=0.0, filter_scale=1,
                norm=1, sparsity=0.01, window='hann', scale=True,
-               pad_mode='reflect', res_type=None):
+               pad_mode='reflect', res_type=None, dtype=None):
     '''Compute the hybrid constant-Q transform of an audio signal.
 
     Here, the hybrid CQT uses the pseudo CQT for higher frequencies where
@@ -235,6 +239,11 @@ def hybrid_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
 
     res_type : string
         Resampling mode.  See `librosa.core.cqt` for details.
+
+    dtype : np.dtype, optional
+        The complex dtype to use for computing the CQT.
+        By default, this is inferred to match the precision of
+        the input signal.
 
     Returns
     -------
@@ -303,7 +312,8 @@ def hybrid_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
                                    sparsity=sparsity,
                                    window=window,
                                    scale=scale,
-                                   pad_mode=pad_mode))
+                                   pad_mode=pad_mode,
+                                   dtype=dtype))
 
     if n_bins_full > 0:
         cqt_resp.append(np.abs(cqt(y, sr,
@@ -317,16 +327,17 @@ def hybrid_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
                                    window=window,
                                    scale=scale,
                                    pad_mode=pad_mode,
-                                   res_type=res_type)))
+                                   res_type=res_type,
+                                   dtype=dtype)))
 
-    return __trim_stack(cqt_resp, n_bins)
+    return __trim_stack(cqt_resp, n_bins, dtype=dtype)
 
 
 @cache(level=20)
 def pseudo_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
                bins_per_octave=12, tuning=0.0, filter_scale=1,
                norm=1, sparsity=0.01, window='hann', scale=True,
-               pad_mode='reflect'):
+               pad_mode='reflect', dtype=None):
     '''Compute the pseudo constant-Q transform of an audio signal.
 
     This uses a single fft size that is the smallest power of 2 that is greater
@@ -381,6 +392,10 @@ def pseudo_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
 
         See also: `librosa.core.stft` and `np.pad`.
 
+    dtype : np.dtype, optional
+        The complex data type for CQT calculations.  
+        By default, this is inferred to match the precision of the input signal.
+
     Returns
     -------
     CQT : np.ndarray [shape=(n_bins, t), dtype=np.float]
@@ -407,6 +422,9 @@ def pseudo_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
     if tuning is None:
         tuning = estimate_tuning(y=y, sr=sr, bins_per_octave=bins_per_octave)
 
+    if dtype is None:
+        dtype = util.dtype_r2c(y.dtype)
+
     # Apply tuning correction
     fmin = fmin * 2.0**(tuning / bins_per_octave)
 
@@ -415,12 +433,13 @@ def pseudo_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
                                            filter_scale,
                                            norm, sparsity,
                                            hop_length=hop_length,
-                                           window=window)
+                                           window=window,
+                                           dtype=dtype)
 
     fft_basis = np.abs(fft_basis)
 
     # Compute the magnitude STFT with Hann window
-    D = np.abs(stft(y, n_fft=n_fft, hop_length=hop_length, pad_mode=pad_mode))
+    D = np.abs(stft(y, n_fft=n_fft, hop_length=hop_length, pad_mode=pad_mode, dtype=dtype))
 
     # Project onto the pseudo-cqt basis
     C = fft_basis.dot(D)
@@ -442,7 +461,7 @@ def pseudo_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
 @cache(level=40)
 def icqt(C, sr=22050, hop_length=512, fmin=None, bins_per_octave=12,
          tuning=0.0, filter_scale=1, norm=1, sparsity=0.01, window='hann',
-         scale=True, length=None, res_type='fft', dtype=np.float32):
+         scale=True, length=None, res_type='fft', dtype=None):
     '''Compute the inverse constant-Q transform.
 
     Given a constant-Q transform representation `C` of an audio signal `y`,
@@ -501,7 +520,8 @@ def icqt(C, sr=22050, hop_length=512, fmin=None, bins_per_octave=12,
         See `librosa.resample` for supported modes.
 
     dtype : numeric type
-        Real numeric type for `y`.  Default is 32-bit float.
+        Real numeric type for `y`.  Default is inferred to match the numerical
+        precision of the input CQT.
 
     Returns
     -------
@@ -620,7 +640,7 @@ def icqt(C, sr=22050, hop_length=512, fmin=None, bins_per_octave=12,
 def vqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84, gamma=None,
         bins_per_octave=12, tuning=0.0, filter_scale=1,
         norm=1, sparsity=0.01, window='hann',
-        scale=True, pad_mode='reflect', res_type=None):
+        scale=True, pad_mode='reflect', res_type=None, dtype=None):
     '''Compute the variable-Q transform of an audio signal.
 
     This implementation is based on the recursive sub-sampling method
@@ -717,6 +737,10 @@ def vqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84, gamma=None,
         but potentially slow FFT-based down-sampling, while `res_type='polyphase'` will
         use a fast, but potentially inaccurate down-sampling.
 
+    dtype : np.dtype
+        The dtype of the output array.  By default, this is inferred to match the
+        numerical precision of the input signal.
+
     Returns
     -------
     VQT : np.ndarray [shape=(n_bins, t), dtype=np.complex or np.float]
@@ -772,6 +796,9 @@ def vqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84, gamma=None,
     if gamma is None:
         gamma = 24.7 * alpha / 0.108
 
+    if dtype is None:
+        dtype = util.dtype_r2c(y.dtype)
+
     # Apply tuning correction
     fmin = fmin * 2.0**(tuning / bins_per_octave)
 
@@ -813,10 +840,11 @@ def vqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84, gamma=None,
                                                norm,
                                                sparsity,
                                                window=window,
-                                               gamma=gamma)
+                                               gamma=gamma,
+                                               dtype=dtype)
 
         # Compute the VQT filter response and append it to the stack
-        vqt_resp.append(__cqt_response(y, n_fft, hop_length, fft_basis, pad_mode))
+        vqt_resp.append(__cqt_response(y, n_fft, hop_length, fft_basis, pad_mode, dtype=dtype))
 
         fmin_t /= 2
         fmax_t /= 2
@@ -842,8 +870,7 @@ def vqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84, gamma=None,
         if i > 0:
             if len(my_y) < 2:
                 raise ParameterError('Input signal length={} is too short for '
-                                     '{:d}-octave CQT/VQT'.format(len_orig,
-                                                              n_octaves))
+                                     '{:d}-octave CQT/VQT'.format(len_orig, n_octaves))
 
             my_y = audio.resample(my_y, 2, 1,
                                   res_type=res_type,
@@ -859,14 +886,15 @@ def vqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84, gamma=None,
                                                norm,
                                                sparsity,
                                                window=window,
-                                               gamma=gamma)
+                                               gamma=gamma,
+                                               dtype=dtype)
         # Re-scale the filters to compensate for downsampling
         fft_basis[:] *= np.sqrt(2**i)
 
         # Compute the vqt filter response and append to the stack
-        vqt_resp.append(__cqt_response(my_y, n_fft, my_hop, fft_basis, pad_mode))
+        vqt_resp.append(__cqt_response(my_y, n_fft, my_hop, fft_basis, pad_mode, dtype=dtype))
 
-    V = __trim_stack(vqt_resp, n_bins)
+    V = __trim_stack(vqt_resp, n_bins, dtype=dtype)
 
     if scale:
         lengths = filters.constant_q_lengths(sr, fmin,
@@ -883,7 +911,7 @@ def vqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84, gamma=None,
 @cache(level=10)
 def __cqt_filter_fft(sr, fmin, n_bins, bins_per_octave,
                      filter_scale, norm, sparsity, hop_length=None,
-                     window='hann', gamma=0.):
+                     window='hann', gamma=0., dtype=np.complex):
     '''Generate the frequency domain constant-Q filter basis.'''
 
     basis, lengths = filters.constant_q(sr,
@@ -912,12 +940,12 @@ def __cqt_filter_fft(sr, fmin, n_bins, bins_per_octave,
     fft_basis = fft.fft(basis, n=n_fft, axis=1)[:, :(n_fft // 2)+1]
 
     # sparsify the basis
-    fft_basis = util.sparsify_rows(fft_basis, quantile=sparsity)
+    fft_basis = util.sparsify_rows(fft_basis, quantile=sparsity, dtype=dtype)
 
     return fft_basis, n_fft, lengths
 
 
-def __trim_stack(cqt_resp, n_bins):
+def __trim_stack(cqt_resp, n_bins, dtype=None):
     '''Helper function to trim and stack a collection of CQT responses'''
 
     # cleanup any framing errors at the boundaries
@@ -930,13 +958,14 @@ def __trim_stack(cqt_resp, n_bins):
     return np.asfortranarray(cqt_resp[-n_bins:])
 
 
-def __cqt_response(y, n_fft, hop_length, fft_basis, mode):
+def __cqt_response(y, n_fft, hop_length, fft_basis, mode, dtype=None):
     '''Compute the filter response with a target STFT hop.'''
 
     # Compute the STFT matrix
     D = stft(y, n_fft=n_fft, hop_length=hop_length,
              window='ones',
-             pad_mode=mode)
+             pad_mode=mode,
+             dtype=dtype)
 
     # And filter response energy
     return fft_basis.dot(D)
@@ -1003,7 +1032,7 @@ def __num_two_factors(x):
 
 def griffinlim_cqt(C, n_iter=32, sr=22050, hop_length=512, fmin=None, bins_per_octave=12, tuning=0.0,
                    filter_scale=1, norm=1, sparsity=0.01, window='hann', scale=True,
-                   pad_mode='reflect', res_type='kaiser_fast', dtype=np.float32,
+                   pad_mode='reflect', res_type='kaiser_fast', dtype=None,
                    length=None, momentum=0.99, init='random', random_state=None):
     '''Approximate constant-Q magnitude spectrogram inversion using the "fast" Griffin-Lim
     algorithm [1]_ [2]_.
@@ -1091,7 +1120,8 @@ def griffinlim_cqt(C, n_iter=32, sr=22050, hop_length=512, fmin=None, bins_per_o
         See `librosa.core.resample` for a list of available options.
 
     dtype : numeric type
-        Real numeric type for `y`.  Default is 32-bit float.
+        Real numeric type for `y`.  Default is inferred to match the precision
+        of the input CQT.
 
     length : int > 0, optional
         If provided, the output `y` is zero-padded or clipped to exactly
@@ -1207,7 +1237,7 @@ def griffinlim_cqt(C, n_iter=32, sr=22050, hop_length=512, fmin=None, bins_per_o
         # Rebuild the spectrogram
         rebuilt = cqt(inverse, sr=sr, bins_per_octave=bins_per_octave, n_bins=C.shape[0],
                       hop_length=hop_length, fmin=fmin, tuning=tuning, filter_scale=filter_scale,
-                      window=window, res_type=res_type)
+                      window=window, res_type=res_type, dtype=C.dtype)
 
         # Update our phase estimates
         angles[:] = rebuilt - (momentum / (1 + momentum)) * tprev

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -954,7 +954,7 @@ def __trim_stack(cqt_resp, n_bins, dtype):
     # Copy per-octave data into output array
     n = 0
     for c_i in cqt_resp[::-1]:
-        cqt_out[n:min(n + c_i.shape[0], n_bins)] = c_i
+        cqt_out[n:min(n + c_i.shape[0], n_bins)] = c_i[:min(c_i.shape[0], n_bins - n)]
         n += c_i.shape[0]
 
     return cqt_out

--- a/librosa/util/__init__.py
+++ b/librosa/util/__init__.py
@@ -43,6 +43,8 @@ Miscellaneous
     peak_pick
     nnls
     cyclic_gradient
+    dtype_c2r
+    dtype_r2c
 
 
 Input validation

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -30,7 +30,9 @@ __all__ = ['MAX_MEM_BLOCK',
            'softmask',
            'buf_to_float',
            'tiny',
-           'cyclic_gradient']
+           'cyclic_gradient',
+           'dtype_r2c',
+           'dtype_c2r']
 
 
 def frame(x, frame_length, hop_length, axis=-1):
@@ -1956,3 +1958,118 @@ def stack(arrays, axis=0):
         np.stack(arrays, axis=axis, out=result)
 
         return result
+
+
+def dtype_r2c(d, default=np.complex64):
+    '''Find the complex numpy dtype corresponding to a real dtype.
+
+    This is used to maintain numerical precision and memory footprint
+    when constructing complex arrays from real-valued data
+    (e.g. in a Fourier transform).
+
+    A `float32` (single-precision) type maps to `complex64`,
+    while a `float64` (double-precision) maps to `complex128`.
+
+
+    Parameters
+    ----------
+    d : np.dtype
+        The real-valued dtype to convert to complex.
+        If `d` is a complex type already, it will be returned.
+
+    default : np.dtype, optional
+        The default complex target type, if `d` does not match a
+        known dtype
+
+    Returns
+    -------
+    d_c : np.dtype
+        The complex dtype
+
+    See Also
+    --------
+    dtype_c2r
+    np.dtype
+
+    Examples
+    --------
+    >>> librosa.util.dtype_r2c(np.float32)
+    dtype('complex64')
+
+    >>> librosa.util.dtype_r2c(np.int16)
+    dtype('complex64')
+
+    >>> librosa.util.dtype_r2c(np.complex128)
+    dtype('complex128')
+    '''
+    mapping = {np.dtype(np.float32): np.complex64,
+               np.dtype(np.float64): np.complex128,
+               np.dtype(np.float): np.complex}
+
+    # If we're given a complex type already, return it
+    dt = np.dtype(d)
+    if dt.kind == 'c':
+        return dt
+
+    # Otherwise, try to map the dtype.
+    # If no match is found, return the default.
+    return np.dtype(mapping.get(dt, default))
+
+
+def dtype_c2r(d, default=np.float32):
+    '''Find the real numpy dtype corresponding to a complex dtype.
+
+    This is used to maintain numerical precision and memory footprint
+    when constructing real arrays from complex-valued data
+    (e.g. in an inverse Fourier transform).
+
+    A `complex64` (single-precision) type maps to `float32`,
+    while a `complex128` (double-precision) maps to `float64`.
+
+
+    Parameters
+    ----------
+    d : np.dtype
+        The complex-valued dtype to convert to real.
+        If `d` is a real (float) type already, it will be returned.
+
+    default : np.dtype, optional
+        The default real target type, if `d` does not match a
+        known dtype
+
+    Returns
+    -------
+    d_r : np.dtype
+        The real dtype
+
+    See Also
+    --------
+    dtype_r2c
+    np.dtype
+
+    Examples
+    --------
+    >>> librosa.util.dtype_r2c(np.complex64)
+    dtype('float32')
+
+    >>> librosa.util.dtype_r2c(np.float32)
+    dtype('float32')
+
+    >>> librosa.util.dtype_r2c(np.int16)
+    dtype('float32')
+
+    >>> librosa.util.dtype_r2c(np.complex128)
+    dtype('float64')
+    '''
+    mapping = {np.dtype(np.complex64): np.float32,
+               np.dtype(np.complex128): np.float64,
+               np.dtype(np.complex): np.float}
+
+    # If we're given a real type already, return it
+    dt = np.dtype(d)
+    if dt.kind == 'f':
+        return dt
+
+    # Otherwise, try to map the dtype.
+    # If no match is found, return the default.
+    return np.dtype(mapping.get(np.dtype(d), default))

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -1121,7 +1121,7 @@ def peak_pick(x, pre_max, post_max, pre_avg, post_avg, delta, wait):
 
 
 @cache(level=40)
-def sparsify_rows(x, quantile=0.01):
+def sparsify_rows(x, quantile=0.01, dtype=None):
     '''
     Return a row-sparse matrix approximating the input `x`.
 
@@ -1132,6 +1132,10 @@ def sparsify_rows(x, quantile=0.01):
 
     quantile : float in [0, 1.0)
         Percentage of magnitude to discard in each row of `x`
+
+    dtype : np.dtype, optional
+        The dtype of the output array.
+        If not provided, then `x.dtype` will be used.
 
     Returns
     -------
@@ -1196,7 +1200,10 @@ def sparsify_rows(x, quantile=0.01):
     if not 0.0 <= quantile < 1:
         raise ParameterError('Invalid quantile {:.2f}'.format(quantile))
 
-    x_sparse = scipy.sparse.lil_matrix(x.shape, dtype=x.dtype)
+    if dtype is None:
+        dtype = x.dtype
+
+    x_sparse = scipy.sparse.lil_matrix(x.shape, dtype=dtype)
 
     mags = np.abs(x)
     norms = np.sum(mags, axis=1, keepdims=True)

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -69,7 +69,7 @@ def sr_cqt():
 
 @pytest.fixture(scope="module")
 def y_cqt(sr_cqt):
-    return make_signal(sr_cqt, 5.0)
+    return make_signal(sr_cqt, 2.0)
 
 
 @pytest.mark.xfail(raises=librosa.ParameterError)
@@ -313,7 +313,7 @@ def sr_white():
 @pytest.fixture(scope="module")
 def y_white(sr_white):
     srand()
-    return np.random.randn(30 * sr_white)
+    return np.random.randn(10 * sr_white)
 
 
 @pytest.mark.parametrize("scale", [False, True])

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -520,3 +520,9 @@ def test_griffinlim_cqt_momentum_warn():
     x = np.zeros((33, 3))
     with pytest.warns(UserWarning):
         librosa.griffinlim_cqt(x, momentum=2)
+
+
+@pytest.mark.parametrize('dtype', [np.complex64, np.complex128])
+def test_cqt_precision(y_cqt, sr_cqt, dtype):
+    C = librosa.cqt(y=y_cqt, sr=sr_cqt, dtype=dtype)
+    assert np.dtype(C.dtype) == np.dtype(dtype)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1140,3 +1140,18 @@ def test_example_info(key):
 
 def test_list_examples():
     librosa.util.list_examples()
+
+
+@pytest.mark.parametrize('dtype,target', [(np.float32, np.complex64), (np.float64, np.complex128), (np.int32, np.complex64), (np.complex128, np.complex128)])
+def test_dtype_r2c(dtype, target):
+    inf_type = librosa.util.dtype_r2c(dtype)
+
+    # better to do a bidirectional subtype test than strict equality here
+    assert np.issubdtype(inf_type, target) and np.issubdtype(target, inf_type)
+
+@pytest.mark.parametrize('dtype,target', [(np.float32, np.float32), (np.complex64, np.float32), (np.int32, np.float32), (np.complex128, np.float64)])
+def test_dtype_c2r(dtype, target):
+    inf_type = librosa.util.dtype_c2r(dtype)
+
+    # better to do a bidirectional subtype test than strict equality here
+    assert np.issubdtype(inf_type, target) and np.issubdtype(target, inf_type)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -525,6 +525,18 @@ def test_sparsify_rows_badquantile(X, quantile):
     librosa.util.sparsify_rows(X, quantile=quantile)
 
 
+@pytest.mark.parametrize('dtype', [None, np.float32, np.float64])
+@pytest.mark.parametrize('ref_dtype', [np.float32, np.float64])
+def test_sparsify_rows_dtype(dtype, ref_dtype):
+    x = np.ones(10, dtype=ref_dtype)
+    xs = librosa.util.sparsify_rows(x, dtype=dtype)
+
+    if dtype is None:
+        assert xs.dtype == x.dtype
+    else:
+        assert xs.dtype == dtype
+
+
 @pytest.mark.parametrize("ndim", [1, 2])
 @pytest.mark.parametrize("d", [1, 5, 10, 100])
 @pytest.mark.parametrize("q", [0.0, 0.01, 0.25, 0.5, 0.99])


### PR DESCRIPTION
#### Reference Issue
- Fixes #1143 
- Fixes #1144 
- Addresses #1074 


#### What does this implement/fix? Explain your changes.

This PR addresses dtype control in spectrogram calculations in a few steps:

1. Helper functions are added to `util` to infer minimal dtypes when converting between real and complex
2. `sparsify_rows` API has expanded to allow explicit dtype control (this supports CQT basis construction)
3. all CQT-related methods now have a `dtype=` parameter
4. all STFT-related methods (including GL) do automatic dtype inference

#### Any other comments?

Committing this now to get the CI on the way.

As mentioned in #1144, I'd also like to revamp the `__trim_stack` helper in cqt to be more memory efficient.  Rolling that into this PR because this is broadly concerned with memory efficiency and copying.
