### PR TITLE
support np.integer wherever we support int

### DIFF
--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -877,7 +877,7 @@ def lpc(y, order):
     >>> ax.set_title('LP Model Forward Prediction')
 
     """
-    if not isinstance(order, int) or order < 1:
+    if not isinstance(order, (int, np.integer)) or order < 1:
         raise ParameterError("order must be an integer > 0")
 
     util.valid_audio(y, mono=True)

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -2153,7 +2153,7 @@ def pcen(
             "time_constant={} must be strictly positive".format(time_constant)
         )
 
-    if max_size < 1 or not isinstance(max_size, int):
+    if max_size < 1 or not isinstance(max_size, (int, np.integer)):
         raise ParameterError("max_size={} must be a positive integer".format(max_size))
 
     if b is None:

--- a/librosa/display.py
+++ b/librosa/display.py
@@ -702,7 +702,7 @@ def waveplot(
 
     util.valid_audio(y, mono=False)
 
-    if not (isinstance(max_sr, int) and max_sr > 0):
+    if not (isinstance(max_sr, (int, np.integer)) and max_sr > 0):
         raise ParameterError("max_sr must be a non-negative integer")
 
     target_sr = sr

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -509,7 +509,7 @@ def spectral_contrast(
             "freq.shape mismatch: expected " "({:d},)".format(S.shape[0])
         )
 
-    if n_bands < 1 or not isinstance(n_bands, int):
+    if n_bands < 1 or not isinstance(n_bands, (int, np.integer)):
         raise ParameterError("n_bands must be a positive integer")
 
     if not 0.0 < quantile < 1.0:
@@ -1580,7 +1580,7 @@ def chroma_cens(
 
     if not (
         (win_len_smooth is None)
-        or (isinstance(win_len_smooth, int) and win_len_smooth > 0)
+        or (isinstance(win_len_smooth, (int, np.integer)) and win_len_smooth > 0)
     ):
         raise ParameterError(
             "win_len_smooth={} must be a positive integer or None".format(

--- a/librosa/feature/utils.py
+++ b/librosa/feature/utils.py
@@ -107,7 +107,7 @@ def delta(data, width=9, order=1, axis=-1, mode="interp", **kwargs):
     if width < 3 or np.mod(width, 2) != 1:
         raise ParameterError("width must be an odd integer >= 3")
 
-    if order <= 0 or not isinstance(order, int):
+    if order <= 0 or not isinstance(order, (int, np.integer)):
         raise ParameterError("order must be a positive integer")
 
     kwargs.pop("deriv", None)

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -631,7 +631,7 @@ def constant_q_lengths(
     if filter_scale <= 0:
         raise ParameterError("filter_scale must be positive")
 
-    if n_bins <= 0 or not isinstance(n_bins, int):
+    if n_bins <= 0 or not isinstance(n_bins, (int, np.integer)):
         raise ParameterError("n_bins must be a positive integer")
 
     # Q should be capitalized here, so we suppress the name warning

--- a/librosa/onset.py
+++ b/librosa/onset.py
@@ -547,10 +547,10 @@ def onset_strength_multi(
     if aggregate is None:
         aggregate = np.mean
 
-    if lag < 1 or not isinstance(lag, int):
+    if lag < 1 or not isinstance(lag, (int, np.integer)):
         raise ParameterError("lag must be a positive integer")
 
-    if max_size < 1 or not isinstance(max_size, int):
+    if max_size < 1 or not isinstance(max_size, (int, np.integer)):
         raise ParameterError("max_size must be a positive integer")
 
     # First, compute mel spectrogram

--- a/librosa/sequence.py
+++ b/librosa/sequence.py
@@ -1443,7 +1443,7 @@ def transition_uniform(n_states):
            [0.333, 0.333, 0.333]])
     """
 
-    if not isinstance(n_states, int) or n_states <= 0:
+    if not isinstance(n_states, (int, np.integer)) or n_states <= 0:
         raise ParameterError("n_states={} must be a positive integer")
 
     transition = np.empty((n_states, n_states), dtype=np.float)
@@ -1491,7 +1491,7 @@ def transition_loop(n_states, prob):
            [0.375, 0.375, 0.25 ]])
     """
 
-    if not isinstance(n_states, int) or n_states <= 1:
+    if not isinstance(n_states, (int, np.integer)) or n_states <= 1:
         raise ParameterError("n_states={} must be a positive integer > 1")
 
     transition = np.empty((n_states, n_states), dtype=np.float)
@@ -1558,7 +1558,7 @@ def transition_cycle(n_states, prob):
            [0.1, 0. , 0. , 0.9]])
     """
 
-    if not isinstance(n_states, int) or n_states <= 1:
+    if not isinstance(n_states, (int, np.integer)) or n_states <= 1:
         raise ParameterError("n_states={} must be a positive integer > 1")
 
     transition = np.zeros((n_states, n_states), dtype=np.float)
@@ -1661,7 +1661,7 @@ def transition_local(n_states, width, window="triangle", wrap=False):
            [0.   , 0.   , 0.   , 0.   , 1.   ]])
     """
 
-    if not isinstance(n_states, int) or n_states <= 1:
+    if not isinstance(n_states, (int, np.integer)) or n_states <= 1:
         raise ParameterError("n_states={} must be a positive integer > 1")
 
     width = np.asarray(width, dtype=int)


### PR DESCRIPTION
#### Reference Issue
Fixes #1275 


#### What does this implement/fix? Explain your changes.

Wherever we check for `isinstance(foo, int)` we should also allow `np.integer`.

#### Any other comments?

Late addition to the 0.8.1 release.