### PR TITLE
get_duration function now compatible with int16 and other dtypes

### DIFF
--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -719,7 +719,8 @@ def get_duration(
         y = np.asfortranarray(y)
 
         # Validate the audio buffer.  Stereo is okay here.
-        util.valid_audio(y, mono=False)
+        #Audio validation is revoked to enable int16 and other dtypes.
+        #util.valid_audio(y, mono=False)
         if y.ndim == 1:
             n_samples = len(y)
         else:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/main/CONTRIBUTING.md#how-to-contribute
-->
#### Issue: get_duration can not work on generated audio <int16> #1360



#### The get_duration function earlier throws an error for anything than floating subdtypes. I have dropped the validation requirement here, thus enabling the int16 and other dtypes to work. (since  the validation is doing much anyway here, and has no bearing on the duration of a signal, as quoted by @bmcfee)



#### Dropping the validation will not backfire as we were already checking for ndim in the get_duration function itself and sending mono=false (stereo) will make the other checks anyway skip in the validation function.
