### PR TITLE
Scale covariance, self-similarity etc. plots to square

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -161,7 +161,7 @@ sphinx_gallery_conf = {
         "pooch": "https://www.fatiando.org/pooch/latest/",
     },
     "reset_modules": (reset_mpl,),
-    'capture_repr': ('_repr_html_'),
+    'capture_repr': ('_repr_html_',),
 }
 
 # Generate plots for example sections

--- a/docs/examples/plot_display.py
+++ b/docs/examples/plot_display.py
@@ -271,6 +271,9 @@ img = librosa.display.specshow(ccov, y_axis='chroma', x_axis='chroma',
 ax.set(title='Chroma covariance')
 fig.colorbar(img, ax=ax)
 
+# %%
+# Certain plots (e.g. covariance, self-similarity) are automatically
+# squared by `specshow`. To override that, pass `auto_scale=False`.
 
 # %%
 # Color maps

--- a/librosa/display.py
+++ b/librosa/display.py
@@ -647,6 +647,7 @@ def specshow(
     Sa=None,
     mela=None,
     thaat=None,
+    auto_scale=True,
     ax=None,
     **kwargs,
 ):
@@ -767,6 +768,13 @@ def specshow(
     thaat : str, optional
         If using `chroma_h` display mode, specify the parent thaat.
 
+    auto_scale : bool
+        Certain plots are automatically scaled for squared axes if `True` (default).
+
+        These plots include covariance, self-similarity, self-distance etc.
+
+        To override, set it to `False`.
+
     ax : matplotlib.axes.Axes or None
         Axes to plot on instead of the default `plt.gca()`.
 
@@ -859,6 +867,9 @@ def specshow(
     __decorate_axis(axes.xaxis, x_axis, key=key, Sa=Sa, mela=mela, thaat=thaat)
     __decorate_axis(axes.yaxis, y_axis, key=key, Sa=Sa, mela=mela, thaat=thaat)
 
+    # If the plot is a self-similarity/covariance etc. plot, square it
+    if __same_axes(x_axis, y_axis, axes.get_xlim(), axes.get_ylim()) and auto_scale:
+        axes.set_aspect('equal')
     return out
 
 
@@ -1194,3 +1205,9 @@ def __coord_n(n, **_kwargs):
 def __coord_time(n, sr=22050, hop_length=512, **_kwargs):
     """Get time coordinates from frames"""
     return core.frames_to_time(np.arange(n + 1), sr=sr, hop_length=hop_length)
+
+def __same_axes(x_axis, y_axis, xlim, ylim):
+    """Check if two axes are the same, used to determine squared plots"""
+    axes_same_and_not_none = (x_axis == y_axis) and (x_axis is not None)
+    axes_same_lim = xlim == ylim
+    return axes_same_and_not_none and axes_same_lim

--- a/librosa/display.py
+++ b/librosa/display.py
@@ -647,7 +647,7 @@ def specshow(
     Sa=None,
     mela=None,
     thaat=None,
-    auto_scale=True,
+    auto_aspect=True,
     ax=None,
     **kwargs,
 ):
@@ -768,12 +768,11 @@ def specshow(
     thaat : str, optional
         If using `chroma_h` display mode, specify the parent thaat.
 
-    auto_scale : bool
-        Certain plots are automatically scaled for squared axes if `True` (default).
+    auto_aspect : bool
+        Axes will have 'equal' aspect if the horizontal and vertical dimensions 
+        cover the same extent and their types match.
 
-        These plots include covariance, self-similarity, self-distance etc.
-
-        To override, set it to `False`.
+        To override, set to `False`.
 
     ax : matplotlib.axes.Axes or None
         Axes to plot on instead of the default `plt.gca()`.
@@ -868,7 +867,7 @@ def specshow(
     __decorate_axis(axes.yaxis, y_axis, key=key, Sa=Sa, mela=mela, thaat=thaat)
 
     # If the plot is a self-similarity/covariance etc. plot, square it
-    if __same_axes(x_axis, y_axis, axes.get_xlim(), axes.get_ylim()) and auto_scale:
+    if __same_axes(x_axis, y_axis, axes.get_xlim(), axes.get_ylim()) and auto_aspect:
         axes.set_aspect('equal')
     return out
 

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -720,3 +720,12 @@ def test_display_cqt_svara(C, sr):
     ax4.label_outer()
 
     return fig
+
+
+@pytest.mark.parametrize("x_axis,y_axis,xlim,ylim,out",
+                         [(None, None, (0.0, 1.0), (0.0, 1.0), False),
+                          ("time", "linear", (0.0, 1.0), (0.0, 1.0), False),
+                          ("time", "time", (0.0, 1.0), (0.0, 2.0), False),
+                          ("chroma", "chroma", (0.0, 1.0), (0.0, 1.0), True)])
+def test_same_axes(x_axis, y_axis, xlim, ylim, out):
+    assert librosa.display.__same_axes(x_axis, y_axis, xlim, ylim) == out


### PR DESCRIPTION
#### Reference Issue
Fixes #1299.

#### What does this implement/fix? Explain your changes.
`display.specshow` now automatically squares covariance, self-similarity etc. plots.
The fix includes:
- display.specshow updates:
    - auto_scale parameter and its explanation in the docstring of specshow
    - a helper function to check if the plot should be square (with axes name and limit checks)
    - the test of that helper function in the test suite
    - the plot squaring procedure that is hit only if the helper function returns true and auto_scale=True
- Briefly mention `plot_display.py` that the plots are automatically squared in certain cases and can be bypassed with the auto_scale parameter.

#### Any other comments?
I also made a tiny change in `docs/conf.py`. Tuples with single elements and without a trailing comma throws error when they are treated as iterables. This was throwing an error when I tried to build docs with the following `Python 3.7.6` environment.

```
alabaster==0.7.12
appdirs==1.4.4
attrs==20.3.0
audioread==2.1.9
autopep8==1.5.6
Babel==2.9.0
certifi==2020.12.5
cffi==1.14.5
chardet==4.0.0
contextlib2==0.6.0.post1
coverage==5.5
cycler==0.10.0
decorator==5.0.7
docutils==0.16
idna==2.10
imagesize==1.2.0
importlib-metadata==4.0.1
iniconfig==1.1.1
Jinja2==2.11.3
joblib==1.0.1
kiwisolver==1.3.1
-e git+https://github.com/dorukhansergin/librosa.git@6d6f7c866c2a74e19ac37f6d0f125ea610f6fe76#egg=librosa
llvmlite==0.36.0
MarkupSafe==1.1.1
matplotlib==3.4.1
numba==0.53.1
numpy==1.20.2
numpydoc==1.1.0
packaging==20.9
pep8==1.7.1
Pillow==8.2.0
pluggy==0.13.1
pooch==1.3.0
py==1.10.0
pycodestyle==2.7.0
pycparser==2.20
pyflakes==2.3.1
Pygments==2.8.1
pyparsing==2.4.7
pytest==6.2.3
pytest-cov==2.11.1
pytest-mpl==0.12
python-dateutil==2.8.1
pytz==2021.1
requests==2.25.1
resampy==0.2.2
samplerate==0.1.0
scikit-learn==0.24.1
scipy==1.6.2
six==1.15.0
snowballstemmer==2.1.0
SoundFile==0.10.3.post1
Sphinx==3.5.4
sphinx-gallery==0.8.2
sphinx-multiversion==0.2.4
sphinx-rtd-theme==0.5.2
sphinxcontrib-applehelp==1.0.2
sphinxcontrib-devhelp==1.0.2
sphinxcontrib-htmlhelp==1.0.3
sphinxcontrib-jsmath==1.0.1
sphinxcontrib-qthelp==1.0.3
sphinxcontrib-serializinghtml==1.1.4
sphinxcontrib-svg2pdfconverter==1.1.1
threadpoolctl==2.1.0
toml==0.10.2
typing-extensions==3.7.4.3
urllib3==1.26.4
zipp==3.4.1
```
