### PR TITLE
Simplify and strengthen CQT tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ docs/auto_examples/
 # Testing and checkpoints
 .ipynb_checkpoints
 .coverage.*
+coverage.xml
 
 #IDE
 .idea/

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -120,7 +120,7 @@ def test_cqt_exceed_passband(y_cqt, sr_cqt, bpo):
 @pytest.mark.parametrize("tuning", [None, 0, 0.25])
 @pytest.mark.parametrize("filter_scale", [1])
 @pytest.mark.parametrize("norm", [1])
-@pytest.mark.parametrize("res_type", ["polyphase"])
+@pytest.mark.parametrize("res_type", [None])
 @pytest.mark.parametrize("hop_length", [512])
 @pytest.mark.parametrize("sparsity", [0.01])
 def test_cqt(

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -271,11 +271,8 @@ def y_hybrid():
 @pytest.mark.parametrize("n_bins", [1, 12, 24, 48, 72, 74, 76])
 @pytest.mark.parametrize("bins_per_octave", [12, 24])
 @pytest.mark.parametrize("tuning", [None, 0, 0.25])
-#@pytest.mark.parametrize("resolution", [1, 2])
 @pytest.mark.parametrize("resolution", [1])
-#@pytest.mark.parametrize("norm", [1, 2])
 @pytest.mark.parametrize("norm", [1])
-#@pytest.mark.parametrize("res_type", [None, "polyphase"])
 @pytest.mark.parametrize("res_type", ["polyphase"])
 def test_hybrid_cqt(
     y_hybrid,
@@ -552,13 +549,10 @@ def y_chirp():
 @pytest.mark.parametrize("res_type", ["polyphase"])
 @pytest.mark.parametrize("pad_mode", ["reflect"])
 @pytest.mark.parametrize("scale", [False, True])
-#@pytest.mark.parametrize("momentum", [0, 0.99])
 @pytest.mark.parametrize("momentum", [0.99])
-#@pytest.mark.parametrize("random_state", [None, 0, np.random.RandomState()])
 @pytest.mark.parametrize("random_state", [0])
 @pytest.mark.parametrize("fmin", [40.0])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
-#@pytest.mark.parametrize("init", [None, "random"])
 @pytest.mark.parametrize("init", [None])
 def test_griffinlim_cqt(
     y_chirp,
@@ -637,6 +631,36 @@ def test_griffinlim_cqt(
 
     # Check that the data is okay
     assert np.all(np.isfinite(y_rec))
+
+
+@pytest.mark.parametrize('momentum', [0, 0.95, 0.99])
+def test_griffinlim_cqt_momentum(y_chirp, momentum):
+
+    C = librosa.cqt(y=y_chirp, sr=22050, res_type='polyphase')
+    y_rec = librosa.griffinlim_cqt(np.abs(C), sr=22050,
+            momentum=momentum, res_type='polyphase')
+
+    assert np.all(np.isfinite(y_rec))
+
+
+@pytest.mark.parametrize('random_state', [None, 0, np.random.RandomState()])
+def test_griffinlim_cqt_rng(y_chirp, random_state):
+
+    C = librosa.cqt(y=y_chirp, sr=22050, res_type='polyphase')
+    y_rec = librosa.griffinlim_cqt(np.abs(C), sr=22050,
+            random_state=random_state, res_type='polyphase')
+
+    assert np.all(np.isfinite(y_rec))
+
+
+@pytest.mark.parametrize('init', [None, "random"])
+def test_griffinlim_cqt_init(y_chirp, init):
+    C = librosa.cqt(y=y_chirp, sr=22050, res_type='polyphase')
+    y_rec = librosa.griffinlim_cqt(np.abs(C), sr=22050,
+            init=init, res_type='polyphase')
+
+    assert np.all(np.isfinite(y_rec))
+
 
 
 @pytest.mark.xfail(raises=librosa.ParameterError)

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -17,6 +17,7 @@ except KeyError:
 
 import librosa
 import numpy as np
+import scipy.stats
 
 import pytest
 
@@ -90,6 +91,11 @@ def y_cqt(sr_cqt):
     return make_signal(sr_cqt, 2.0)
 
 
+@pytest.fixture(scope='module')
+def y_cqt_110(sr_cqt):
+    return librosa.tone(110.0, sr_cqt, duration=0.75)
+
+
 @pytest.mark.xfail(raises=librosa.ParameterError)
 @pytest.mark.parametrize("hop_length", [-1, 0, 16, 63, 65])
 @pytest.mark.parametrize("bpo", [12, 24])
@@ -112,13 +118,13 @@ def test_cqt_exceed_passband(y_cqt, sr_cqt, bpo):
 @pytest.mark.parametrize("n_bins", [1, 12, 24, 76])
 @pytest.mark.parametrize("bins_per_octave", [12, 24])
 @pytest.mark.parametrize("tuning", [None, 0, 0.25])
-@pytest.mark.parametrize("filter_scale", [1, 2])
-@pytest.mark.parametrize("norm", [1, 2])
-@pytest.mark.parametrize("res_type", [None, "polyphase"])
+@pytest.mark.parametrize("filter_scale", [1])
+@pytest.mark.parametrize("norm", [1])
+@pytest.mark.parametrize("res_type", ["polyphase"])
+@pytest.mark.parametrize("hop_length", [512])
 @pytest.mark.parametrize("sparsity", [0.01])
-@pytest.mark.parametrize("hop_length", [256, 512])
 def test_cqt(
-    y_cqt,
+    y_cqt_110,
     sr_cqt,
     hop_length,
     fmin,
@@ -132,7 +138,7 @@ def test_cqt(
 ):
 
     C = librosa.cqt(
-        y=y_cqt,
+        y=y_cqt_110,
         sr=sr_cqt,
         hop_length=hop_length,
         fmin=fmin,
@@ -151,6 +157,44 @@ def test_cqt(
     # number of bins is correct
     assert C.shape[0] == n_bins
 
+    if fmin is None:
+        fmin = librosa.note_to_hz('C1')
+
+    # check for peaks if 110 is within range
+    if 110 <= fmin * 2**(n_bins / bins_per_octave):
+        peaks = np.argmax(np.abs(C), axis=0)
+
+        # This is our most common peak index in the CQT spectrum
+        # we use the mode here over frames to sidestep transient effects
+        # at the beginning and end of the CQT
+        common_peak = scipy.stats.mode(peaks)[0][0]
+
+        # Convert peak index to frequency
+        peak_frequency = fmin * 2**(common_peak / bins_per_octave)
+
+        # Check that it matches 110, which is an analysis frequency
+        assert np.isclose(peak_frequency, 110)
+
+
+@pytest.mark.parametrize('hop_length', [256, 512])
+def test_cqt_frame_rate(y_cqt_110, sr_cqt, hop_length):
+
+    C = librosa.cqt(y=y_cqt_110, sr=sr_cqt,
+                    hop_length=hop_length,
+                    res_type='polyphase')
+
+    # At sr=11025, hop of 256 gives 17 frames for default
+    # analysis
+    # hop of 512 gives 33 frames
+
+    if hop_length == 256:
+        assert C.shape[1] == 33
+    elif hop_length == 512:
+        assert C.shape[1] == 17
+    else:
+        # Unsupported test case
+        assert False
+
 
 @pytest.mark.parametrize("fmin", [None, librosa.note_to_hz("C2")])
 @pytest.mark.parametrize("n_bins", [12, 24])
@@ -163,7 +207,7 @@ def test_cqt(
 @pytest.mark.parametrize("sparsity", [0.01])
 @pytest.mark.parametrize("hop_length", [512])
 def test_vqt(
-    y_cqt,
+    y_cqt_110,
     sr_cqt,
     hop_length,
     fmin,
@@ -178,7 +222,7 @@ def test_vqt(
 ):
 
     C = librosa.vqt(
-        y=y_cqt,
+        y=y_cqt_110,
         sr=sr_cqt,
         hop_length=hop_length,
         fmin=fmin,
@@ -198,6 +242,22 @@ def test_vqt(
     # number of bins is correct
     assert C.shape[0] == n_bins
 
+    if fmin is None:
+        fmin = librosa.note_to_hz('C1')
+
+    # check for peaks if 110 is within range
+    if 110 <= fmin * 2**(n_bins / bins_per_octave):
+        peaks = np.argmax(np.abs(C), axis=0)
+
+        # This is our most common peak index in the CQT spectrum
+        # we use the mode here over frames to sidestep transient effects
+        # at the beginning and end of the CQT
+        common_peak = scipy.stats.mode(peaks)[0][0]
+
+        # Convert peak index to frequency
+        peak_frequency = fmin * 2**(common_peak / bins_per_octave)
+
+        # Check that it matches 110, which is an analysis frequency
 
 @pytest.fixture(scope="module")
 def y_hybrid():
@@ -211,9 +271,12 @@ def y_hybrid():
 @pytest.mark.parametrize("n_bins", [1, 12, 24, 48, 72, 74, 76])
 @pytest.mark.parametrize("bins_per_octave", [12, 24])
 @pytest.mark.parametrize("tuning", [None, 0, 0.25])
-@pytest.mark.parametrize("resolution", [1, 2])
-@pytest.mark.parametrize("norm", [1, 2])
-@pytest.mark.parametrize("res_type", [None, "polyphase"])
+#@pytest.mark.parametrize("resolution", [1, 2])
+@pytest.mark.parametrize("resolution", [1])
+#@pytest.mark.parametrize("norm", [1, 2])
+@pytest.mark.parametrize("norm", [1])
+#@pytest.mark.parametrize("res_type", [None, "polyphase"])
+@pytest.mark.parametrize("res_type", ["polyphase"])
 def test_hybrid_cqt(
     y_hybrid,
     sr,
@@ -489,11 +552,14 @@ def y_chirp():
 @pytest.mark.parametrize("res_type", ["polyphase"])
 @pytest.mark.parametrize("pad_mode", ["reflect"])
 @pytest.mark.parametrize("scale", [False, True])
-@pytest.mark.parametrize("momentum", [0, 0.99])
-@pytest.mark.parametrize("random_state", [None, 0, np.random.RandomState()])
+#@pytest.mark.parametrize("momentum", [0, 0.99])
+@pytest.mark.parametrize("momentum", [0.99])
+#@pytest.mark.parametrize("random_state", [None, 0, np.random.RandomState()])
+@pytest.mark.parametrize("random_state", [0])
 @pytest.mark.parametrize("fmin", [40.0])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
-@pytest.mark.parametrize("init", [None, "random"])
+#@pytest.mark.parametrize("init", [None, "random"])
+@pytest.mark.parametrize("init", [None])
 def test_griffinlim_cqt(
     y_chirp,
     hop_length,
@@ -580,7 +646,7 @@ def test_griffinlim_cqt_badinit():
 
 
 @pytest.mark.xfail(raises=librosa.ParameterError)
-def test_griffinlim_cqt_momentum():
+def test_griffinlim_cqt_bad_momentum():
     x = np.zeros((33, 3))
     librosa.griffinlim_cqt(x, momentum=-1)
 

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -177,12 +177,14 @@ def test_cqt(
 
 
 @pytest.mark.parametrize("fmin", [librosa.note_to_hz("C1")])
-@pytest.mark.parametrize("bins_per_octave", [12, 24])
-def test_cqt_early_downsample(y_cqt_110, sr_cqt, fmin, bins_per_octave):
+@pytest.mark.parametrize("bins_per_octave", [12])
+@pytest.mark.parametrize("n_bins", [88])
+def test_cqt_early_downsample(y_cqt_110, sr_cqt, n_bins, fmin, bins_per_octave):
     C = librosa.cqt(
         y=y_cqt_110,
         sr=sr_cqt,
         fmin=fmin,
+        n_bins=n_bins,
         bins_per_octave=bins_per_octave,
         res_type=None,
     )
@@ -191,13 +193,13 @@ def test_cqt_early_downsample(y_cqt_110, sr_cqt, fmin, bins_per_octave):
     assert np.iscomplexobj(C)
 
     # number of bins is correct
-    assert C.shape[0] == 84
+    assert C.shape[0] == n_bins
 
     if fmin is None:
         fmin = librosa.note_to_hz("C1")
 
     # check for peaks if 110 is within range
-    if 110 <= fmin * 2 ** (84 / bins_per_octave):
+    if 110 <= fmin * 2 ** (n_bins / bins_per_octave):
         peaks = np.argmax(np.abs(C), axis=0)
 
         # This is our most common peak index in the CQT spectrum

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -91,7 +91,7 @@ def y_cqt(sr_cqt):
     return make_signal(sr_cqt, 2.0)
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def y_cqt_110(sr_cqt):
     return librosa.tone(110.0, sr_cqt, duration=0.75)
 
@@ -120,7 +120,7 @@ def test_cqt_exceed_passband(y_cqt, sr_cqt, bpo):
 @pytest.mark.parametrize("tuning", [None, 0, 0.25])
 @pytest.mark.parametrize("filter_scale", [1])
 @pytest.mark.parametrize("norm", [1])
-@pytest.mark.parametrize("res_type", ['polyphase'])
+@pytest.mark.parametrize("res_type", ["polyphase"])
 @pytest.mark.parametrize("hop_length", [512])
 @pytest.mark.parametrize("sparsity", [0.01])
 def test_cqt(
@@ -158,10 +158,10 @@ def test_cqt(
     assert C.shape[0] == n_bins
 
     if fmin is None:
-        fmin = librosa.note_to_hz('C1')
+        fmin = librosa.note_to_hz("C1")
 
     # check for peaks if 110 is within range
-    if 110 <= fmin * 2**(n_bins / bins_per_octave):
+    if 110 <= fmin * 2 ** (n_bins / bins_per_octave):
         peaks = np.argmax(np.abs(C), axis=0)
 
         # This is our most common peak index in the CQT spectrum
@@ -170,7 +170,7 @@ def test_cqt(
         common_peak = scipy.stats.mode(peaks)[0][0]
 
         # Convert peak index to frequency
-        peak_frequency = fmin * 2**(common_peak / bins_per_octave)
+        peak_frequency = fmin * 2 ** (common_peak / bins_per_octave)
 
         # Check that it matches 110, which is an analysis frequency
         assert np.isclose(peak_frequency, 110)
@@ -194,10 +194,10 @@ def test_cqt_early_downsample(y_cqt_110, sr_cqt, fmin, bins_per_octave):
     assert C.shape[0] == 84
 
     if fmin is None:
-        fmin = librosa.note_to_hz('C1')
+        fmin = librosa.note_to_hz("C1")
 
     # check for peaks if 110 is within range
-    if 110 <= fmin * 2**(84 / bins_per_octave):
+    if 110 <= fmin * 2 ** (84 / bins_per_octave):
         peaks = np.argmax(np.abs(C), axis=0)
 
         # This is our most common peak index in the CQT spectrum
@@ -206,18 +206,16 @@ def test_cqt_early_downsample(y_cqt_110, sr_cqt, fmin, bins_per_octave):
         common_peak = scipy.stats.mode(peaks)[0][0]
 
         # Convert peak index to frequency
-        peak_frequency = fmin * 2**(common_peak / bins_per_octave)
+        peak_frequency = fmin * 2 ** (common_peak / bins_per_octave)
 
         # Check that it matches 110, which is an analysis frequency
         assert np.isclose(peak_frequency, 110)
 
 
-@pytest.mark.parametrize('hop_length', [256, 512])
+@pytest.mark.parametrize("hop_length", [256, 512])
 def test_cqt_frame_rate(y_cqt_110, sr_cqt, hop_length):
 
-    C = librosa.cqt(y=y_cqt_110, sr=sr_cqt,
-                    hop_length=hop_length,
-                    res_type='polyphase')
+    C = librosa.cqt(y=y_cqt_110, sr=sr_cqt, hop_length=hop_length, res_type="polyphase")
 
     # At sr=11025, hop of 256 gives 17 frames for default
     # analysis
@@ -279,10 +277,10 @@ def test_vqt(
     assert C.shape[0] == n_bins
 
     if fmin is None:
-        fmin = librosa.note_to_hz('C1')
+        fmin = librosa.note_to_hz("C1")
 
     # check for peaks if 110 is within range
-    if 110 <= fmin * 2**(n_bins / bins_per_octave):
+    if 110 <= fmin * 2 ** (n_bins / bins_per_octave):
         peaks = np.argmax(np.abs(C), axis=0)
 
         # This is our most common peak index in the CQT spectrum
@@ -291,9 +289,10 @@ def test_vqt(
         common_peak = scipy.stats.mode(peaks)[0][0]
 
         # Convert peak index to frequency
-        peak_frequency = fmin * 2**(common_peak / bins_per_octave)
+        peak_frequency = fmin * 2 ** (common_peak / bins_per_octave)
 
         # Check that it matches 110, which is an analysis frequency
+
 
 @pytest.fixture(scope="module")
 def y_hybrid():
@@ -669,34 +668,36 @@ def test_griffinlim_cqt(
     assert np.all(np.isfinite(y_rec))
 
 
-@pytest.mark.parametrize('momentum', [0, 0.95])
+@pytest.mark.parametrize("momentum", [0, 0.95])
 def test_griffinlim_cqt_momentum(y_chirp, momentum):
 
-    C = librosa.cqt(y=y_chirp, sr=22050, res_type='polyphase')
-    y_rec = librosa.griffinlim_cqt(np.abs(C), sr=22050, n_iter=2,
-            momentum=momentum, res_type='polyphase')
+    C = librosa.cqt(y=y_chirp, sr=22050, res_type="polyphase")
+    y_rec = librosa.griffinlim_cqt(
+        np.abs(C), sr=22050, n_iter=2, momentum=momentum, res_type="polyphase"
+    )
 
     assert np.all(np.isfinite(y_rec))
 
 
-@pytest.mark.parametrize('random_state', [None, 0, np.random.RandomState()])
+@pytest.mark.parametrize("random_state", [None, 0, np.random.RandomState()])
 def test_griffinlim_cqt_rng(y_chirp, random_state):
 
-    C = librosa.cqt(y=y_chirp, sr=22050, res_type='polyphase')
-    y_rec = librosa.griffinlim_cqt(np.abs(C), sr=22050, n_iter=2,
-            random_state=random_state, res_type='polyphase')
+    C = librosa.cqt(y=y_chirp, sr=22050, res_type="polyphase")
+    y_rec = librosa.griffinlim_cqt(
+        np.abs(C), sr=22050, n_iter=2, random_state=random_state, res_type="polyphase"
+    )
 
     assert np.all(np.isfinite(y_rec))
 
 
-@pytest.mark.parametrize('init', [None, "random"])
+@pytest.mark.parametrize("init", [None, "random"])
 def test_griffinlim_cqt_init(y_chirp, init):
-    C = librosa.cqt(y=y_chirp, sr=22050, res_type='polyphase')
-    y_rec = librosa.griffinlim_cqt(np.abs(C), sr=22050, n_iter=2,
-            init=init, res_type='polyphase')
+    C = librosa.cqt(y=y_chirp, sr=22050, res_type="polyphase")
+    y_rec = librosa.griffinlim_cqt(
+        np.abs(C), sr=22050, n_iter=2, init=init, res_type="polyphase"
+    )
 
     assert np.all(np.isfinite(y_rec))
-
 
 
 @pytest.mark.xfail(raises=librosa.ParameterError)

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -120,7 +120,7 @@ def test_cqt_exceed_passband(y_cqt, sr_cqt, bpo):
 @pytest.mark.parametrize("tuning", [None, 0, 0.25])
 @pytest.mark.parametrize("filter_scale", [1])
 @pytest.mark.parametrize("norm", [1])
-@pytest.mark.parametrize("res_type", [None])
+@pytest.mark.parametrize("res_type", ['polyphase'])
 @pytest.mark.parametrize("hop_length", [512])
 @pytest.mark.parametrize("sparsity", [0.01])
 def test_cqt(
@@ -162,6 +162,42 @@ def test_cqt(
 
     # check for peaks if 110 is within range
     if 110 <= fmin * 2**(n_bins / bins_per_octave):
+        peaks = np.argmax(np.abs(C), axis=0)
+
+        # This is our most common peak index in the CQT spectrum
+        # we use the mode here over frames to sidestep transient effects
+        # at the beginning and end of the CQT
+        common_peak = scipy.stats.mode(peaks)[0][0]
+
+        # Convert peak index to frequency
+        peak_frequency = fmin * 2**(common_peak / bins_per_octave)
+
+        # Check that it matches 110, which is an analysis frequency
+        assert np.isclose(peak_frequency, 110)
+
+
+@pytest.mark.parametrize("fmin", [librosa.note_to_hz("C1")])
+@pytest.mark.parametrize("bins_per_octave", [12, 24])
+def test_cqt_early_downsample(y_cqt_110, sr_cqt, fmin, bins_per_octave):
+    C = librosa.cqt(
+        y=y_cqt_110,
+        sr=sr_cqt,
+        fmin=fmin,
+        bins_per_octave=bins_per_octave,
+        res_type=None,
+    )
+
+    # type is complex
+    assert np.iscomplexobj(C)
+
+    # number of bins is correct
+    assert C.shape[0] == 84
+
+    if fmin is None:
+        fmin = librosa.note_to_hz('C1')
+
+    # check for peaks if 110 is within range
+    if 110 <= fmin * 2**(84 / bins_per_octave):
         peaks = np.argmax(np.abs(C), axis=0)
 
         # This is our most common peak index in the CQT spectrum
@@ -602,7 +638,7 @@ def test_griffinlim_cqt(
         bins_per_octave=bins_per_octave,
         scale=scale,
         pad_mode=pad_mode,
-        n_iter=3,
+        n_iter=2,
         momentum=momentum,
         random_state=random_state,
         length=length,
@@ -633,11 +669,11 @@ def test_griffinlim_cqt(
     assert np.all(np.isfinite(y_rec))
 
 
-@pytest.mark.parametrize('momentum', [0, 0.95, 0.99])
+@pytest.mark.parametrize('momentum', [0, 0.95])
 def test_griffinlim_cqt_momentum(y_chirp, momentum):
 
     C = librosa.cqt(y=y_chirp, sr=22050, res_type='polyphase')
-    y_rec = librosa.griffinlim_cqt(np.abs(C), sr=22050,
+    y_rec = librosa.griffinlim_cqt(np.abs(C), sr=22050, n_iter=2,
             momentum=momentum, res_type='polyphase')
 
     assert np.all(np.isfinite(y_rec))
@@ -647,7 +683,7 @@ def test_griffinlim_cqt_momentum(y_chirp, momentum):
 def test_griffinlim_cqt_rng(y_chirp, random_state):
 
     C = librosa.cqt(y=y_chirp, sr=22050, res_type='polyphase')
-    y_rec = librosa.griffinlim_cqt(np.abs(C), sr=22050,
+    y_rec = librosa.griffinlim_cqt(np.abs(C), sr=22050, n_iter=2,
             random_state=random_state, res_type='polyphase')
 
     assert np.all(np.isfinite(y_rec))
@@ -656,7 +692,7 @@ def test_griffinlim_cqt_rng(y_chirp, random_state):
 @pytest.mark.parametrize('init', [None, "random"])
 def test_griffinlim_cqt_init(y_chirp, init):
     C = librosa.cqt(y=y_chirp, sr=22050, res_type='polyphase')
-    y_rec = librosa.griffinlim_cqt(np.abs(C), sr=22050,
+    y_rec = librosa.griffinlim_cqt(np.abs(C), sr=22050, n_iter=2,
             init=init, res_type='polyphase')
 
     assert np.all(np.isfinite(y_rec))


### PR DESCRIPTION
#### Reference Issue
Fixes #1176 


#### What does this implement/fix? Explain your changes.

This PR simplifies the test suite for constant-Q functions, as described in #1176's comment thread.  Specifically:

- CQT/VQT core functionality tests now use a fixed tone and look for a prominent peak in the output spectrum at the correct location
- Test cases have been significantly reduced for test_cqt, test_hybrid_cqt, test_vqt, and test_griffinlim_cqt.
- griffinlim-cqt tests now independently sweep for initialization, momentum, and random_state.  Tests in this case are still lax, mainly ensuring that output is well-formed.

On my local machine, `main::test_constantq.py` runs in about 10 minutes, while the proposed changes now run in 56 seconds. I expect that these changes will cut our CI times (currently 20 minutes) in about half.  

#### Any other comments?

I also added coverage.xml to gitignore.

There should be no changes in line coverage, although we have lost some path coverage.  However, I'm pretty sure that these paths were redundantly tested anyway.