### PR TITLE
Return keys in list_examples

### DIFF
--- a/librosa/util/files.py
+++ b/librosa/util/files.py
@@ -112,6 +112,11 @@ def list_examples():
 
     A brief description is provided in the second column.
 
+    Returns
+    -------
+    examples : List[str]
+        List of paths to the audio example files included with librosa
+
     See Also
     --------
     util.example
@@ -119,8 +124,10 @@ def list_examples():
     """
     print("AVAILABLE EXAMPLES")
     print("-" * 68)
-    for key in sorted(__TRACKMAP.keys()):
+    examples = sorted(__TRACKMAP.keys())
+    for key in examples:
         print("{:10}\t{}".format(key, __TRACKMAP[key]["desc"]))
+    return examples
 
 
 def example_info(key):


### PR DESCRIPTION
This PR introduces a minor change to `librosa.util.list_examples` such that it also returns the keys as a `List[str]`. This would be useful for finding all available files programmatically when testing DSP code.

1. Perhaps the current `list_examples` function is intentionally only printing and returning `None` though? If so, just let me know and I'll close this PR!
2. It might be sensible to make the print to stdout optional by introducing a function argument (e.g. `librosa.util.list_examples(display=True)`). As long as the current default is preserved, it shouldn't break anything.