### PR TITLE
Check for unique frequencies in harmonic interpolation

### DIFF
--- a/librosa/core/harmonic.py
+++ b/librosa/core/harmonic.py
@@ -2,10 +2,13 @@
 # -*- coding: utf-8 -*-
 """Harmonic calculations for frequency representations"""
 
+import warnings
+
 import numpy as np
 import scipy.interpolate
 import scipy.signal
 from ..util.exceptions import ParameterError
+from ..util import is_unique
 
 __all__ = ["salience", "interp_harmonics"]
 
@@ -218,6 +221,11 @@ def interp_harmonics(x, freqs, h_range, kind="linear", fill_value=0, axis=-2):
     if freqs.ndim == 1 and len(freqs) == x.shape[axis]:
         # Build the 1-D interpolator.
         # All frames have a common domain, so we only need one interpolator here.
+
+        # First, verify that the input frequencies are unique
+        if not is_unique(freqs, axis=0):
+            warnings.warn("Frequencies are not unique. This may produce incorrect harmonic interpolations.")
+
         f_interp = scipy.interpolate.interp1d(
             freqs,
             x,
@@ -235,6 +243,9 @@ def interp_harmonics(x, freqs, h_range, kind="linear", fill_value=0, axis=-2):
         return f_interp(f_out)
 
     elif freqs.shape == x.shape:
+        if not np.all(is_unique(freqs, axis=axis)):
+            warnings.warn("Frequencies are not unique. This may produce incorrect harmonic interpolations.")
+
         # If we have time-varying frequencies, then it must match exactly the shape of the input
 
         # We'll define a frame-wise interpolator helper function that we will vectorize over

--- a/librosa/util/__init__.py
+++ b/librosa/util/__init__.py
@@ -47,6 +47,8 @@ Miscellaneous
     cyclic_gradient
     dtype_c2r
     dtype_r2c
+    count_unique
+    is_unique
 
 
 Input validation

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1573,6 +1573,16 @@ def test_harmonics_2d():
             assert np.allclose(vals, yh[i, : len(vals)])
 
 
+def test_harmonics_1d_nonunique():
+    x = np.arange(-8, 8)**2
+    y = np.linspace(-8, 8, num=len(x), endpoint=False) ** 2
+
+    h = [0.25, 0.5, 1, 2, 4]
+
+    with pytest.warns(UserWarning):
+        yh = librosa.interp_harmonics(y, x, h, axis=0)
+
+
 @pytest.mark.xfail(raises=librosa.ParameterError)
 def test_harmonics_badshape_1d():
     freqs = np.zeros(100)
@@ -1610,6 +1620,18 @@ def test_harmonics_2d_varying():
             step = h[i]
             vals = y[::step]
             assert np.allclose(vals, yh[i, : len(vals)])
+
+
+def test_harmonics_2d_varying_nonunique():
+
+    x = np.arange(-8, 8) ** 2
+    y = np.linspace(-8, 8, num=len(x), endpoint=False) ** 2
+    x = np.tile(x, (5, 1)).T
+    y = np.tile(y, (5, 1)).T
+    h = [0.25, 0.5, 1, 2, 4]
+
+    with pytest.warns(UserWarning):
+        yh = librosa.interp_harmonics(y, x, h, axis=-2)
 
 
 def test_show_versions():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1315,3 +1315,25 @@ def test_expand_to_2d(axes, ndim):
     # Verify that we have 1s on expanded dims
     for i, ax in enumerate(axes):
         assert xout.shape[ax] == x.shape[i]
+
+
+def test_count_unique():
+
+    x = np.vander(np.arange(5))
+
+    x0 = librosa.util.count_unique(x, axis=0)
+    x1 = librosa.util.count_unique(x, axis=1)
+
+    assert np.allclose(x0, [5, 5, 5, 5, 1])
+    assert np.allclose(x1, [2, 1, 5, 5, 5])
+
+
+def test_is_unique():
+
+    x = np.vander(np.arange(5))
+
+    x0 = librosa.util.is_unique(x, axis=0)
+    x1 = librosa.util.is_unique(x, axis=1)
+
+    assert np.allclose(x0, [True, True, True, True, False])
+    assert np.allclose(x1, [False, False, True, True, True])


### PR DESCRIPTION
#### Reference Issue
Fixes #1358 


#### What does this implement/fix? Explain your changes.

This PR adds a check to harmonic interpolation to detect when frequencies are non-unique.  Since interpolator behavior is undefined in this case, we issue a warning here but allow the interpolator to proceed.

This works both for the 1d (fixed frequency) case and the time-varying / reassigned spectrogram case.  In the latter, uniqueness is verified independently at each frame.

#### Any other comments?

This PR also adds a couple of helper routines to util: `count_unique` and `is_unique`.  Only the latter is used, but the former might come in handy at some point in the future.  Both are simple applications of `np.apply_along_axis`, and a little numba acceleration is included to keep the overhead low.

I think there's not much to this PR, and it should be merge-ready when CI passes.