### PR TITLE
Remove usage of deprecated dtype aliases

### DIFF
--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -840,7 +840,7 @@ def vqt(
 
     Returns
     -------
-    VQT : np.ndarray [shape=(..., n_bins, t), dtype=np.complex or np.float]
+    VQT : np.ndarray [shape=(..., n_bins, t), dtype=np.complex]
         Variable-Q value each frequency at each time.
 
     See Also
@@ -1012,7 +1012,7 @@ def __cqt_filter_fft(
     hop_length=None,
     window="hann",
     gamma=0.0,
-    dtype=np.complex,
+    dtype=np.complex64,
 ):
     """Generate the frequency domain constant-Q filter basis."""
 

--- a/librosa/core/convert.py
+++ b/librosa/core/convert.py
@@ -1258,7 +1258,7 @@ def tempo_frequencies(n_bins, hop_length=512, sr=22050):
                6.764,     6.747])
     """
 
-    bin_frequencies = np.zeros(int(n_bins), dtype=np.float)
+    bin_frequencies = np.zeros(int(n_bins), dtype=np.float64)
 
     bin_frequencies[0] = np.inf
     bin_frequencies[1:] = 60.0 * sr / (hop_length * np.arange(1.0, n_bins))

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1248,7 +1248,7 @@ def phase_vocoder(D, rate, hop_length=None, n_fft=None):
     if hop_length is None:
         hop_length = int(n_fft // 4)
 
-    time_steps = np.arange(0, D.shape[-1], rate, dtype=np.float)
+    time_steps = np.arange(0, D.shape[-1], rate, dtype=np.float64)
 
     # Create an empty output array
     shape = list(D.shape)
@@ -2548,7 +2548,7 @@ def _spectrogram(
 
     Returns
     -------
-    S_out : np.ndarray [dtype=np.float32]
+    S_out : np.ndarray [dtype=np.float]
         - If ``S`` is provided as input, then ``S_out == S``
         - Else, ``S_out = |stft(y, ...)|**power``
 

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -755,7 +755,7 @@ def cq_to_chroma(
     cq_to_ch = np.roll(cq_to_ch, -int(n_merge // 2), axis=1)
 
     # How many octaves are we repeating?
-    n_octaves = np.ceil(np.float(n_input) / bins_per_octave)
+    n_octaves = np.ceil(float(n_input) / bins_per_octave)
 
     # Repeat and trim
     cq_to_ch = np.tile(cq_to_ch, int(n_octaves))[:, :n_input]

--- a/librosa/sequence.py
+++ b/librosa/sequence.py
@@ -169,9 +169,9 @@ def dtw(
     ...           title='Matching cost function')
     """
     # Default Parameters
-    default_steps = np.array([[1, 1], [0, 1], [1, 0]], dtype=np.int)
-    default_weights_add = np.zeros(3, dtype=np.float)
-    default_weights_mul = np.ones(3, dtype=np.float)
+    default_steps = np.array([[1, 1], [0, 1], [1, 0]], dtype=np.uint32)
+    default_weights_add = np.zeros(3, dtype=np.float64)
+    default_weights_mul = np.ones(3, dtype=np.float64)
 
     if step_sizes_sigma is None:
         # Use the default steps
@@ -186,10 +186,10 @@ def dtw(
     else:
         # If we have custom steps but no weights, construct them here
         if weights_add is None:
-            weights_add = np.zeros(len(step_sizes_sigma), dtype=np.float)
+            weights_add = np.zeros(len(step_sizes_sigma), dtype=np.float64)
 
         if weights_mul is None:
-            weights_mul = np.ones(len(step_sizes_sigma), dtype=np.float)
+            weights_mul = np.ones(len(step_sizes_sigma), dtype=np.float64)
 
         # Make the default step weights infinite so that they are never
         # preferred over custom steps
@@ -289,7 +289,7 @@ def dtw(
 
     # initialize step matrix with -1
     # will be filled in calc_accu_cost() with indices from step_sizes_sigma
-    steps = np.zeros(D.shape, dtype=np.int)
+    steps = np.zeros(D.shape, dtype=np.int32)
 
     # these steps correspond to left- (first row) and up-(first column) moves
     steps[0, :] = 1
@@ -532,7 +532,7 @@ def dtw_backtracking(steps, step_sizes_sigma=None, subseq=False, start=None):
         )
 
     # Default Parameters
-    default_steps = np.array([[1, 1], [0, 1], [1, 0]], dtype=np.int)
+    default_steps = np.array([[1, 1], [0, 1], [1, 0]], dtype=np.uint32)
 
     if step_sizes_sigma is None:
         # Use the default steps
@@ -1492,7 +1492,7 @@ def transition_uniform(n_states):
     if not isinstance(n_states, (int, np.integer)) or n_states <= 0:
         raise ParameterError("n_states={} must be a positive integer")
 
-    transition = np.empty((n_states, n_states), dtype=np.float)
+    transition = np.empty((n_states, n_states), dtype=np.float64)
     transition.fill(1.0 / n_states)
     return transition
 
@@ -1540,10 +1540,10 @@ def transition_loop(n_states, prob):
     if not isinstance(n_states, (int, np.integer)) or n_states <= 1:
         raise ParameterError("n_states={} must be a positive integer > 1")
 
-    transition = np.empty((n_states, n_states), dtype=np.float)
+    transition = np.empty((n_states, n_states), dtype=np.float64)
 
     # if it's a float, make it a vector
-    prob = np.asarray(prob, dtype=np.float)
+    prob = np.asarray(prob, dtype=np.float64)
 
     if prob.ndim == 0:
         prob = np.tile(prob, n_states)
@@ -1607,10 +1607,10 @@ def transition_cycle(n_states, prob):
     if not isinstance(n_states, (int, np.integer)) or n_states <= 1:
         raise ParameterError("n_states={} must be a positive integer > 1")
 
-    transition = np.zeros((n_states, n_states), dtype=np.float)
+    transition = np.zeros((n_states, n_states), dtype=np.float64)
 
     # if it's a float, make it a vector
-    prob = np.asarray(prob, dtype=np.float)
+    prob = np.asarray(prob, dtype=np.float64)
 
     if prob.ndim == 0:
         prob = np.tile(prob, n_states)
@@ -1722,7 +1722,7 @@ def transition_local(n_states, width, window="triangle", wrap=False):
     if np.any(width < 1):
         raise ParameterError("width={} must be at least 1")
 
-    transition = np.zeros((n_states, n_states), dtype=np.float)
+    transition = np.zeros((n_states, n_states), dtype=np.float64)
 
     # Fill in the widths.  This is inefficient, but simple
     for i, width_i in enumerate(width):

--- a/librosa/util/matching.py
+++ b/librosa/util/matching.py
@@ -296,7 +296,7 @@ def match_events(events_from, events_to, left=True, right=True):
         )
 
     # array of matched items
-    output = np.empty_like(events_from, dtype=np.int)
+    output = np.empty_like(events_from, dtype=np.int32)
 
     return __match_events_helper(output, events_from, events_to, left, right)
 

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -923,7 +923,7 @@ def normalize(S, norm=np.inf, axis=0, threshold=None, fill=None):
         raise ParameterError("Input must be finite")
 
     # All norms only depend on magnitude, let's do that first
-    mag = np.abs(S).astype(np.float)
+    mag = np.abs(S).astype(float)
 
     # For max/min norms, filling with 1 works
     fill_norm = 1
@@ -2153,7 +2153,7 @@ def dtype_r2c(d, default=np.complex64):
     mapping = {
         np.dtype(np.float32): np.complex64,
         np.dtype(np.float64): np.complex128,
-        np.dtype(np.float): np.complex,
+        np.dtype(np.float): np.dtype(np.complex).type,
     }
 
     # If we're given a complex type already, return it
@@ -2214,7 +2214,7 @@ def dtype_c2r(d, default=np.float32):
     mapping = {
         np.dtype(np.complex64): np.float32,
         np.dtype(np.complex128): np.float64,
-        np.dtype(np.complex): np.float,
+        np.dtype(complex): np.dtype(np.float).type,
     }
 
     # If we're given a real type already, return it


### PR DESCRIPTION
#### Reference Issue
Fixes #1350 


#### What does this implement/fix? Explain your changes.

This PR replaces deprecated dtype aliases (`np.float`, `np.int`, `np.complex`) for dtypes with explicit precision where available.

#### Any other comments?

Not much to this one; I searched the code base by grepping and made substitutions where appropriate.  If this passes CI, it should be good to go.