### PR TITLE
[CR] Fixing cqt filterbank normalization

### DIFF
--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -984,7 +984,7 @@ def vqt(
         )
 
         # Re-scale the filters to compensate for downsampling
-        fft_basis[:] *= sr / my_sr
+        fft_basis[:] *= np.sqrt(sr / my_sr)
 
         # Compute the vqt filter response and append to the stack
         vqt_resp.append(

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -899,7 +899,6 @@ def vqt(
 
     freqs_top = freqs[-bins_per_octave:]
 
-    fmin_t = np.min(freqs_top)
     fmax_t = np.max(freqs_top)
     alpha = __bpo_to_alpha(bins_per_octave)
 
@@ -1409,6 +1408,9 @@ def griffinlim_cqt(
             window=window,
             length=length,
             res_type=res_type,
+            norm=norm,
+            scale=scale,
+            sparsity=sparsity,
             dtype=dtype,
         )
 
@@ -1423,6 +1425,10 @@ def griffinlim_cqt(
             tuning=tuning,
             filter_scale=filter_scale,
             window=window,
+            norm=norm,
+            scale=scale,
+            sparsity=sparsity,
+            pad_mode=pad_mode,
             res_type=res_type,
         )
 
@@ -1442,6 +1448,9 @@ def griffinlim_cqt(
         window=window,
         length=length,
         res_type=res_type,
+        norm=norm,
+        scale=scale,
+        sparsity=sparsity,
         dtype=dtype,
     )
 


### PR DESCRIPTION
#### Reference Issue

Observed in #1161 


#### What does this implement/fix? Explain your changes.

This PR fixes a scaling error in the inverse CQT, where we previously weren't correctly normalizing by the basis filters' frequency-domain power.

This PR also fixes a bug introduced in #1381 in the forward CQT/VQT, where filters were scaled to compensate for octave resampling when they should not have been.

#### Any other comments?

This does not fix the inverse VQT problem, but it gets us closer.