### PR TITLE
Only use initialized memory in tests

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -203,7 +203,7 @@ def test_resample_scale(resample_mono, res_type, sr_out):
 @pytest.mark.parametrize("sr_in, sr_out", [(100, 100.1), (100.1, 100)])
 @pytest.mark.xfail(raises=librosa.ParameterError)
 def test_resample_poly_float(sr_in, sr_out):
-    y = np.empty(128)
+    y = np.zeros(128)
     librosa.resample(y, sr_in, sr_out, res_type="polyphase")
 
 
@@ -240,7 +240,7 @@ def test_stft(infile):
 
 def test_stft_winsizes():
     # Test for issue #1095
-    x = np.empty(1000000)
+    x = np.zeros(1000000)
 
     for power in range(12, 17):
         N = 2 ** power
@@ -643,7 +643,7 @@ def test_get_duration_buffer(sr, dur):
 @pytest.mark.parametrize("n_fft", [512, 2048])
 @pytest.mark.parametrize("hop_length", [256, 512])
 def test_get_duration_specgram(sr, dur, n_fft, hop_length, center):
-    z = np.empty(int(sr * dur))
+    z = np.zeros(int(sr * dur))
     S = librosa.util.frame(z, frame_length=(n_fft // 2 + 1), hop_length=hop_length)
 
     dur_est = librosa.get_duration(S=S, sr=sr, n_fft=n_fft, hop_length=hop_length, center=center)

--- a/tests/test_decompose.py
+++ b/tests/test_decompose.py
@@ -192,7 +192,7 @@ def test_nn_filter_avg():
 @pytest.mark.xfail(raises=librosa.ParameterError)
 @pytest.mark.parametrize("x,y", [(10, 10), (100, 20), (20, 100), (100, 101), (101, 101)])
 @pytest.mark.parametrize("sparse", [False, True])
-@pytest.mark.parametrize("data", [np.empty((10, 100))])
+@pytest.mark.parametrize("data", [np.zeros((10, 100))])
 def test_nn_filter_badselfsim(data, x, y, sparse):
 
     srand()

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -339,7 +339,7 @@ def test_rms_noinput():
 
 @pytest.mark.xfail(raises=librosa.ParameterError)
 def test_rms_badshape():
-    S = np.empty((100, 3))
+    S = np.zeros((100, 3))
     librosa.feature.rms(S=S, frame_length=100)
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -335,8 +335,8 @@ def test_axis_sort(ndim, axis, index, value):
 @pytest.mark.parametrize(
     "int_from, int_to",
     [
-        (np.asarray([[0, 2], [0, 4], [3, 6]]), np.empty((0, 2), dtype=int)),
-        (np.empty((0, 2), dtype=int), np.asarray([[0, 2], [0, 4], [3, 6]])),
+        (np.asarray([[0, 2], [0, 4], [3, 6]]), np.zeros((0, 2), dtype=int)),
+        (np.zeros((0, 2), dtype=int), np.asarray([[0, 2], [0, 4], [3, 6]])),
     ],
 )
 @pytest.mark.xfail(raises=librosa.ParameterError)


### PR DESCRIPTION
#### Reference Issue
Fixes #951 


#### What does this implement/fix? Explain your changes.

Replace all calls to `np.empty` in the test suite by `np.zeros`.  This should eliminate the heisenbugs we occasionally see where audio buffers fail validation.

#### Any other comments?

No CR needed on this, I think.  If CI passes, I'll merge.
