### PR TITLE
updated default bpo for cens

### DIFF
--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -1331,7 +1331,7 @@ def chroma_cqt(y=None, sr=22050, C=None, hop_length=512, fmin=None,
 
 def chroma_cens(y=None, sr=22050, C=None, hop_length=512, fmin=None,
                 tuning=None, n_chroma=12,
-                n_octaves=7, bins_per_octave=None, cqt_mode='full', window=None,
+                n_octaves=7, bins_per_octave=36, cqt_mode='full', window=None,
                 norm=2, win_len_smooth=41, smoothing_window='hann'):
     r'''Computes the chroma variant "Chroma Energy Normalized" (CENS), following [1]_.
 


### PR DESCRIPTION
#### Reference Issue
Fixes #1191 
Fixes #1170 

#### What does this implement/fix? Explain your changes.

This PR changes the default bins-per-octave for CENS to match chroma_cqt, following #1170 

#### Any other comments?

The documentation has not been updated here, to avoid conflicts with WIP #1178 .

No CR needed, will merge once CI passes.  After that, I'll rebase #1178 and finish the documentation update.
