### PR TITLE
stft issues with large FFT size

### DIFF
--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -218,18 +218,11 @@ def stft(
 
     # Pad the time series so that frames are centered
     if center:
-        if n_fft > y.shape[-1]:
-            warnings.warn(
-                "n_fft={} is too small for input signal of length={}".format(
-                    n_fft, y.shape[-1]
-                )
-            )
-
         y = np.pad(y, int(n_fft // 2), mode=pad_mode)
 
     elif n_fft > y.shape[-1]:
         raise ParameterError(
-            "n_fft={} is too small for input signal of length={}".format(
+            "n_fft={} is too large for input signal of length={}".format(
                 n_fft, y.shape[-1]
             )
         )

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -218,6 +218,13 @@ def stft(
 
     # Pad the time series so that frames are centered
     if center:
+        if n_fft > y.shape[-1]:
+            warnings.warn(
+                "n_fft={} is too small for input signal of length={}".format(
+                    n_fft, y.shape[-1]
+                )
+            )
+
         y = np.pad(y, int(n_fft // 2), mode=pad_mode)
 
     elif n_fft > y.shape[-1]:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -269,6 +269,12 @@ def test_stft_toolong_left():
     librosa.stft(y, n_fft=2048, center=False)
 
 
+def test_stft_toolong_center():
+    y = np.zeros((128,))
+    with pytest.warns(UserWarning):
+        librosa.stft(y, n_fft=2048, center=True)
+
+
 def test_stft_winsizes():
     # Test for issue #1095
     x = np.zeros(1000000)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -269,12 +269,6 @@ def test_stft_toolong_left():
     librosa.stft(y, n_fft=2048, center=False)
 
 
-def test_stft_toolong_center():
-    y = np.zeros((128,))
-    with pytest.warns(UserWarning):
-        librosa.stft(y, n_fft=2048, center=True)
-
-
 def test_stft_winsizes():
     # Test for issue #1095
     x = np.zeros(1000000)


### PR DESCRIPTION
I wondered about some warnings raised by the `stft` function when `n_fft` is larger than the signal length. In theory, this should not be a problem when `win_length` is shorter because `n_fft` is achieved by zero-padding. The following example illustrates the issue:

```python
import librosa
import numpy as np

x = np.random.random(4000)
X = librosa.stft(x, hop_length=100, win_length=200, n_fft=4001)
```

This raises a warning.
```
UserWarning: n_fft=4001 is too small for input signal of length=4000
  n_fft, y.shape[-1]
```

I have various concerns, maybe based on a misunderstanding?

1. In general, should it not mean that the FFT size is too large (instead of too small)?
2. When `center=True`, it should pad zeros as necessary to fulfill the FFT size. In practice, I found the output to be fine for all FFT sizes. Isn't the warning unnecessary?
3. Currently, an error is raised if `center=False`. In theory, we could have an arbitrarily large FFT size if the window size fits the signal. As far as I see, this is only a problem in the specific librosa implementation, where we do windows of FFT size instead of using windows of the window size (with zero padding afterward). Of course, the librosa implementation is more efficient compared to an implementation with zero padding after windowing.

I don't know how to handle it? I want to start with the suggestion of removing the warning and re-phrasing the error message. However, I only see that the third point can be addressed by reimplementing the STFT for the case of `center=False` and `n_fft > y.shape[-1]`.