### PR TITLE
futureproofing matplotlib dependencies

### DIFF
--- a/librosa/display.py
+++ b/librosa/display.py
@@ -42,6 +42,9 @@ from matplotlib.axes import Axes
 from matplotlib.ticker import Formatter, ScalarFormatter
 from matplotlib.ticker import LogLocator, FixedLocator, MaxNLocator
 from matplotlib.ticker import SymmetricalLogLocator
+import matplotlib
+from packaging.version import parse as version_parse
+
 
 from . import core
 from . import util
@@ -946,15 +949,27 @@ def __scale_axes(axes, ax_type, which):
 
     kwargs = dict()
     if which == "x":
-        thresh = "linthreshx"
-        base = "basex"
-        scale = "linscalex"
+        if version_parse(matplotlib.__version__) < version_parse('3.3.0'):
+            thresh = "linthreshx"
+            base = "basex"
+            scale = "linscalex"
+        else:
+            thresh = "linthresh"
+            base = "base"
+            scale = "linscale"
+
         scaler = axes.set_xscale
         limit = axes.set_xlim
     else:
-        thresh = "linthreshy"
-        base = "basey"
-        scale = "linscaley"
+        if version_parse(matplotlib.__version__) < version_parse('3.3.0'):
+            thresh = "linthreshy"
+            base = "basey"
+            scale = "linscaley"
+        else:
+            thresh = "linthresh"
+            base = "base"
+            scale = "linscale"
+
         scaler = axes.set_yscale
         limit = axes.set_ylim
 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,8 @@ setup(
         'resampy >= 0.2.2',
         'numba >= 0.43.0',
         'soundfile >= 0.9.0',
-        'pooch >= 1.0'
+        'pooch >= 1.0',
+        'packaging >= 20.0'
     ],
     python_requires='>=3.6',
     extras_require={


### PR DESCRIPTION
#### Reference Issue
Fixes #1266 


#### What does this implement/fix? Explain your changes.

This PR adds a run-time check on the matplotlib version when setting axis scales.  This is in response to a keyword deprecation cycle introduced in matplotlib 3.3, and which will break things for our current code starting in matplotlib 3.5.0.  (`basex => base`, `linthreshx => linthresh`, etc.)  The API change is documented [here](https://matplotlib.org/3.3.3/api/api_changes.html#log-symlog-scale-base-ticks-and-nonpos-specification).

The fix is to use the old-style keywords on matplotlib < 3.3.0, and the new-style on >= 3.3.0.

Starting in 0.9.0, we can bump up the minimum matplotlib requirement and remove this shim code, but this will at least keep the 0.8.1 release of librosa running for a while into the future.

#### Any other comments?

This PR adds a dependency on the `packaging` package for parsing version strings.  Version string parsing is such a headache that I think it's worth the added dependency to let someone else deal with it.