### PR TITLE
docs: Fix simple typo, recomended -> recommended

### DIFF
--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -466,12 +466,12 @@ def yin(
 
     fmin: number > 0 [scalar]
         minimum frequency in Hertz.
-        The recomended minimum is ``librosa.note_to_hz('C2')`` (~65 Hz)
+        The recommended minimum is ``librosa.note_to_hz('C2')`` (~65 Hz)
         though lower values may be feasible.
 
     fmax: number > 0 [scalar]
         maximum frequency in Hertz.
-        The recomended maximum is ``librosa.note_to_hz('C7')`` (~2093 Hz)
+        The recommended maximum is ``librosa.note_to_hz('C7')`` (~2093 Hz)
         though higher values may be feasible.
 
     sr : number > 0 [scalar]
@@ -637,12 +637,12 @@ def pyin(
 
     fmin: number > 0 [scalar]
         minimum frequency in Hertz.
-        The recomended minimum is ``librosa.note_to_hz('C2')`` (~65 Hz)
+        The recommended minimum is ``librosa.note_to_hz('C2')`` (~65 Hz)
         though lower values may be feasible.
 
     fmax: number > 0 [scalar]
         maximum frequency in Hertz.
-        The recomended maximum is ``librosa.note_to_hz('C7')`` (~2093 Hz)
+        The recommended maximum is ``librosa.note_to_hz('C7')`` (~2093 Hz)
         though higher values may be feasible.
 
     sr : number > 0 [scalar]


### PR DESCRIPTION
There is a small typo in librosa/core/pitch.py.

Should read `recommended` rather than `recomended`.

