### PR TITLE
Removes unused imports in setup.py & spectral.py

### DIFF
--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -12,7 +12,7 @@ from .. import filters
 from ..util.exceptions import ParameterError
 
 from ..core.convert import fft_frequencies
-from ..core.audio import zero_crossings, to_mono
+from ..core.audio import zero_crossings
 from ..core.spectrum import power_to_db, _spectrogram
 from ..core.constantq import cqt, hybrid_cqt
 from ..core.pitch import estimate_tuning

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
-import sys
 from importlib.machinery import SourceFileLoader
-from setuptools import setup, find_packages
+from setuptools import setup
 
 
 version = SourceFileLoader('librosa.version',


### PR DESCRIPTION
#### Reference Issue
N/A

#### What does this implement/fix? Explain your changes.
This PR fixes three imports in the code that are no longer used.

In setup.py:
- `import sys` no longer needed as of [this commit](https://github.com/librosa/librosa/commit/0c500a454a5e4855f3bb660a43edf3179c9e5666#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7) ("removing 2.7 cruft")
- `from setuptools import find_packages` no longer needed as of PR #1337's switch to using `packages = find:` in setup.cfg

In librosa/feature/spectral.py:
- `from ..core.audio import to_mono` not used since PR #1351 and changes to the `rms()` function ([this commit](https://github.com/librosa/librosa/commit/eb603e7a91598d1e72d3cdeada0ade21a33f9c0c#))

#### Any other comments?
Discovered these while looking for an example of how to split off setup.py into pyproject.toml & setup.cfg (thanks!).

I used pylint to confirm the unused imports. The tests still ran successfully on my local machine after removing them.
