### PR TITLE
Add ffmpeg link for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ If you are not using Anaconda, here are some common commands for different opera
 * Linux (apt-get): `apt-get install ffmpeg` or `apt-get install gstreamer1.0-plugins-base gstreamer1.0-plugins-ugly`
 * Linux (yum): `yum install ffmpeg` or `yum install gstreamer1.0-plugins-base gstreamer1.0-plugins-ugly`
 * Mac: `brew install ffmpeg` or `brew install gstreamer`
-* Windows: download binaries from this [website]( https://gstreamer.freedesktop.org/) 
+* Windows: download ffmpeg binaries from this [website](https://www.gyan.dev/ffmpeg/builds/) or gstreamer binaries from this [website](https://gstreamer.freedesktop.org/)
 
 For GStreamer, you also need to install the Python bindings with 
 ```


### PR DESCRIPTION
Installing gstreamer and pygobject on windows is a lot of pain, it turns out installing ffmpeg is a lot easier. Adding a link for ffmpeg and I hope it will save someone some pain.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/main/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
<!-- Example: Fixes #123 -->


#### What does this implement/fix? Explain your changes.


#### Any other comments?

