### PR TITLE
0.8.1rc2 prep

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -76,7 +76,7 @@ Contributors
 * Connor Guerrero <https://github.com/c-jg>
 * N. Dorukhan Sergin <https://github.com/dorukhansergin>
 * Paul Biberstein <https://github.com/P-bibs>
-
+* dofuuz <https://github.com/dofuuz>
 
 
 Some feature extraction code was based on <https://github.com/ronw/frontend> by Ron Weiss.

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -76,7 +76,7 @@ Contributors
 * Connor Guerrero <https://github.com/c-jg>
 * N. Dorukhan Sergin <https://github.com/dorukhansergin>
 * Paul Biberstein <https://github.com/P-bibs>
-* dofuuz <https://github.com/dofuuz>
+* Myungchul Keum <https://github.com/dofuuz>
 
 
 Some feature extraction code was based on <https://github.com/ronw/frontend> by Ron Weiss.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
 include AUTHORS.md
 include CONTRIBUTING.md
 include LICENSE.md
+include CODE_OF_CONDUCT.md
+include librosa/util/example_data/*

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -27,6 +27,9 @@ deposited under `build/html`.  To deploy, we sync the compiled site to the
 
 Because the historical docs include example code that is executed to generate
 figures, the environment for building historical docs can be brittle.
-Presently, the oldest compiled doc is for release 0.6.3, which only runs on old
-versions of numba due to API changes.  This is why `numba < 0.50` is included as a
-constraint in the `extras_require` for `docs` in `setup.cfg`.
+Presently, the oldest compiled doc is for release 0.6.3.
+The historical docs work with the following dependency versions:
+
+    - numba=0.48 : decorators submodule move in 0.49 gives warnings, and 0.50 breaks old librosa
+    - numpy=1.17 : strict dtype requirements in linspace parameters break some of our old examples from 1.18 on
+    - matplotlib=3.2 : log axes API changes cause warnings in 3.3 onward

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ v0.8.1
 New Features
     - `#1293`_ `librosa.effects.deemphasis`, inverse operation of `librosa.effects.preemphasis`. *Dan Mazur*
     - `#1207`_  `librosa.display.waveshow`, adaptively visualize waveforms by amplitude envelope when zoomed out, or raw sample values when zoomed in. *Brian McFee*
+    - `#1338`_ `librosa.resample` now optionally supports `soxr`. *dofuuz*
 
 
 Bug fixes
@@ -73,6 +74,7 @@ Deprecations to be removed in 0.9
 .. _#1336: https://github.com/librosa/librosa/issues/1336
 .. _#1340: https://github.com/librosa/librosa/issues/1340
 .. _#1341: https://github.com/librosa/librosa/issues/1341
+.. _#1338: https://github.com/librosa/librosa/issues/1338
 
 v0.8.0
 ------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,7 @@ Bug fixes
     - `#1240`_ `librosa.display.specshow` now correctly infers `fmax` for mel frequency axes. *Brian McFee, Bea Steers*
     - `#1311`_ `librosa.filters.chroma` fixed an error in how chromagrams were generated when `n_chroma!=12` and `base_c=True`. *Joon Lim*
     - `#1322`_ `librosa.feature.inverse.mel_to_audio` now infers `hop_length` by default in a way that is consistent with the rest of the package. *Dan Ellis*
+    - `#1341`_ `librosa.onset.onset_detect` no longer modifies user-provided onset envelopes. *Brian McFee*
 
 Documentation
     - `#1211`_ fixed a broken link in the changelog. *Pavel Campr*
@@ -42,6 +43,7 @@ Other changes
     - `#1333`_ minimum version of `soundfile` has been updated to 0.10.2. *Brian McFee*
     - `#1340`_ several functions now support `np.integer`-valued parameters as well as integer-valued parameters. *Brian McFee*
     - `#1207`_ `librosa.display` time-formatted axes now have enhanced precision at short time scales. *Brian McFee*
+    - `#1341`_ `librosa.onset.onset_detect` can now optionally disable normalization of the onset envelope. *Brian McFee*
 
 Deprecations to be removed in 0.9
     - `librosa.display.waveplot` is now deprecated in favor of `librosa.display.waveshow`.
@@ -70,6 +72,7 @@ Deprecations to be removed in 0.9
 .. _#1335: https://github.com/librosa/librosa/issues/1335
 .. _#1336: https://github.com/librosa/librosa/issues/1336
 .. _#1340: https://github.com/librosa/librosa/issues/1340
+.. _#1341: https://github.com/librosa/librosa/issues/1341
 
 v0.8.0
 ------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -40,6 +40,8 @@ Other changes
     - `#1335`_, `#1336`_ `librosa.display.specshow` now supports pitch notation
       (Western, Hindustani, and Carnatic) for STFT matrices. *Paul Biberstein, Brian McFee*
     - `#1333`_ minimum version of `soundfile` has been updated to 0.10.2. *Brian McFee*
+    - `#1340`_ several functions now support `np.integer`-valued parameters as well as integer-valued parameters. *Brian McFee*
+    - `#1207`_ `librosa.display` time-formatted axes now have enhanced precision at short time scales. *Brian McFee*
 
 Deprecations to be removed in 0.9
     - `librosa.display.waveplot` is now deprecated in favor of `librosa.display.waveshow`.
@@ -67,6 +69,7 @@ Deprecations to be removed in 0.9
 .. _#1334: https://github.com/librosa/librosa/issues/1334
 .. _#1335: https://github.com/librosa/librosa/issues/1335
 .. _#1336: https://github.com/librosa/librosa/issues/1336
+.. _#1340: https://github.com/librosa/librosa/issues/1340
 
 v0.8.0
 ------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,7 +12,7 @@ v0.8.1
 New Features
     - `#1293`_ `librosa.effects.deemphasis`, inverse operation of `librosa.effects.preemphasis`. *Dan Mazur*
     - `#1207`_  `librosa.display.waveshow`, adaptively visualize waveforms by amplitude envelope when zoomed out, or raw sample values when zoomed in. *Brian McFee*
-    - `#1338`_ `librosa.resample` now optionally supports `soxr`. *dofuuz*
+    - `#1338`_ `librosa.resample` now optionally supports `soxr`. *Myungchul Keum*
 
 
 Bug fixes

--- a/librosa/version.py
+++ b/librosa/version.py
@@ -6,7 +6,7 @@ import sys
 import importlib
 
 short_version = "0.8"
-version = "0.8.1rc1"
+version = "0.8.1rc2"
 
 
 def __get_mod_version(modname):


### PR DESCRIPTION
This PR should fix the inclusion of package data (example registry) in the sdist archive.

The version number has been bumped to rc2.

I've also added the CoC to the package manifest, because we forgot to do that before!

I'll leave this PR open in case we want to add any more changes prior to rc2.