### PR TITLE
Warning stacklevels

### DIFF
--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -171,7 +171,8 @@ def load(
     except RuntimeError as exc:
         # If soundfile failed, try audioread instead
         if isinstance(path, (str, pathlib.PurePath)):
-            warnings.warn("PySoundFile failed. Trying audioread instead.")
+            warnings.warn("PySoundFile failed. Trying audioread instead.",
+                          stacklevel=2)
             y, sr_native = __audioread_load(path, offset, duration, dtype)
         else:
             raise (exc)

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -1381,7 +1381,8 @@ def griffinlim_cqt(
     if momentum > 1:
         warnings.warn(
             "Griffin-Lim with momentum={} > 1 can be unstable. "
-            "Proceed with caution!".format(momentum)
+            "Proceed with caution!".format(momentum),
+            stacklevel=2
         )
     elif momentum < 0:
         raise ParameterError(

--- a/librosa/core/harmonic.py
+++ b/librosa/core/harmonic.py
@@ -226,7 +226,8 @@ def interp_harmonics(x, *, freqs, harmonics, kind="linear", fill_value=0, axis=-
         # First, verify that the input frequencies are unique
         if not is_unique(freqs, axis=0):
             warnings.warn(
-                "Frequencies are not unique. This may produce incorrect harmonic interpolations."
+                "Frequencies are not unique. This may produce incorrect harmonic interpolations.",
+                stacklevel=2
             )
 
         f_interp = scipy.interpolate.interp1d(
@@ -248,7 +249,8 @@ def interp_harmonics(x, *, freqs, harmonics, kind="linear", fill_value=0, axis=-
     elif freqs.shape == x.shape:
         if not np.all(is_unique(freqs, axis=axis)):
             warnings.warn(
-                "Frequencies are not unique. This may produce incorrect harmonic interpolations."
+                "Frequencies are not unique. This may produce incorrect harmonic interpolations.",
+                stacklevel=2
             )
 
         # If we have time-varying frequencies, then it must match exactly the shape of the input

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -160,7 +160,7 @@ def pitch_tuning(frequencies, *, resolution=0.01, bins_per_octave=12):
     frequencies = frequencies[frequencies > 0]
 
     if not np.any(frequencies):
-        warnings.warn("Trying to estimate tuning from empty frequency set.")
+        warnings.warn("Trying to estimate tuning from empty frequency set.", stacklevel=2)
         return 0.0
 
     # Compute the residual relative to the number of bins

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -222,7 +222,8 @@ def stft(
             warnings.warn(
                 "n_fft={} is too small for input signal of length={}".format(
                     n_fft, y.shape[-1]
-                )
+                ),
+                stacklevel=2
             )
 
         padding = [(0, 0) for _ in range(y.ndim)]
@@ -1596,7 +1597,8 @@ def power_to_db(S, *, ref=1.0, amin=1e-10, top_db=80.0):
         warnings.warn(
             "power_to_db was called on complex input so phase "
             "information will be discarded. To suppress this warning, "
-            "call power_to_db(np.abs(D)**2) instead."
+            "call power_to_db(np.abs(D)**2) instead.",
+            stacklevel=2,
         )
         magnitude = np.abs(S)
     else:
@@ -1693,7 +1695,8 @@ def amplitude_to_db(S, *, ref=1.0, amin=1e-5, top_db=80.0):
         warnings.warn(
             "amplitude_to_db was called on complex input so phase "
             "information will be discarded. To suppress this warning, "
-            "call amplitude_to_db(np.abs(S)) instead."
+            "call amplitude_to_db(np.abs(S)) instead.",
+            stacklevel=2
         )
 
     magnitude = np.abs(S)
@@ -2225,7 +2228,8 @@ def pcen(
         warnings.warn(
             "pcen was called on complex input so phase "
             "information will be discarded. To suppress this warning, "
-            "call pcen(np.abs(D)) instead."
+            "call pcen(np.abs(D)) instead.",
+            stacklevel=2
         )
         S = np.abs(S)
 
@@ -2425,7 +2429,8 @@ def griffinlim(
     if momentum > 1:
         warnings.warn(
             "Griffin-Lim with momentum={} > 1 can be unstable. "
-            "Proceed with caution!".format(momentum)
+            "Proceed with caution!".format(momentum),
+            stacklevel=2
         )
     elif momentum < 0:
         raise ParameterError(

--- a/librosa/display.py
+++ b/librosa/display.py
@@ -851,7 +851,8 @@ def specshow(
 
     if np.issubdtype(data.dtype, np.complexfloating):
         warnings.warn(
-            "Trying to display complex-valued input. " "Showing magnitude instead."
+            "Trying to display complex-valued input. " "Showing magnitude instead.",
+            stacklevel=2
         )
         data = np.abs(data)
 
@@ -1240,7 +1241,8 @@ def __coord_cqt_hz(n, fmin=None, bins_per_octave=12, sr=22050, **_kwargs):
     if np.any(freqs > 0.5 * sr):
         warnings.warn(
             "Frequency axis exceeds Nyquist. "
-            "Did you remember to set all spectrogram parameters in specshow?"
+            "Did you remember to set all spectrogram parameters in specshow?",
+            stacklevel=4,
         )
 
     return freqs

--- a/librosa/feature/inverse.py
+++ b/librosa/feature/inverse.py
@@ -251,6 +251,7 @@ def mfcc_to_mel(mfcc, *, n_mels=128, dct_type=2, norm="ortho", ref=1.0, lifter=0
             warnings.warn(
                 message="lifter array includes critial values that may invoke underflow.",
                 category=UserWarning,
+                stacklevel=2,
             )
 
         # lifter mfcc values

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -252,7 +252,7 @@ def mel(
             "Empty filters detected in mel frequency basis. "
             "Some channels will produce empty responses. "
             "Try increasing your sampling rate (and fmax) or "
-            "reducing n_mels."
+            "reducing n_mels.",
         )
 
     return weights
@@ -433,7 +433,6 @@ def __float_window(window_spec):
     return _wrap
 
 
-@cache(level=10)
 @deprecated(version="0.9.0", version_removed="1.0")
 def constant_q(
     *,
@@ -598,8 +597,8 @@ def constant_q(
     return filters, np.asarray(lengths)
 
 
-@cache(level=10)
 @deprecated(version="0.9.0", version_removed="1.0")
+@cache(level=10)
 def constant_q_lengths(
     *, sr, fmin, n_bins=84, bins_per_octave=12, window="hann", filter_scale=1, gamma=0
 ):

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -253,6 +253,7 @@ def mel(
             "Some channels will produce empty responses. "
             "Try increasing your sampling rate (and fmax) or "
             "reducing n_mels.",
+            stacklevel=2,
         )
 
     return weights

--- a/librosa/util/decorators.py
+++ b/librosa/util/decorators.py
@@ -18,8 +18,7 @@ def moved(*, moved_from, version, version_removed):
 
     def __wrapper(func, *args, **kwargs):
         """Warn the user, and then proceed."""
-        code = func.__code__
-        warnings.warn_explicit(
+        warnings.warn(
             "{:s}\n\tThis function was moved to '{:s}.{:s}' in "
             "librosa version {:s}."
             "\n\tThis alias will be removed in librosa version "
@@ -27,8 +26,7 @@ def moved(*, moved_from, version, version_removed):
                 moved_from, func.__module__, func.__name__, version, version_removed
             ),
             category=DeprecationWarning,
-            filename=code.co_filename,
-            lineno=code.co_firstlineno + 1,
+            stacklevel=3  # Would be 2, but the decorator adds a level
         )
         return func(*args, **kwargs)
 
@@ -43,15 +41,13 @@ def deprecated(*, version, version_removed):
 
     def __wrapper(func, *args, **kwargs):
         """Warn the user, and then proceed."""
-        code = func.__code__
-        warnings.warn_explicit(
+        warnings.warn(
             "{:s}.{:s}\n\tDeprecated as of librosa version {:s}."
             "\n\tIt will be removed in librosa version {:s}.".format(
                 func.__module__, func.__name__, version, version_removed
             ),
             category=DeprecationWarning,
-            filename=code.co_filename,
-            lineno=code.co_firstlineno + 1,
+            stacklevel=3  # Would be 2, but the decorator adds a level
         )
         return func(*args, **kwargs)
 

--- a/librosa/util/deprecation.py
+++ b/librosa/util/deprecation.py
@@ -50,9 +50,8 @@ def rename_kw(
     else:
         stack = inspect.stack()
         dep_func = stack[1]
-        caller = stack[2]
 
-        warnings.warn_explicit(
+        warnings.warn(
             "{:s}() keyword argument '{:s}' has been "
             "renamed to '{:s}' in version {:}."
             "\n\tThis alias will be removed in version "
@@ -60,8 +59,7 @@ def rename_kw(
                 dep_func[3], old_name, new_name, version_deprecated, version_removed
             ),
             category=DeprecationWarning,
-            filename=caller[1],
-            lineno=caller[2],
+            stacklevel=3,
         )
 
         return old_value

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -2157,7 +2157,7 @@ def dtype_r2c(d, *, default=np.complex64):
     mapping = {
         np.dtype(np.float32): np.complex64,
         np.dtype(np.float64): np.complex128,
-        np.dtype(np.float): np.dtype(np.complex).type,
+        np.dtype(float): np.dtype(complex).type,
     }
 
     # If we're given a complex type already, return it


### PR DESCRIPTION
#### Reference Issue
Fixes #1432 


#### What does this implement/fix? Explain your changes.
This PR adds stacklevels to warnings issued by librosa.

#### Any other comments?

As noted in #1432, this is actually a bit more delicate than I initially thought.  Some basic rules here:

1. deprecations should always come outside of caching
2. warnings generated by cached functions are tricky to manage.  I haven't resolved this completely yet.
3. Stacklevel should be 2 for functions that are called directly by users, but can be larger for internal functions.  This gets messy quite rapidly.

Additionally, I've rolled in some minor cleanups to better deal with upstream deprecations that were previously swept under the rug, see #1350 .

