### PR TITLE
Fix package name typo in doc generation dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,7 @@ docs =
     matplotlib >= 2.0.0, < 3.3
     sphinx-multiversion >= 0.2.3
     sphinx-gallery >= 0.7
-    spinxcontrib-svg2pdfconverter
+    sphinxcontrib-svg2pdfconverter
     presets
 tests =
     matplotlib >= 3.0


### PR DESCRIPTION

#### Reference Issue

N/A

#### What does this implement/fix? Explain your changes.

Fixes a typo in setup.cfg so that `pip install -e .[docs]` will install dependencies for documentation generation.

#### Any other comments?

Out of curiosity, are these generated manually or is there automation that generates them on release?
