### PR TITLE
Update CI build matrix and dependency versions

### DIFF
--- a/.github/environment-ci.yml
+++ b/.github/environment-ci.yml
@@ -25,7 +25,6 @@ dependencies:
   - contextlib2
   - coverage
   - ffmpeg
-  - tomli<2.0
   - pip:
     - soxr
     - samplerate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,6 @@ jobs:
                       name: "Minimal dependencies"
 
                     - os: ubuntu-latest
-                      python-version: "3.6"
-                      channel-priority: "strict"
-                      envfile: ".github/environment-ci.yml"
-
-                    - os: ubuntu-latest
                       python-version: "3.7"
                       channel-priority: "strict"
                       envfile: ".github/environment-ci.yml"

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,4 +81,4 @@ tests =
     samplerate
     soxr
 display =
-    matplotlib >= 1.5
+    matplotlib >= 3.3.0


### PR DESCRIPTION

#### Reference Issue

Fixes #1419 

#### What does this implement/fix? Explain your changes.

This PR removes python 3.6 from the main build matrix, but keeps it for the "minimal" environment.  This ensures that our latest stable dependencies continue to be tested properly.

#### Any other comments?

I think we can keep 3.6 as the official minimal supported python for the 0.9 release.  This puts us a bit behind some other packages, but we have no explicit need for bumping to 3.7 just yet, and it does no harm to leave it as is.

No CR necessary on this, I'll merge when tests pass.

I've also updated the setup.cfg to reflect our recent changes to matplotlib requirements.  There was a mis-specification in our earlier change there.