### PR TITLE
Chromagrams of a signal with n_chroma!=12 & base_c = True

### DIFF
--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -386,7 +386,7 @@ def chroma(
         )
 
     if base_c:
-        wts = np.roll(wts, -3, axis=0)
+        wts = np.roll(wts, -3*(n_chroma//12), axis=0)
 
     # remove aliasing columns, copy to ensure row-contiguity
     return np.ascontiguousarray(wts[:, : int(1 + n_fft / 2)], dtype=dtype)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -195,6 +195,21 @@ def test_chromafb(infile):
     assert np.allclose(wts, DATA["wts"])
 
 
+# Testing two tones, 261.63 Hz and 440 Hz
+@pytest.mark.parametrize("freq", [261.63, 440])
+def test_chroma_issue1295(freq):
+
+    tone_1 = librosa.tone(frequency=freq, sr=22050, duration=1)
+    chroma_1 = librosa.feature.chroma_stft(y=tone_1, sr=22050, n_chroma=120, base_c = True)
+
+    actual_argmax = np.unravel_index(chroma_1.argmax(), chroma_1.shape)
+    
+    if freq == 261.63:
+        assert actual_argmax == (5, 43)
+    elif freq == 440:
+        assert actual_argmax == (86, 43)
+
+
 @pytest.mark.parametrize("n", [16, 16.0, 16.25, 16.75])
 @pytest.mark.parametrize(
     "window_name",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/main/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
Issues #1295

#### What does this implement/fix?
Under the conditions of n_chroma  != 12 and base_c = True, a proper chroma has not been made. It is because the line 389 of filter.py, which is intended to make adjustments on chroma filter matrix if base_c = True, was not taking account of the number of chroma bins (always rolling by -3 regardless of it). @bekemax suggested the following change will fix this issue, allowing chromas to be made in correct range under those conditions.

#### Any other comments?

[EDIT by @lostanlen: this PR will close #1295]