### PR TITLE
Move responsibility for fetching version number to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ filterwarnings =
 
 [metadata]
 name = librosa
+version = attr: librosa.version.version
 description = Python module for audio and music processing
 long_description = file: README.md
 long_description_content_type = text/markdown; charset=UTF-8

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,4 @@
-from importlib.machinery import SourceFileLoader
 from setuptools import setup
 
-
-version = SourceFileLoader('librosa.version',
-                           'librosa/version.py').load_module()
-
 if __name__ == '__main__':
-    setup(version=version.version)
+    setup()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/main/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
<!-- Example: Fixes #123 -->
N/A

#### What does this implement/fix? Explain your changes.
This PR streamlines the way setuptools fetches the librosa version number. It moves the responsibility from `setup.py` to `setup.cfg`. The benefit is the import and version fetch statements in `setup.py` can be removed, thus reducing the librosa code base that needs to be maintained. The responsibility can be offloaded to setuptools, [which handles version fetching since v46.4.0](https://packaging.python.org/guides/single-sourcing-package-version/).

#### Any other comments?
The current `pyproject.toml` requires setuptools >= 48, so there is no downside to this change AFAIK. It built and tested successfully on my local machine.
