### PR TITLE
specshow returns quadmesh

### DIFF
--- a/librosa/display.py
+++ b/librosa/display.py
@@ -630,8 +630,8 @@ def specshow(data, x_coords=None, y_coords=None,
 
     Returns
     -------
-    axes
-        The axis handle for the figure.
+    colormesh : `matplotlib.collections.QuadMesh`
+        The color mesh object produced by `matplotlib.pyplot.pcolormesh`
 
 
     See Also
@@ -773,7 +773,7 @@ def specshow(data, x_coords=None, y_coords=None,
     __decorate_axis(axes.xaxis, x_axis, key=key)
     __decorate_axis(axes.yaxis, y_axis, key=key)
 
-    return axes
+    return out
 
 
 def __set_current_image(ax, img):


### PR DESCRIPTION
#### Reference Issue
Fixes #1180 


#### What does this implement/fix? Explain your changes.
This PR changes `specshow` to return the constructed QuadMesh obejct rather than the axes handle.

As detailed in #1180, this makes it easier to work with things like `colorbar` in matplotlib's object API.



