### PR TITLE
updated a/b/c-weighting coefficients for consistency with 1983 standard

### DIFF
--- a/librosa/core/convert.py
+++ b/librosa/core/convert.py
@@ -1344,7 +1344,7 @@ def A_weighting(frequencies, min_db=-80.0):  # pylint: disable=invalid-name
     """
     f_sq = np.asanyarray(frequencies) ** 2.0
 
-    const = np.array([12194.22, 20.598997, 107.65265, 737.86223]) ** 2.0
+    const = np.array([12194.217, 20.598997, 107.65265, 737.86223]) ** 2.0
     weights = 2.0 + 20.0 * (
         np.log10(const[0])
         + 2 * np.log10(f_sq)
@@ -1400,7 +1400,7 @@ def B_weighting(frequencies, min_db=-80.0):  # pylint: disable=invalid-name
     """
     f_sq = np.asanyarray(frequencies) ** 2.0
 
-    const = np.array([12194.22, 20.598997, 158.48932]) ** 2.0
+    const = np.array([12194.217, 20.598997, 158.48932]) ** 2.0
     weights = 0.17 + 20.0 * (
         np.log10(const[0])
         + 1.5 * np.log10(f_sq)
@@ -1454,7 +1454,7 @@ def C_weighting(frequencies, min_db=-80.0):  # pylint: disable=invalid-name
     """
     f_sq = np.asanyarray(frequencies) ** 2.0
 
-    const = np.array([12194.22, 20.598997]) ** 2.0
+    const = np.array([12194.217, 20.598997]) ** 2.0
     weights = 0.062 + 20.0 * (
         np.log10(const[0])
         + np.log10(f_sq)


### PR DESCRIPTION
#### Reference Issue
Fixes #1273 


#### What does this implement/fix? Explain your changes.

This PR revises the constants used in A, B, and C weighting to be consistent with appendix C of ANSI S1.4-1983: https://law.resource.org/pub/us/cfr/ibr/002/ansi.s1.4.1983.pdf .  D-weighting is unchanged, and I'm inclined to leave it as is since A) it's deprecated, and B) not covered by the 83 standard anyway.

#### Any other comments?

None of these changes matter very much: we're talking hundredths of a decibel here.  But consistency is nice!