### PR TITLE
fixed off-by-one in yin/pyin difference calculation, fixes #1425

### DIFF
--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -399,7 +399,7 @@ def _cumulative_mean_normalized_difference(
     """
     # Autocorrelation.
     a = np.fft.rfft(y_frames, frame_length, axis=-2)
-    b = np.fft.rfft(y_frames[..., win_length::-1, :], frame_length, axis=-2)
+    b = np.fft.rfft(y_frames[..., win_length:0:-1, :], frame_length, axis=-2)
     acf_frames = np.fft.irfft(a * b, frame_length, axis=-2)[..., win_length:, :]
     acf_frames[np.abs(acf_frames) < 1e-6] = 0
 


### PR DESCRIPTION
#### Reference Issue
Fixes #1425 


#### What does this implement/fix? Explain your changes.

This PR implements the correction to yin's autocorrelation noted in #1425.

The only real difference here is the inclusion (exclusion) of the 0th sample per frame in the autocorrelation calculation.  It's a little ambiguous in the yin paper about how this should be handled, though the matlab code does seem to exclude it.  Our previous implementation (0.8 series) included it, and #1425 notes that it can produce some very small frame modulation artifacts in the resulting f0.

I'm not 100% sure I understand this, but I expect it comes down to analyzing a frame of length `win_length+1` and interpreting it as a frame of length `win_length`; the forced padding in the rfft calculations obscured this point for us.

#### Any other comments?

The change in behavior here is quite miniscule, on the order of hundreths of a Hz.  I don't think anyone will be impacted much by this change, but it does stabilize the detection behavior a little bit.
