### PR TITLE
added util.localmin

### DIFF
--- a/librosa/util/__init__.py
+++ b/librosa/util/__init__.py
@@ -40,6 +40,7 @@ Miscellaneous
     :toctree: generated/
 
     localmax
+    localmin
     peak_pick
     nnls
     cyclic_gradient

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -453,6 +453,31 @@ def test_localmax(ndim, axis):
                 assert data[tuple(hits)] >= data[tuple(compare_idx)]
 
 
+@pytest.mark.parametrize("ndim, axis", [(n, m) for n in range(1, 5) for m in range(n)])
+def test_localmin(ndim, axis):
+
+    srand()
+
+    data = np.random.randn(*([7] * ndim))
+    lm = librosa.util.localmin(data, axis=axis)
+
+    for hits in np.argwhere(lm):
+        for offset in [-1, 1]:
+            compare_idx = hits.copy()
+            compare_idx[axis] += offset
+
+            if compare_idx[axis] < 0:
+                continue
+
+            if compare_idx[axis] >= data.shape[axis]:
+                continue
+
+            if offset < 0:
+                assert data[tuple(hits)] < data[tuple(compare_idx)]
+            else:
+                assert data[tuple(hits)] <= data[tuple(compare_idx)]
+
+
 @pytest.mark.parametrize("x", [np.random.randn(_) ** 2 for _ in [1, 5, 10, 100]])
 @pytest.mark.parametrize("pre_max", [0, 1, 10])
 @pytest.mark.parametrize("post_max", [1, 10])


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR adds `util.localmin`, basically the same as `localmax`, but for finding local minima.

This came up in #1063 , where local minima are needed instead of maxima.  While we can use `localmax(-x)` to get local minima, doing so invokes a duplication of the array.  Implementing localmin directly saves us a copy operation.

#### Any other comments?

No CR needed on this one.  Will merge when CI finishes.

At some point, we might want to look into rewriting both of these functions to not rely on padding, but I'll leave that for a separate issue.