### PR TITLE
Correct dtype usage in griffinlim_cqt

### DIFF
--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -1248,7 +1248,7 @@ def griffinlim_cqt(C, n_iter=32, sr=22050, hop_length=512, fmin=None, bins_per_o
         # Rebuild the spectrogram
         rebuilt = cqt(inverse, sr=sr, bins_per_octave=bins_per_octave, n_bins=C.shape[0],
                       hop_length=hop_length, fmin=fmin, tuning=tuning, filter_scale=filter_scale,
-                      window=window, res_type=res_type, dtype=C.dtype)
+                      window=window, res_type=res_type)
 
         # Update our phase estimates
         angles[:] = rebuilt - (momentum / (1 + momentum)) * tprev


### PR DESCRIPTION
#### Reference Issue
fixes #1189 


#### What does this implement/fix? Explain your changes.
This PR fixes a regression introduced by #1171 .  We had accidentally propagated the original `C.dtype` (which is real/float-valued) to the forward call to cqt.

Removing this parameter so that dtype is inferred produces the correct behavior.

#### Any other comments?

No CR needed here, will merge when CI passes.
