### PR TITLE
fix #1330 - minimal ubuntu dist → 18.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - os: ubuntu-16.04
+                    - os: ubuntu-18.04
                       python-version: 3.7
 
                     - os: ubuntu-latest


### PR DESCRIPTION
#### Reference Issue
Fixes #1330 


#### What does this implement/fix? Explain your changes.

This PR sets the CI workflow for our unit tests to use ubuntu 18.04 and ubuntu latest, rather than 16.04 which will be retired soon.

#### Any other comments?

No CR necessary here.  Unless things messed up, I'll merge when it's green.