### PR TITLE
Make the default hop_length=None for mel_to_audio

### DIFF
--- a/librosa/feature/inverse.py
+++ b/librosa/feature/inverse.py
@@ -93,7 +93,7 @@ def mel_to_audio(
     M,
     sr=22050,
     n_fft=2048,
-    hop_length=512,
+    hop_length=None,
     win_length=None,
     window="hann",
     center=True,


### PR DESCRIPTION
Fixes #1318

The docstring indicates that the default hop_length for mel_to_audio will be n_fft//4, which is what the underlying griffinlim() will do with hop_length=None. 

However, the function definition previously had a fixed default of 512, which led to unexpected results for non-default n_ffts.
