### PR TITLE
Remove unnecessary dynamic __all__ modifications

### DIFF
--- a/librosa/__init__.py
+++ b/librosa/__init__.py
@@ -201,8 +201,6 @@ Miscellaneous
     set_fftlib
 """
 
-import warnings
-import sys
 from .version import version as __version__
 from .version import show_versions
 

--- a/librosa/core/__init__.py
+++ b/librosa/core/__init__.py
@@ -12,4 +12,12 @@ from .fft import *  # pylint: disable=wildcard-import
 from .notation import *  # pylint: disable=wildcard-import
 
 
-__all__ = [_ for _ in dir() if not _.startswith("_")]
+__all__ = []
+__all__ += convert.__all__
+__all__ += audio.__all__
+__all__ += spectrum.__all__
+__all__ += pitch.__all__
+__all__ += constantq.__all__
+__all__ += harmonic.__all__
+__all__ += fft.__all__
+__all__ += notation.__all__

--- a/librosa/core/__init__.py
+++ b/librosa/core/__init__.py
@@ -10,14 +10,3 @@ from .constantq import *  # pylint: disable=wildcard-import
 from .harmonic import *  # pylint: disable=wildcard-import
 from .fft import *  # pylint: disable=wildcard-import
 from .notation import *  # pylint: disable=wildcard-import
-
-
-__all__ = []
-__all__ += convert.__all__
-__all__ += audio.__all__
-__all__ += spectrum.__all__
-__all__ += pitch.__all__
-__all__ += constantq.__all__
-__all__ += harmonic.__all__
-__all__ += fft.__all__
-__all__ += notation.__all__

--- a/librosa/feature/__init__.py
+++ b/librosa/feature/__init__.py
@@ -58,8 +58,3 @@ from .utils import *  # pylint: disable=wildcard-import
 from .spectral import *  # pylint: disable=wildcard-import
 from .rhythm import *  # pylint: disable=wildcard-import
 from . import inverse
-
-__all__ = ["inverse"]
-__all__ += utils.__all__
-__all__ += spectral.__all__
-__all__ += rhythm.__all__

--- a/librosa/feature/__init__.py
+++ b/librosa/feature/__init__.py
@@ -59,4 +59,7 @@ from .spectral import *  # pylint: disable=wildcard-import
 from .rhythm import *  # pylint: disable=wildcard-import
 from . import inverse
 
-__all__ = [_ for _ in dir() if not _.startswith("_")]
+__all__ = ["inverse"]
+__all__ += utils.__all__
+__all__ += spectral.__all__
+__all__ += rhythm.__all__

--- a/librosa/util/__init__.py
+++ b/librosa/util/__init__.py
@@ -82,4 +82,9 @@ from ._nnls import *  # pylint: disable=wildcard-import
 from . import decorators
 from . import exceptions
 
-__all__ = [_ for _ in dir() if not _.startswith("_")]
+__all__ = ["decorators", "exceptions"]
+__all__ = utils.__all__
+__all__ = files.__all__
+__all__ = matching.__all__
+__all__ = deprecation.__all__
+__all__ = _nnls.__all__

--- a/librosa/util/__init__.py
+++ b/librosa/util/__init__.py
@@ -81,10 +81,3 @@ from .deprecation import *  # pylint: disable=wildcard-import
 from ._nnls import *  # pylint: disable=wildcard-import
 from . import decorators
 from . import exceptions
-
-__all__ = ["decorators", "exceptions"]
-__all__ = utils.__all__
-__all__ = files.__all__
-__all__ = matching.__all__
-__all__ = deprecation.__all__
-__all__ = _nnls.__all__

--- a/librosa/util/deprecation.py
+++ b/librosa/util/deprecation.py
@@ -5,7 +5,6 @@
 import inspect
 import warnings
 
-__all__ = ["Deprecated", "rename_kw"]
 
 class Deprecated(object):
     """A dummy class to catch usage of deprecated variable names"""

--- a/librosa/util/deprecation.py
+++ b/librosa/util/deprecation.py
@@ -5,6 +5,7 @@
 import inspect
 import warnings
 
+__all__ = ["Deprecated", "rename_kw"]
 
 class Deprecated(object):
     """A dummy class to catch usage of deprecated variable names"""


### PR DESCRIPTION
#### Reference Issue

Fixes #1429 

![image](https://user-images.githubusercontent.com/3620703/147814251-228bfa71-d8d5-4ee0-9f75-a1f76d3d3578.png)

#### What does this implement/fix? Explain your changes.

This PR makes librosa conformant with the official [library interface standard](https://github.com/python/typing/blob/master/docs/source/libraries.rst#library-interface).

#### Any other comments?

It turned out that that the number of dynamic `__all__` usages is actually quite manageable. Also wildcard usage isn't an issue, i.e., there is no need to also list all symbols everywhere in the imports. So overall, the change would be relatively minor actually.

