### PR TITLE
cmap returns binary colormaps for boolean data

### DIFF
--- a/librosa/display.py
+++ b/librosa/display.py
@@ -340,7 +340,7 @@ def cmap(data, robust=True, cmap_seq='magma', cmap_bool='gray_r', cmap_div='cool
     data = np.atleast_1d(data)
 
     if data.dtype == 'bool':
-        return get_cmap(cmap_bool)
+        return get_cmap(cmap_bool, lut=2)
 
     data = data[np.isfinite(data)]
 
@@ -349,8 +349,7 @@ def cmap(data, robust=True, cmap_seq='magma', cmap_bool='gray_r', cmap_div='cool
     else:
         min_p, max_p = 0, 100
 
-    max_val = np.percentile(data, max_p)
-    min_val = np.percentile(data, min_p)
+    min_val, max_val = np.percentile(data, [min_p, max_p])
 
     if min_val >= 0 or max_val <= 0:
         return get_cmap(cmap_seq)


### PR DESCRIPTION
#### Reference Issue
Fixes #1185 


#### What does this implement/fix? Explain your changes.
This PR sets `lut=2` for getting the colormap of boolean data.

#### Any other comments?

The result of this can be seen with the following code snippet:
```python
import matplotlib.pyplot as plt
import librosa
import librosa.display
y, sr = librosa.load(librosa.ex('trumpet'))
c = librosa.feature.chroma_cqt(y=y, sr=sr)
R = librosa.segment.recurrence_matrix(c)
librosa.display.specshow(R)
plt.colorbar()
plt.show()
```
Before this change, produces:
![image](https://user-images.githubusercontent.com/1190540/85788468-067b1e80-b6fb-11ea-8680-a0d0330e9b21.png)

with the proposed change, produces:
![image](https://user-images.githubusercontent.com/1190540/85788433-f4997b80-b6fa-11ea-98a9-f334be6f888c.png)

(in both cases, the colorbar ticks are out of control of cmap, and not affected by this PR).

As an aside, I also merged the quantile checks here, so the function should be ~2x as fast on non-binary data.

