### PR TITLE
[CR] generalizing cqt/vqt filterbank construction

### DIFF
--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -875,7 +875,7 @@ def vqt(
     n_filters = min(bins_per_octave, n_bins)
 
     # Relative difference in frequency between any two consecutive bands
-    alpha = 2.0 ** (1.0 / bins_per_octave) - 1
+    alpha = 2.0 ** (0.5 / bins_per_octave) - 2.0**(-0.5 / bins_per_octave)
 
     if fmin is None:
         # C1 by default
@@ -894,12 +894,11 @@ def vqt(
     fmin = fmin * 2.0 ** (tuning / bins_per_octave)
 
     # First thing, get the freqs of the top octave
-    freqs = cqt_frequencies(n_bins, fmin, bins_per_octave=bins_per_octave)[
-        -bins_per_octave:
-    ]
+    freqs = cqt_frequencies(n_bins, fmin, bins_per_octave=bins_per_octave)
+    freqs_top = freqs[-bins_per_octave:]
 
-    fmin_t = np.min(freqs)
-    fmax_t = np.max(freqs)
+    fmin_t = np.min(freqs_top)
+    fmax_t = np.max(freqs_top)
 
     # Determine required resampling quality
     Q = float(filter_scale) / alpha

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -884,7 +884,7 @@ def vqt(
     fmin = fmin * 2.0 ** (tuning / bins_per_octave)
 
     # First thing, get the freqs of the top octave
-    freqs = cqt_frequencies(n_bins, fmin, bins_per_octave=bins_per_octave)
+    freqs = cqt_frequencies(n_bins=n_bins, fmin=fmin, bins_per_octave=bins_per_octave)
     freqs_top = freqs[-bins_per_octave:]
 
     fmin_t = np.min(freqs_top)
@@ -978,10 +978,8 @@ def vqt(
     V = __trim_stack(vqt_resp, n_bins, dtype)
 
     if scale:
-        freqs = cqt_frequencies(
-            fmin=fmin, n_bins=n_bins, bins_per_octave=bins_per_octave
-        )
-        alpha = __bpo_to_alpha(bins_per_octave)
+        # Recompute lengths here because early downsampling may have changed
+        # our sampling rate
         lengths, _ = filters.wavelet_lengths(
             freqs,
             sr=sr,

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -1441,5 +1441,5 @@ def __bpo_to_alpha(bins_per_octave):
     alpha : number > 0
     """
 
-    r = 2**(1/bins_per_octave)
-    return (r**2 - 1) / (r**2 + 1)
+    r = 2 ** (1 / bins_per_octave)
+    return (r ** 2 - 1) / (r ** 2 + 1)

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -1441,4 +1441,5 @@ def __bpo_to_alpha(bins_per_octave):
     alpha : number > 0
     """
 
-    return 2.0 ** (0.5 / bins_per_octave) - 2.0 ** (-0.5 / bins_per_octave)
+    r = 2**(1/bins_per_octave)
+    return (r**2 - 1) / (r**2 + 1)

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -762,16 +762,14 @@ def wavelet_lengths(
             f"Frequency array={freqs} must be in strictly ascending order"
         )
 
-    # We need at least 4 frequencies to infer alpha
-    if len(freqs) > 4:
+    # We need at least 2 frequencies to infer alpha
+    if len(freqs) > 1:
         # Approximate the local octave resolution
         bpo = np.empty(len(freqs))
         logf = np.log2(freqs)
-        bpo[0] = 2/(logf[2] - logf[0])
-        bpo[1] = 2/(logf[3] - logf[1])
-        bpo[-1] = 2/(logf[-1] - logf[-3])
-        bpo[-2] = 2/(logf[-2] - logf[-4])
-        bpo[2:-2] = 4/(logf[4:] - logf[:-4])
+        bpo[0] = 1/(logf[1] - logf[0])
+        bpo[-1] = 1/(logf[-1] - logf[-2])
+        bpo[1:-1] = 2/(logf[2:] - logf[:-2])
 
         alpha = (2.0**(2/bpo) - 1) / (2.0**(2/bpo) + 1)
     elif alpha is None:

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -634,15 +634,17 @@ def constant_q_lengths(
     if n_bins <= 0 or not isinstance(n_bins, (int, np.integer)):
         raise ParameterError("n_bins must be a positive integer")
 
-    # Q should be capitalized here, so we suppress the name warning
-    # pylint: disable=invalid-name
-    alpha = 2.0 ** (1.0 / bins_per_octave) - 1.0
-    Q = float(filter_scale) / alpha
-
     # Compute the frequencies
     freq = fmin * (2.0 ** (np.arange(n_bins, dtype=float) / bins_per_octave))
 
-    if freq[-1] * (1 + 0.5 * window_bandwidth(window) / Q) > sr / 2.0:
+    # Q should be capitalized here, so we suppress the name warning
+    # pylint: disable=invalid-name
+    #
+    # Filters have ~1bin bandwidth centered at the current frequency
+    alpha = 2.0 ** (0.5 / bins_per_octave) - 2.0**(-0.5 / bins_per_octave)
+    Q = float(filter_scale) / alpha
+
+    if max(freq * (1 + 0.5 * window_bandwidth(window) / Q)) > sr / 2.0:
         raise ParameterError("Filter pass-band lies beyond Nyquist")
 
     # Convert frequencies to filter lengths

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -623,7 +623,7 @@ def constant_q_lengths(
     """
 
     if fmin <= 0:
-        raise ParameterError("fmin must be positive")
+        raise ParameterError("fmin must be strictly positive")
 
     if bins_per_octave <= 0:
         raise ParameterError("bins_per_octave must be positive")
@@ -645,7 +645,7 @@ def constant_q_lengths(
     Q = float(filter_scale) / alpha
 
     if max(freq * (1 + 0.5 * window_bandwidth(window) / Q)) > sr / 2.0:
-        raise ParameterError("Filter pass-band lies beyond Nyquist")
+        raise ParameterError(f"Maximum filter frequency={freq:.3g} exceeds Nyquist={sr/2}")
 
     # Convert frequencies to filter lengths
     lengths = Q * sr / (freq + gamma / alpha)

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -670,8 +670,9 @@ def constant_q_lengths(
 
 
 @cache(level=10)
-def wavelet_lengths(freqs, sr=22050, window="hann", filter_scale=1, gamma=0,
-        alpha=None):
+def wavelet_lengths(
+    freqs, sr=22050, window="hann", filter_scale=1, gamma=0, alpha=None
+):
     """Return length of each filter in a wavelet basis.
 
     Parameters
@@ -777,7 +778,9 @@ def wavelet_lengths(freqs, sr=22050, window="hann", filter_scale=1, gamma=0,
         freq_high = freqs[-1] / freq_roots[-2]
         alpha[-1] = (freq_high - freq_roots[-2]) / freq_roots[-1]
     elif alpha is None:
-        raise ParameterError('Cannot construct a wavelet basis for a single frequency if alpha is not provided')
+        raise ParameterError(
+            "Cannot construct a wavelet basis for a single frequency if alpha is not provided"
+        )
 
     if gamma is None:
         gamma = alpha * 24.7 / 0.108

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -655,7 +655,7 @@ def constant_q_lengths(
     # pylint: disable=invalid-name
     #
     # Balance filter bandwidths
-    alpha = (2.0**(2/bins_per_octave) - 1) / (2.0**(2/bins_per_octave) + 1)
+    alpha = (2.0 ** (2 / bins_per_octave) - 1) / (2.0 ** (2 / bins_per_octave) + 1)
     Q = float(filter_scale) / alpha
 
     if max(freq * (1 + 0.5 * window_bandwidth(window) / Q)) > sr / 2.0:
@@ -698,8 +698,19 @@ def wavelet_lengths(
 
             B[k] = alpha[k] * freqs[k] + gamma
 
-        where ``alpha[k]`` is difference between the geometric means of
-        ``(freqs[k], freqs[k+1])`` and ``(freqs[k], freqs[k-1])``.
+        ``alpha[k]`` is twice the relative difference between ``freqs[k+1]`` and ``freqs[k-1]``::
+
+            alpha[k] = (freqs[k+1]-freqs[k-1]) / (freqs[k+1]+freqs[k-1])
+
+        If ``freqs`` follows a geometric progression (as in CQT and VQT), the vector
+        ``alpha`` is constant and such that::
+
+            (1 + alpha) * freqs[k-1] = (1 - alpha) * freqs[k+1]
+
+        Furthermore, if ``gamma=0`` (default), ``alpha`` is such that even-``k`` and
+        odd-``k`` filters are interleaved::
+
+            freqs[k-1] + B[k-1] = freqs[k+1] - B[k-1]
 
         If ``gamma=None`` is specified, then ``gamma`` is computed such
         that each filter has bandwidth proportional to the equivalent
@@ -767,11 +778,11 @@ def wavelet_lengths(
         # Approximate the local octave resolution
         bpo = np.empty(len(freqs))
         logf = np.log2(freqs)
-        bpo[0] = 1/(logf[1] - logf[0])
-        bpo[-1] = 1/(logf[-1] - logf[-2])
-        bpo[1:-1] = 2/(logf[2:] - logf[:-2])
+        bpo[0] = 1 / (logf[1] - logf[0])
+        bpo[-1] = 1 / (logf[-1] - logf[-2])
+        bpo[1:-1] = 2 / (logf[2:] - logf[:-2])
 
-        alpha = (2.0**(2/bpo) - 1) / (2.0**(2/bpo) + 1)
+        alpha = (2.0 ** (2 / bpo) - 1) / (2.0 ** (2 / bpo) + 1)
     elif alpha is None:
         raise ParameterError(
             "Cannot construct a wavelet basis for a single frequency if alpha is not provided"

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -768,7 +768,7 @@ def wavelet_lengths(
     if np.any(freqs <= 0):
         raise ParameterError("frequencies must be strictly positive")
 
-    if np.any(freqs[:-1] > freqs[1:]):
+    if len(freqs) > 1 and np.any(freqs[:-1] > freqs[1:]):
         raise ParameterError(
             f"Frequency array={freqs} must be in strictly ascending order"
         )

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -744,6 +744,7 @@ def wavelet_lengths(
 
         - If the frequency array is not sorted in ascending order
     """
+    freqs = np.asarray(freqs)
     if filter_scale <= 0:
         raise ParameterError(f"filter_scale={filter_scale} must be positive")
 

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -645,7 +645,7 @@ def constant_q_lengths(
     Q = float(filter_scale) / alpha
 
     if max(freq * (1 + 0.5 * window_bandwidth(window) / Q)) > sr / 2.0:
-        raise ParameterError(f"Maximum filter frequency={freq:.3g} exceeds Nyquist={sr/2}")
+        raise ParameterError(f"Maximum filter frequency={max(freq):.2f} would exceed Nyquist={sr/2}")
 
     # Convert frequencies to filter lengths
     lengths = Q * sr / (freq + gamma / alpha)

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -710,7 +710,7 @@ def wavelet_lengths(
         Furthermore, if ``gamma=0`` (default), ``alpha`` is such that even-``k`` and
         odd-``k`` filters are interleaved::
 
-            freqs[k-1] + B[k-1] = freqs[k+1] - B[k-1]
+            freqs[k-1] + B[k-1] = freqs[k+1] - B[k+1]
 
         If ``gamma=None`` is specified, then ``gamma`` is computed such
         that each filter has bandwidth proportional to the equivalent

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -726,3 +726,9 @@ def test_griffinlim_cqt_momentum_warn():
 def test_cqt_precision(y_cqt, sr_cqt, dtype):
     C = librosa.cqt(y=y_cqt, sr=sr_cqt, dtype=dtype)
     assert np.dtype(C.dtype) == np.dtype(dtype)
+
+
+@pytest.mark.parametrize("n_bins_missing", range(-11, 11))
+def test_cqt_partial_octave(y_cqt, sr_cqt, n_bins_missing):
+    # Test what happens when n_bins is +- 1 bin from complete octaves
+    librosa.cqt(y=y_cqt, sr=sr_cqt, n_bins=72-n_bins_missing, bins_per_octave=12)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -341,7 +341,7 @@ def test_wavelet_lengths_badfreqsorder():
 
 @pytest.mark.xfail(raises=librosa.ParameterError)
 def test_wavelet_lengths_noalpha():
-    librosa.filters.wavelet_lengths(2**np.arange(3)[::-1])
+    librosa.filters.wavelet_lengths(freqs=[64], alpha=None)
 
 
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -282,6 +282,69 @@ def test_constant_q(sr, fmin, n_bins, bins_per_octave, filter_scale, pad_fft, no
     assert not np.any(F_fft[:, -F_fft.shape[1] // 2 :] > 1e-4)
 
 
+@pytest.mark.parametrize("sr", [11025])
+@pytest.mark.parametrize("fmin", [librosa.note_to_hz("C3")])
+@pytest.mark.parametrize("n_bins", [12, 24])
+@pytest.mark.parametrize("bins_per_octave", [12, 24])
+@pytest.mark.parametrize("filter_scale", [1, 2])
+@pytest.mark.parametrize("norm", [1, 2])
+@pytest.mark.parametrize("pad_fft", [False, True])
+@pytest.mark.parametrize("gamma", [0, 10, None])
+def test_wavelet(sr, fmin, n_bins, bins_per_octave, filter_scale, pad_fft, norm, gamma):
+
+    freqs = librosa.cqt_frequencies(fmin=fmin, n_bins=n_bins, bins_per_octave=bins_per_octave)
+
+    F, lengths = librosa.filters.wavelet(
+        freqs,
+        sr=sr,
+        filter_scale=filter_scale,
+        pad_fft=pad_fft,
+        norm=norm,
+        gamma=gamma
+    )
+
+    assert np.all(lengths <= F.shape[1])
+
+    assert len(F) == n_bins
+
+    if not pad_fft:
+        return
+
+    assert np.mod(np.log2(F.shape[1]), 1.0) == 0.0
+
+    # Check for vanishing negative frequencies
+    F_fft = np.abs(np.fft.fft(F, axis=1))
+    # Normalize by row-wise peak
+    F_fft = F_fft / np.max(F_fft, axis=1, keepdims=True)
+    assert np.max(F_fft[:, -F_fft.shape[1] // 2 :]) < 1e-3
+
+
+@pytest.mark.xfail(raises=librosa.ParameterError)
+def test_wavelet_lengths_badscale():
+    librosa.filters.wavelet_lengths(2**np.arange(3), filter_scale=-1)
+
+
+@pytest.mark.xfail(raises=librosa.ParameterError)
+def test_wavelet_lengths_badgamma():
+    librosa.filters.wavelet_lengths(2**np.arange(3), gamma=-1)
+
+
+@pytest.mark.xfail(raises=librosa.ParameterError)
+def test_wavelet_lengths_badfreqs():
+    librosa.filters.wavelet_lengths(2**np.arange(3) -20)
+
+
+@pytest.mark.xfail(raises=librosa.ParameterError)
+def test_wavelet_lengths_badfreqsorder():
+    librosa.filters.wavelet_lengths(2**np.arange(3)[::-1])
+
+
+@pytest.mark.xfail(raises=librosa.ParameterError)
+def test_wavelet_lengths_noalpha():
+    librosa.filters.wavelet_lengths(2**np.arange(3)[::-1])
+
+
+
 @pytest.mark.xfail(raises=librosa.ParameterError)
 @pytest.mark.parametrize(
     "sr,fmin,n_bins,bins_per_octave,filter_scale,norm",


### PR DESCRIPTION
#### Reference Issue
Fixes #1073, #18, #1396


#### What does this implement/fix? Explain your changes.

This PR will generalize the VQT filterbank construction to allow for non-uniform spacing of filter frequencies.

Additionally, the bandwidth calculation for VQT (and CQT) filters is now determined by the separation between the midpoints to neighboring frequencies `f[k+1], f[k-1]` rather than comparison to the next frequency up.  This is a very small change for CQT (ET)-based analyses, but will give us a bit more flexibility when spacing is non-uniform.

Before I dig further into the implementation, I wonder if we should refactor the interface a bit here?  Or perhaps create a parallel interface entirely?

The CQT filter constructor (and length helper) is quite simple, and I don't see much benefit in extending the API to support arbitrary frequencies.  (This would be very non-constant-Q indeed!)  Instead, we could create a new interface for wavelet construction that could be used directly by VQT, and accept an array of frequencies as parameters rather than BPO, fmin, nbins, etc.  (At some point, we may want to deprecate `filters.constant_q_*` if the functionality is fully supplanted.)  It's already a bit of a stretch having `gamma=` in the CQT constructor, so I think this kind of change might be overdue.  But I wanted to get thoughts from others (ie @lostanlen ) before going ahead with it.

#### Any other comments?

Once this is merged, we can look at implementing just-intonation VQT and related methods, as described in #1402 .