### PR TITLE
Fix padding for IIRT

### DIFF
--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1321,7 +1321,7 @@ def iirt(y, sr=22050, win_length=2048, hop_length=None, center=True,
 
     # Pad the time series so that frames are centered
     if center:
-        y = np.pad(y, int(hop_length), mode=pad_mode)
+        y = np.pad(y, int(win_length // 2), mode=pad_mode)
 
     # get the semitone filterbank
     filterbank_ct, sample_rates = semitone_filterbank(tuning=tuning, flayout=flayout, **kwargs)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1387,6 +1387,20 @@ def test_iirt_peaks():
         assert all(abs(cur_peak_times - click_times) < (2 * win_length / Fs))
 
 
+def test_iirt_padding():
+    Fs = 22050
+    x = np.zeros(Fs)
+    H = 512
+    num_frames = np.empty(5)
+
+    for i in range(1, 6):
+        N = i * H
+        X = librosa.iirt(x, sr=Fs, hop_length=H, win_length=N, center=True)
+        num_frames[i-1] = X.shape[1]
+
+    assert np.all(num_frames == num_frames[0])
+
+
 @pytest.fixture(scope="module")
 def S_pcen():
     return np.abs(np.random.randn(9, 30))


### PR DESCRIPTION
Again a small fix for IIRT. In the current version, the padding (for `center=True`) is not done properly. This PR fixes this issue.

The following code example illustrates the issue by comparing the STFT and IIRT output for increasing window sizes. For STFT, the number of frames is always the same. Without this PR, the number of frames varies for IIRT.

```python
import librosa

x, Fs = librosa.load(librosa.util.example_audio_file(), duration=1.0)
H = 512

for i in range(1, 7):
    N = i * H
    X_stft = librosa.stft(x, n_fft=N, hop_length=H, win_length=N, center=True)
    X_iirt = librosa.iirt(x, sr=Fs, hop_length=H, win_length=N, center=True)
    
    print(f'Num frames for STFT: {X_stft.shape[1]}; Num frames for STFT: {X_iirt.shape[1]}')
```

Output before this PR:
```
Num frames for STFT: 44; Num frames for STFT: 45
Num frames for STFT: 44; Num frames for STFT: 44
Num frames for STFT: 44; Num frames for STFT: 43
Num frames for STFT: 44; Num frames for STFT: 42
Num frames for STFT: 44; Num frames for STFT: 41
Num frames for STFT: 44; Num frames for STFT: 40
```

Output with this PR:
```
Num frames for STFT: 44; Num frames for STFT: 44
Num frames for STFT: 44; Num frames for STFT: 44
Num frames for STFT: 44; Num frames for STFT: 44
Num frames for STFT: 44; Num frames for STFT: 44
Num frames for STFT: 44; Num frames for STFT: 44
Num frames for STFT: 44; Num frames for STFT: 44
```
