### PR TITLE
[CR] add soundfile object handling to load and stream

### DIFF
--- a/.github/environment-ci.yml
+++ b/.github/environment-ci.yml
@@ -25,6 +25,7 @@ dependencies:
   - contextlib2
   - coverage
   - ffmpeg
+  - tomli<2.0
   - pip:
     - soxr
     - samplerate

--- a/.github/environment-minimal.yml
+++ b/.github/environment-minimal.yml
@@ -25,6 +25,7 @@ dependencies:
   - contextlib2
   - coverage
   - ffmpeg
+  - tomli<2.0
   - pip:
     - soxr
     - samplerate

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -731,10 +731,11 @@ def get_samplerate(path):
 
     Parameters
     ----------
-    path : string, int, or file-like
+    path : string, int, soundfile.SoundFile, or file-like
         The path to the file to be loaded
         As in ``load``, this can also be an integer or open file-handle
         that can be processed by `soundfile`.
+        An existing `soundfile.SoundFile` object can also be supplied.
 
     Returns
     -------
@@ -750,6 +751,9 @@ def get_samplerate(path):
     22050
     """
     try:
+        if isinstance(path, sf.SoundFile):
+            return path.samplerate
+
         return sf.info(path).samplerate
     except RuntimeError:
         with audioread.audio_open(path) as fdesc:

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -61,7 +61,7 @@ def load(
 
     Parameters
     ----------
-    path : string, int, pathlib.Path or file-like object
+    path : string, int, pathlib.Path, soundfile.SoundFile or file-like object
         path to the input file.
 
         Any codec supported by `soundfile` or `audioread` will work.
@@ -70,7 +70,7 @@ def load(
         file interface (e.g. `pathlib.Path`) are supported as `path`.
 
         If the codec is supported by `soundfile`, then `path` can also be
-        an open file descriptor (int).
+        an open file descriptor (int) or an existing `soundfile.SoundFile` object.
 
         On the contrary, if the codec is not supported by `soundfile`
         (for example, MP3), then `path` must be a file path (string or `pathlib.Path`).
@@ -146,7 +146,15 @@ def load(
     """
 
     try:
-        with sf.SoundFile(path) as sf_desc:
+        if isinstance(path, sf.SoundFile):
+            # If the user passed an existing soundfile object,
+            # we can use it directly
+            context = path
+        else:
+            # Otherwise, create the soundfile object
+            context = sf.SoundFile(path)
+
+        with context as sf_desc:
             sr_native = sf_desc.samplerate
             if offset:
                 # Seek to the start of the target read

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2085,6 +2085,17 @@ def test_get_samplerate(ext):
     assert sr == 22050
 
 
+def test_get_samplerate_soundfile():
+
+    path = os.path.join("tests", "data", os.path.extsep.join(["test1_22050", "wav"]))
+
+    sfo = soundfile.SoundFile(path)
+
+    sr2 = librosa.get_samplerate(sfo)
+
+    assert sr2 == 22050
+
+
 @pytest.fixture(params=["as_file", "as_string"])
 def path(request):
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2096,7 +2096,7 @@ def test_get_samplerate_soundfile():
     assert sr2 == 22050
 
 
-@pytest.fixture(params=["as_file", "as_string"])
+@pytest.fixture(params=["as_file", "as_string", "as_sfo"])
 def path(request):
 
     # test data is stereo, int 16
@@ -2106,6 +2106,9 @@ def path(request):
         yield path
     elif request.param == "as_file":
         with open(path, "rb") as f:
+            yield f
+    elif request.param == "as_sfo":
+        with soundfile.SoundFile(path) as f:
             yield f
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -13,6 +13,7 @@ try:
 except:
     pass
 
+import soundfile
 import librosa
 import glob
 import numpy as np
@@ -51,6 +52,21 @@ def test_load(infile):
     assert sr == DATA["sr"]
 
     assert np.allclose(y, DATA["y"])
+
+
+def test_load_soundfile():
+
+    fname = os.path.join("tests", "data", "test1_44100.wav")
+    # Load from filename
+    y, sr = librosa.load(fname, sr=None, mono=False)
+
+    # Load from soundfile object
+
+    sfo = soundfile.SoundFile(fname)
+    y2, sr2 = librosa.load(sfo, sr=None, mono=False)
+
+    assert np.allclose(y, y2)
+    assert np.isclose(sr, sr2)
 
 
 @pytest.mark.parametrize("res_type", ["kaiser_fast", "kaiser_best", "scipy"])


### PR DESCRIPTION
#### Reference Issue
Fixes #1349 (indirectly)


#### What does this implement/fix? Explain your changes.
This PR adds support for existing soundfile objects in load and stream.  This makes it possible to work with raw objects, and provides a way for users to completely control the decoding process within our input wrappers.  This will obviate the need for exposing more API through `load` so that #1349 is no longer an issue.

#### Any other comments?

This is WIP; load works as expected, but stream will take a bit of refactoring.

I guess we should also extend this to `get_duration` and `get_samplerate`.