### PR TITLE
1025 deemphasis

### DIFF
--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -662,6 +662,7 @@ def preemphasis(y, coef=0.97, zi=None, return_zf=False):
 
     return y_out
 
+
 def deemphasis(y, coef=0.95, zi=None):
     """De-emphasize an audio signal with the inverse operation of preemphasis():
 
@@ -691,7 +692,8 @@ def deemphasis(y, coef=0.95, zi=None):
         Initial filter state. If inverting a previous preemphasis(), the same value should be used.
          When making successive calls to non-overlapping
 
-        By default ``zi`` is initialized as ``((2 - coef) * y[0] - y[1]) / (3 - coef)``. This
+        By default ``zi`` is initialized as
+        ``((2 - coef) * y[0] - y[1]) / (3 - coef)``. This
         value corresponds to the transformation of the default initialization of ``zi`` in ``preemphasis()``,
         ``2*y[0] - y[1]``.
 

--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -645,6 +645,9 @@ def preemphasis(y, coef=0.97, zi=None, return_zf=False):
     >>> np.allclose(y_filt, np.concatenate([y_filt_1, y_filt_2]))
     True
 
+    See Also
+    --------
+    deemphasis
     """
     b = np.asarray([1.0, -coef], dtype=y.dtype)
     a = np.asarray([1.0], dtype=y.dtype)
@@ -667,7 +670,7 @@ def deemphasis(y, coef=0.95, zi=None):
     """De-emphasize an audio signal with the inverse operation of preemphasis():
 
     If y = preemphasis(x, coef=coef, zi=zi), the deemphasis is:
-        x[i] -> y[i] + coef * x[i-1]
+        x[i] = y[i] + coef * x[i-1]
         x = deemphasis(y, coef=coef, zi=zi)
 
 
@@ -699,7 +702,7 @@ def deemphasis(y, coef=0.95, zi=None):
     Returns
     -------
     y_out : np.ndarray
-        pre-emphasized signal
+        de-emphasized signal
 
     Examples
     --------
@@ -719,8 +722,6 @@ def deemphasis(y, coef=0.95, zi=None):
     a = np.asarray([1.0], dtype=y.dtype)
 
     if zi is None:
-        if coef == 3.0:
-            raise NotImplementedError("Unable to do deemphasis if coefficient is 3.")
         zi = ((2 - coef) * y[0] - y[1]) / (3 - coef)
     y[0] -= zi
 

--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -666,9 +666,9 @@ def preemphasis(y, coef=0.97, zi=None, return_zf=False):
 def deemphasis(y, coef=0.95, zi=None):
     """De-emphasize an audio signal with the inverse operation of preemphasis():
 
-    If y~ = preemphasis(y, coef=coef, zi=zi)
-        y[i] -> y~[i] + coef * y[i-1]
-        y = deemphasis(y~, coef=coef, zi=zi)
+    If y = preemphasis(x, coef=coef, zi=zi), the deemphasis is:
+        x[i] -> y[i] + coef * x[i-1]
+        x = deemphasis(y, coef=coef, zi=zi)
 
 
     Parameters
@@ -690,12 +690,11 @@ def deemphasis(y, coef=0.95, zi=None):
 
     zi : number
         Initial filter state. If inverting a previous preemphasis(), the same value should be used.
-         When making successive calls to non-overlapping
 
         By default ``zi`` is initialized as
         ``((2 - coef) * y[0] - y[1]) / (3 - coef)``. This
         value corresponds to the transformation of the default initialization of ``zi`` in ``preemphasis()``,
-        ``2*y[0] - y[1]``.
+        ``2*x[0] - x[1]``.
 
     Returns
     -------
@@ -704,13 +703,17 @@ def deemphasis(y, coef=0.95, zi=None):
 
     Examples
     --------
-    Apply a standard pre-emphasis filter and invert it with deemphasis
+    Apply a standard pre-emphasis filter and invert it with de-emphasis
 
     >>> y, sr = librosa.load(librosa.ex('trumpet'))
     >>> y_filt = librosa.effects.preemphasis(y)
     >>> y_deemph = librosa.effects.deemphasis(y_filt)
     >>> np.allclose(y, y_deemph)
     True
+
+    See Also
+    --------
+    preemphasis
     """
     b = np.asarray([1.0, -coef], dtype=y.dtype)
     a = np.asarray([1.0], dtype=y.dtype)

--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -30,6 +30,7 @@ Miscellaneous
     trim
     split
     preemphasis
+    deemphasis
 """
 
 import numpy as np
@@ -659,4 +660,64 @@ def preemphasis(y, coef=0.97, zi=None, return_zf=False):
     if return_zf:
         return y_out, z_f
 
+    return y_out
+
+def deemphasis(y, coef=0.95, zi=None):
+    """De-emphasize an audio signal with the inverse operation of preemphasis():
+
+    If y~ = preemphasis(y, coef=coef, zi=zi)
+        y[i] -> y~[i] + coef * y[i-1]
+        y = deemphasis(y~, coef=coef, zi=zi)
+
+
+    Parameters
+    ----------
+    y : np.ndarray
+        Audio signal
+
+    coef : positive number
+        Pre-emphasis coefficient.  Typical values of ``coef`` are between 0 and 1.
+
+        At the limit ``coef=0``, the signal is unchanged.
+
+        At ``coef=1``, the result is the first-order difference of the signal.
+
+        The default (0.97) matches the pre-emphasis filter used in the HTK
+        implementation of MFCCs [#]_.
+
+        .. [#] http://htk.eng.cam.ac.uk/
+
+    zi : number
+        Initial filter state. If inverting a previous preemphasis(), the same value should be used.
+         When making successive calls to non-overlapping
+
+        By default ``zi`` is initialized as ``((2 - coef) * y[0] - y[1]) / (3 - coef)``. This
+        value corresponds to the transformation of the default initialization of ``zi`` in ``preemphasis()``,
+        ``2*y[0] - y[1]``.
+
+    Returns
+    -------
+    y_out : np.ndarray
+        pre-emphasized signal
+
+    Examples
+    --------
+    Apply a standard pre-emphasis filter and invert it with deemphasis
+
+    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y_filt = librosa.effects.preemphasis(y)
+    >>> y_deemph = librosa.effects.deemphasis(y_filt)
+    >>> np.allclose(y, y_deemph)
+    True
+    """
+    b = np.asarray([1.0, -coef], dtype=y.dtype)
+    a = np.asarray([1.0], dtype=y.dtype)
+
+    if zi is None:
+        if coef == 3.0:
+            raise NotImplementedError("Unable to do deemphasis if coefficient is 3.")
+        zi = ((2 - coef) * y[0] - y[1]) / (3 - coef)
+    y[0] -= zi
+
+    y_out = scipy.signal.lfilter(a, b, y)
     return y_out

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -286,3 +286,20 @@ def test_preemphasis_continue(dtype):
     assert np.allclose(y_all, np.concatenate([y1, y2]))
     assert np.allclose(zf2, zf_all)
     assert x.dtype == y_all.dtype
+
+@pytest.mark.parametrize("coef", [0.5, 0.99])
+@pytest.mark.parametrize("zi", [None, 0, [0]])
+@pytest.mark.parametrize("return_zf", [False, True])
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_deemphasis(coef, zi, return_zf, dtype):
+    x = np.arange(10, dtype=dtype)
+
+    y = librosa.effects.preemphasis(x, coef=coef, zi=zi, return_zf=return_zf)
+
+    if return_zf:
+        y, zf = y
+
+    y_deemph = librosa.effects.deemphasis(y, coef=coef, zi=zi)
+
+    assert np.allclose(x, y_deemph)
+    assert x.dtype == y_deemph.dtype


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/main/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
<!-- Example: Fixes #123 -->


#### What does this implement/fix? Explain your changes.
This implements `effects.py:deemphasis()`, which is the inverse operation of `effects.py:preemphasis()`. Thus, it resolves https://github.com/librosa/librosa/issues/1025. Tests are added that demonstrate recovery of the original signal prior to preemphasis.


#### Any other comments?
This is my first contribution. Please let me know how to improve it.

