### PR TITLE
display.specshow: fix mel frequency range

### DIFF
--- a/librosa/display.py
+++ b/librosa/display.py
@@ -1121,13 +1121,13 @@ def __coord_fft_hz(n, sr=22050, **_kwargs):
     return basis
 
 
-def __coord_mel_hz(n, fmin=0, fmax=11025.0, **_kwargs):
+def __coord_mel_hz(n, fmin=0, fmax=None, sr=22050, **_kwargs):
     """Get the frequencies for Mel bins"""
 
     if fmin is None:
         fmin = 0
     if fmax is None:
-        fmax = 11025.0
+        fmax = 0.5 * sr
 
     basis = core.mel_frequencies(n, fmin=fmin, fmax=fmax)
     basis[1:] -= 0.5 * np.diff(basis)


### PR DESCRIPTION
#### Reference Issue
Fixes #1240 


#### What does this implement/fix? Explain your changes.

This PR modifies the Mel coordinate decorator to correctly infer `fmax=sr/2` when not provided.  Previously, it had been hard-coded to `11025`, which in distant history was the default fmax independent of sampling rate.

You can still override this behavior by setting `fmax` explicitly when calling specshow.

#### Any other comments?

Behaves as expected now (documented in #1240 ) -- I think there's nothing else to do here.