### PR TITLE
docs: Fix dim calculation error

### DIFF
--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -333,7 +333,7 @@ def stream(
     ------
     y : np.ndarray
         An audio buffer of (at most)
-        ``block_length * (hop_length-1) + frame_length`` samples.
+        ``(block_length-1) * hop_length + frame_length`` samples.
 
     See Also
     --------


### PR DESCRIPTION
#### Reference Issue
None.


#### What does this implement/fix? Explain your changes.
Fix a small dim calculation error.

The shape of a block which yield from `librosa.stream()` method should be `(block_length-1) * hop_length + frame_length` at most.

This can be tested with a few examples using librosa v0.8.

```python
>>> import librosa
>>> filename = librosa.ex('brahms')
>>> sr = librosa.get_samplerate(filename)
>>> stream = librosa.stream(filename,
...     block_length=256,
...     frame_length=4096,
...     hop_length=1024)
>>> print(next(stream).shape)
(265216,)
>>> 256 * (1024-1) + 4096
265984
>>> (256-1) * 1024 + 4096
265216
```

```python
>>> import librosa
>>> filename = librosa.ex('trumpet')
>>> sr = librosa.get_samplerate(filename)
>>> stream = librosa.stream(filename,
...     block_length=128,
...     frame_length=1024,
...     hop_length=512)
>>> print(next(stream).shape)
(66048,)
>>> 128 * (512-1) + 1024
66432
>>> (128-1) * 512 + 1024
66048
```

#### Any other comments?
None.
