### PR TITLE
Fix parentheses in MFCC liftering docstring

### DIFF
--- a/librosa/feature/inverse.py
+++ b/librosa/feature/inverse.py
@@ -218,7 +218,7 @@ def mfcc_to_mel(mfcc, n_mels=128, dct_type=2, norm="ortho", ref=1.0, lifter=0):
     lifter : number >= 0
         If ``lifter>0``, apply inverse liftering (inverse cepstral filtering)::
 
-            M[n, :] <- M[n, :] / (1 + sin(pi * (n + 1) / lifter)) * lifter / 2
+            M[n, :] <- M[n, :] / (1 + sin(pi * (n + 1) / lifter) * lifter / 2)
 
     Returns
     -------

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -1769,7 +1769,7 @@ def mfcc(
     lifter : number >= 0
         If ``lifter>0``, apply *liftering* (cepstral filtering) to the MFCCs::
 
-            M[n, :] <- M[n, :] * (1 + sin(pi * (n + 1) / lifter)) * lifter / 2
+            M[n, :] <- M[n, :] * (1 + sin(pi * (n + 1) / lifter) * lifter / 2)
 
         Setting ``lifter >= 2 * n_mfcc`` emphasizes the higher-order coefficients.
         As ``lifter`` increases, the coefficient weighting becomes approximately linear.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/main/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
Fixes #1310


#### What does this implement/fix? Explain your changes.
Fixed the parentheses in the formula for liftering inside MFCC.  Docstrings are now consistent with the code.
