### PR TITLE
0.9.0rc0 release preparation

### DIFF
--- a/.github/environment-minimal.yml
+++ b/.github/environment-minimal.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   # required
-  - pip
+  - pip<22.0
   - audioread==2.1.5
   - numpy==1.17.0
   - scipy==1.2.0

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -6,7 +6,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - run: pip install bandit codespell flake8
+      - run: pip install bandit codespell flake8 velin
       - run: bandit --recursive --skip B101,B110 .
       - run: codespell --ignore-words-list="ba,trough,ue" --skip="*demo.ipynb"
       - run: flake8 librosa --count --select=E9,F63,F7,F82 --show-source --statistics
+      - run: python -m velin --check librosa

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -77,7 +77,10 @@ Contributors
 * N. Dorukhan Sergin <https://github.com/dorukhansergin>
 * Paul Biberstein <https://github.com/P-bibs>
 * Myungchul Keum <https://github.com/dofuuz>
-
+* Daniel Faronbi <https://github.com/dafaronbi>
+* Iran Roman <https://github.com/iranroman>
+* philstem <https://github.com/philstem>
+* Alex Malins <https://github.com/alexmalins>
 
 Some feature extraction code was based on <https://github.com/ronw/frontend> by Ron Weiss.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,87 @@
 Changelog
 *********
 
+v0.9.0
+======
+2022-02-??
+
+The main feature of this release is (nearly) full support for arbitrary multi-channel processing, along with several speed and stability enhancements.
+A detailed list of changes is provided below.
+
+New Features
+    - `#1130`_ Nearly full support for multi-channel processing. *Brian McFee, Daniel Faronbi, Iran Roman*
+    - `#1331`_ Option to disable unicode characters in display functions. *Brian McFee*
+    - `#1441`_ Significantly expanded the library of example audio clips. *Brian McFee*
+
+API changes
+    - `#1114`_ Most functions now require keyword arguments. *Brian McFee*
+    - `#1382`_ The default padding mode for most functions (including STFT) is now zero-padding. *Brian McFee*
+    - `#1418`_ `librosa.load` and `librosa.stream` can now operate directly on open `soundfile` objects. *Brian McFee*
+    - `#1414`_ `librosa.display.specshow` now uses centered coordinate grids. *Brian McFee*
+    - `#1398`_ `librosa.iirt` now exposes API control over resampling modes. *Brian McFee*
+    - `#1416`_ Removed deprecated functions `librosa.display.waveplot` and `librosa.util.example_audio_file`. *Brian McFee*
+
+Bug fixes
+    - `#1387`_ Fixed errors in support of odd frame lengths in various functions. *Brian McFee*
+    - `#1273`_ Minor corrections to constants in perceptual weighting functions. *Brian McFee*
+    - `#1350`_ Removed uses of deprecated numpy numerical types. *Brian McFee*
+    - `#1361`_ Maximum frequency is now correctly inferred as Nyquist in onset strength calculation. *Brian McFee*
+    - `#1362`_ `librosa.effects.deemphasis` no longer modifies the input signal in-place. *Brian McFee*
+    - `#1375`_ `librosa.util.frame` now correctly works for arbitrary memory layouts and numbers of axes. *Brian McFee*
+    - `#1425`_ Fixed an off-by-one error in `librosa.yin` and `librosa.pyin`. *@philstem, Brian McFee*
+    - `#1430`_ Removed unnecessary `__all__` specifications to better support static analysis. *Fabian Keller*
+    - `#1407`_ Corrected a normalization error in inverse CQT. *Brian McFee, Vincent Lostanlen*
+
+Documentation
+    - `#1328`_ Retired the `examples/` folder and expanded the `Advanced Examples` gallery. *Brian McFee*
+    - `#1427`_ Fixed docstring for `librosa.core.reassigned_spectrogram`. *Fabian Keller*
+
+Other changes
+    - `#418`_ `librosa.cqt` now supports arbitrary hop lengths. *Brian McFee*
+    - `#1405`_ Improvements and generalizations to constant-Q/variable-Q basis construction. *Brian McFee, Vincent Lostanlen*
+    - `#1324`_ Added a run-time check for minimally supported matplotlib versions. *Brian McFee*
+    - `#1325`_ Enhanced continuous integration testing for oldest and newest environments. *Brian McFee*
+    - `#1358`_ Harmonic interpolation now preemptively detects repeated values that produce unstable estimates. *Brian McFee*
+    - `#1432`_ Specify stack levels in warnings to provide more helpful warning messages. *Brian McFee*
+    - `#1404`_, `#1406`_ Improved packaging configurations. *Alex Malins*
+    - `#1384`_ Fixed package configuration error for documentation builds. *Adam Weiss*
+
+Deprecations
+    - `#1389`_ The `mono` parameter of `librosa.util.valid_audio` is deprecated and the default is now set to `False`. *Brian McFee*
+    - `#1405`_ CQT filter-bank constructors `librosa.filters.constant_q` are now deprecated in favor of `librosa.filters.wavelet`. *Brian McFee, Vincent Lostanlen*
+
+
+.. _#418: https://github.com/librosa/librosa/issues/418
+.. _#1114: https://github.com/librosa/librosa/issues/1114
+.. _#1130: https://github.com/librosa/librosa/issues/1130
+.. _#1273: https://github.com/librosa/librosa/issues/1273
+.. _#1324: https://github.com/librosa/librosa/issues/1324
+.. _#1325: https://github.com/librosa/librosa/issues/1325
+.. _#1328: https://github.com/librosa/librosa/issues/1328
+.. _#1331: https://github.com/librosa/librosa/issues/1331
+.. _#1350: https://github.com/librosa/librosa/issues/1350
+.. _#1358: https://github.com/librosa/librosa/issues/1358
+.. _#1361: https://github.com/librosa/librosa/issues/1361
+.. _#1362: https://github.com/librosa/librosa/issues/1362
+.. _#1375: https://github.com/librosa/librosa/issues/1375
+.. _#1382: https://github.com/librosa/librosa/issues/1382
+.. _#1384: https://github.com/librosa/librosa/issues/1384
+.. _#1387: https://github.com/librosa/librosa/issues/1387
+.. _#1389: https://github.com/librosa/librosa/issues/1389
+.. _#1398: https://github.com/librosa/librosa/issues/1398
+.. _#1404: https://github.com/librosa/librosa/issues/1404
+.. _#1405: https://github.com/librosa/librosa/issues/1405
+.. _#1406: https://github.com/librosa/librosa/issues/1406
+.. _#1407: https://github.com/librosa/librosa/issues/1407
+.. _#1414: https://github.com/librosa/librosa/issues/1414
+.. _#1416: https://github.com/librosa/librosa/issues/1416
+.. _#1418: https://github.com/librosa/librosa/issues/1418
+.. _#1425: https://github.com/librosa/librosa/issues/1425
+.. _#1427: https://github.com/librosa/librosa/issues/1427
+.. _#1430: https://github.com/librosa/librosa/issues/1430
+.. _#1432: https://github.com/librosa/librosa/issues/1432
+.. _#1441: https://github.com/librosa/librosa/issues/1441
+
 v0.8
 ====
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,8 +2,12 @@
 Changelog
 *********
 
+v0.9
+====
+
 v0.9.0
-======
+------
+
 2022-02-??
 
 The main feature of this release is (nearly) full support for arbitrary multi-channel processing, along with several speed and stability enhancements.
@@ -35,7 +39,7 @@ Bug fixes
 
 Documentation
     - `#1328`_ Retired the `examples/` folder and expanded the `Advanced Examples` gallery. *Brian McFee*
-    - `#1427`_ Fixed docstring for `librosa.core.reassigned_spectrogram`. *Fabian Keller*
+    - `#1427`_ Fixed docstring for `librosa.reassigned_spectrogram`. *Fabian Keller*
 
 Other changes
     - `#418`_ `librosa.cqt` now supports arbitrary hop lengths. *Brian McFee*

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -390,7 +390,7 @@ texinfo_documents = [
 autodoc_member_order = "bysource"
 
 smv_branch_whitelist = r"^(main)$"  # build main branch, and anything relating to documentation
-smv_tag_whitelist = r"^((0\.7\.2)|(0\.[89]\.\d+)|(0\.9\.0rc0)$"  # use this for final builds
+smv_tag_whitelist = r"^((0\.7\.2)|(0\.[89]\.\d+)|(0\.9\.0rc0))$"  # use this for final builds
 smv_released_pattern = r'.*tags.*'
 smv_remote_whitelist = None
 smv_greatest_tag = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -390,7 +390,7 @@ texinfo_documents = [
 autodoc_member_order = "bysource"
 
 smv_branch_whitelist = r"^(main)$"  # build main branch, and anything relating to documentation
-smv_tag_whitelist = r"^((0\.7\.2)|(0\.[89]\.\d+))$"  # use this for final builds
+smv_tag_whitelist = r"^((0\.7\.2)|(0\.[89]\.\d+)|(0\.9\.0rc0)$"  # use this for final builds
 smv_released_pattern = r'.*tags.*'
 smv_remote_whitelist = None
 smv_greatest_tag = True

--- a/librosa/beat.py
+++ b/librosa/beat.py
@@ -557,7 +557,7 @@ def __beat_tracker(onset_envelope, bpm, fft_res, tightness, trim):
         tempo estimate
     fft_res : float [scalar]
         resolution of the fft (sr / hop_length)
-    tightness: float [scalar]
+    tightness : float [scalar]
         how closely do we adhere to bpm?
     trim : bool [scalar]
         trim leading/trailing beats with weak onsets?

--- a/librosa/beat.py
+++ b/librosa/beat.py
@@ -51,58 +51,42 @@ def beat_track(
            Journal of New Music Research 36.1 (2007): 51-60.
            http://labrosa.ee.columbia.edu/projects/beattrack/
 
-
     Parameters
     ----------
-
     y : np.ndarray [shape=(n,)] or None
         audio time series
-
     sr : number > 0 [scalar]
         sampling rate of ``y``
-
     onset_envelope : np.ndarray [shape=(n,)] or None
         (optional) pre-computed onset strength envelope.
-
     hop_length : int > 0 [scalar]
         number of audio samples between successive ``onset_envelope`` values
-
-    start_bpm  : float > 0 [scalar]
+    start_bpm : float > 0 [scalar]
         initial guess for the tempo estimator (in beats per minute)
-
-    tightness  : float [scalar]
+    tightness : float [scalar]
         tightness of beat distribution around tempo
-
-    trim       : bool [scalar]
+    trim : bool [scalar]
         trim leading/trailing beats with weak onsets
-
-    bpm        : float [scalar]
+    bpm : float [scalar]
         (optional) If provided, use ``bpm`` as the tempo instead of
         estimating it from ``onsets``.
-
-    prior      : scipy.stats.rv_continuous [optional]
+    prior : scipy.stats.rv_continuous [optional]
         An optional prior distribution over tempo.
         If provided, ``start_bpm`` will be ignored.
-
     units : {'frames', 'samples', 'time'}
         The units to encode detected beat events in.
         By default, 'frames' are used.
 
-
     Returns
     -------
-
     tempo : float [scalar, non-negative]
         estimated global tempo (in beats per minute)
-
     beats : np.ndarray [shape=(m,)]
         estimated beat event locations in the specified units
         (default is frame indices)
-
     .. note::
         If no onset strength could be detected, beat_tracker estimates 0 BPM
         and returns an empty list.
-
 
     Raises
     ------
@@ -114,7 +98,6 @@ def beat_track(
     --------
     librosa.onset.onset_strength
 
-
     Examples
     --------
     Track beats using time series input
@@ -125,13 +108,11 @@ def beat_track(
     >>> tempo
     135.99917763157896
 
-
     Print the frames corresponding to beats
 
     >>> beats
     array([  3,  21,  40,  59,  78,  96, 116, 135, 154, 173, 192, 211,
            230, 249, 268, 287, 306, 325, 344, 363])
-
 
     Or print them as timestamps
 
@@ -151,7 +132,6 @@ def beat_track(
     >>> beats
     array([  3,  21,  40,  59,  78,  96, 116, 135, 154, 173, 192, 211,
            230, 249, 268, 287, 306, 325, 344, 363])
-
 
     Plot the beat events against the onset strength envelope
 
@@ -230,32 +210,23 @@ def tempo(
     ----------
     y : np.ndarray [shape=(..., n)] or None
         audio time series. Multi-channel is supported.
-
     sr : number > 0 [scalar]
         sampling rate of the time series
-
-    onset_envelope    : np.ndarray [shape=(..., n)]
+    onset_envelope : np.ndarray [shape=(..., n)]
         pre-computed onset strength envelope
-
     hop_length : int > 0 [scalar]
         hop length of the time series
-
     start_bpm : float [scalar]
         initial guess of the BPM
-
     std_bpm : float > 0 [scalar]
         standard deviation of tempo distribution
-
     ac_size : float > 0 [scalar]
         length (in seconds) of the auto-correlation window
-
     max_tempo : float > 0 [scalar, optional]
         If provided, only estimate tempo below this threshold
-
     aggregate : callable [optional]
         Aggregation function for estimating global tempo.
         If `None`, then tempo is estimated independently for each frame.
-
     prior : scipy.stats.rv_continuous [optional]
         A prior distribution over tempo (in beats per minute).
         By default, a pseudo-log-normal prior is used.
@@ -408,7 +379,6 @@ def plp(
     since `plp` does not require the entire signal to make predictions, it may be
     preferable when beat-tracking long recordings in a streaming setting.
 
-
     .. [#] Grosche, P., & Muller, M. (2011).
         "Extracting predominant local pulse information from music recordings."
         IEEE Transactions on Audio, Speech, and Language Processing, 19(6), 1688-1701.
@@ -494,7 +464,6 @@ def plp(
     ...          label='Predominant local pulse (PLP)')
     >>> ax[2].set(title='Log-normal tempo prior, mean=120', xlim=[5, 20])
     >>> ax[2].legend()
-
 
     PLP local maxima can be used as estimates of beat positions.
 
@@ -584,16 +553,12 @@ def __beat_tracker(onset_envelope, bpm, fft_res, tightness, trim):
     ----------
     onset_envelope : np.ndarray [shape=(n,)]
         onset strength envelope
-
     bpm : float [scalar]
         tempo estimate
-
-    fft_res  : float [scalar]
+    fft_res : float [scalar]
         resolution of the fft (sr / hop_length)
-
     tightness: float [scalar]
         how closely do we adhere to bpm?
-
     trim : bool [scalar]
         trim leading/trailing beats with weak onsets?
 

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -531,7 +531,7 @@ def resample(
         Scale the resampled signal so that ``y`` and ``y_hat`` have approximately
         equal total energy.
 
-    kwargs : additional keyword arguments
+    **kwargs : additional keyword arguments
         If ``fix==True``, additional keyword arguments to pass to
         `librosa.util.fix_length`.
 

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -76,7 +76,7 @@ def load(
         On the contrary, if the codec is not supported by `soundfile`
         (for example, MP3), then `path` must be a file path (string or `pathlib.Path`).
 
-    sr   : number > 0 [scalar]
+    sr : number > 0 [scalar]
         target sampling rate
 
         'None' uses the native sampling rate
@@ -106,15 +106,12 @@ def load(
 
            See :ref:`ioformats` for alternate loading methods.
 
-
     Returns
     -------
-    y    : np.ndarray [shape=(n,) or (..., n)]
+    y : np.ndarray [shape=(n,) or (..., n)]
         audio time series. Multi-channel is supported.
-
-    sr   : number > 0 [scalar]
+    sr : number > 0 [scalar]
         sampling rate of ``y``
-
 
     Examples
     --------
@@ -667,13 +664,13 @@ def get_duration(
         up to the frame resolution. If high precision is required,
         it is better to use the audio time series directly.
 
-    n_fft       : int > 0 [scalar]
+    n_fft : int > 0 [scalar]
         FFT window size for ``S``
 
-    hop_length  : int > 0 [ scalar]
+    hop_length : int > 0 [ scalar]
         number of audio samples between columns of ``S``
 
-    center  : boolean
+    center : boolean
         - If ``True``, ``S[:, t]`` is centered at ``y[t * hop_length]``
         - If ``False``, then ``S[:, t]`` begins at ``y[t * hop_length]``
 
@@ -774,11 +771,9 @@ def autocorrelate(y, *, max_size=None, axis=-1):
     ----------
     y : np.ndarray
         array to autocorrelate
-
-    max_size  : int > 0 or None
+    max_size : int > 0 or None
         maximum correlation lag.
         If unspecified, defaults to ``y.shape[axis]`` (unbounded)
-
     axis : int
         The axis along which to autocorrelate.
         By default, the last axis (-1) is taken.
@@ -859,10 +854,8 @@ def lpc(y, *, order, axis=-1):
     ----------
     y : np.ndarray [shape=(..., n)]
         Time series to fit. Multi-channel is supported..
-
     order : int > 0
         Order of the linear filter
-
     axis : int
         Axis along which to compute the coefficients
 
@@ -880,7 +873,7 @@ def lpc(y, *, order, axis=-1):
     FloatingPointError
         - If ``y`` is ill-conditioned
 
-    See also
+    See Also
     --------
     scipy.signal.lfilter
 
@@ -1033,7 +1026,6 @@ def zero_crossings(
     If ``y`` is multi-dimensional, then zero-crossings are computed along
     the specified ``axis``.
 
-
     Parameters
     ----------
     y : np.ndarray
@@ -1173,29 +1165,21 @@ def clicks(
     ----------
     times : np.ndarray or None
         times to place clicks, in seconds
-
     frames : np.ndarray or None
         frame indices to place clicks
-
     sr : number > 0
         desired sampling rate of the output signal
-
     hop_length : int > 0
         if positions are specified by ``frames``, the number of samples between frames.
-
     click_freq : float > 0
         frequency (in Hz) of the default click signal.  Default is 1KHz.
-
     click_duration : float > 0
         duration (in seconds) of the default click signal.  Default is 100ms.
-
     click : np.ndarray or None
         (optional) click signal sample to use instead of the default click.
         Multi-channel is supported.
-
     length : int > 0
         desired number of samples in the output signal
-
 
     Returns
     -------
@@ -1203,13 +1187,11 @@ def clicks(
         Synthesized click signal.
         This will be monophonic by default, or match the number of channels to a provided ``click`` signal.
 
-
     Raises
     ------
     ParameterError
         - If neither ``times`` nor ``frames`` are provided.
         - If any of ``click_freq``, ``click_duration``, or ``length`` are out of range.
-
 
     Examples
     --------
@@ -1307,36 +1289,29 @@ def tone(frequency, *, sr=22050, length=None, duration=None, phi=None):
     ----------
     frequency : float > 0
         frequency
-
     sr : number > 0
         desired sampling rate of the output signal
-
     length : int > 0
         desired number of samples in the output signal.
         When both ``duration`` and ``length`` are defined,
         ``length`` takes priority.
-
     duration : float > 0
         desired duration in seconds.
         When both ``duration`` and ``length`` are defined,
         ``length`` takes priority.
-
     phi : float or None
         phase offset, in radians. If unspecified, defaults to ``-np.pi * 0.5``.
-
 
     Returns
     -------
     tone_signal : np.ndarray [shape=(length,), dtype=float64]
         Synthesized pure sine tone signal
 
-
     Raises
     ------
     ParameterError
         - If ``frequency`` is not provided.
         - If neither ``length`` nor ``duration`` are provided.
-
 
     Examples
     --------
@@ -1408,12 +1383,10 @@ def chirp(*, fmin, fmax, sr=22050, length=None, duration=None, linear=False, phi
         phase offset, in radians.
         If unspecified, defaults to ``-np.pi * 0.5``.
 
-
     Returns
     -------
     chirp_signal : np.ndarray [shape=(length,), dtype=float64]
         Synthesized chirp signal
-
 
     Raises
     ------
@@ -1421,11 +1394,9 @@ def chirp(*, fmin, fmax, sr=22050, length=None, duration=None, linear=False, phi
         - If either ``fmin`` or ``fmax`` are not provided.
         - If neither ``length`` nor ``duration`` are provided.
 
-
     See Also
     --------
     scipy.signal.chirp
-
 
     Examples
     --------
@@ -1488,7 +1459,6 @@ def mu_compress(x, *, mu=255, quantize=True):
     is calculated by::
 
         sign(x) * ln(1 + mu * abs(x)) /  ln(1 + mu)
-
 
     Parameters
     ----------
@@ -1589,11 +1559,9 @@ def mu_expand(x, *, mu=255.0, quantize=True):
     x : np.ndarray
         The compressed signal.
         If ``quantize=True``, values must be in the range [-1, +1].
-
     mu : positive number
         The compression parameter.  Values of the form ``2**n - 1``
         (e.g., 15, 31, 63, etc.) are most common.
-
     quantize : boolean
         If ``True``, the input is assumed to be quantized to
         ``1 + mu`` distinct integer values.

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -171,8 +171,7 @@ def load(
     except RuntimeError as exc:
         # If soundfile failed, try audioread instead
         if isinstance(path, (str, pathlib.PurePath)):
-            warnings.warn("PySoundFile failed. Trying audioread instead.",
-                          stacklevel=2)
+            warnings.warn("PySoundFile failed. Trying audioread instead.", stacklevel=2)
             y, sr_native = __audioread_load(path, offset, duration, dtype)
         else:
             raise (exc)

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -249,6 +249,10 @@ def hybrid_cqt(
     filter_scale : float > 0
         Filter filter_scale factor. Larger values use longer windows.
 
+    norm : {inf, -inf, 0, float > 0}
+        Type of norm to use for basis function normalization.
+        See `librosa.util.normalize`.
+
     sparsity : float in [0, 1)
         Sparsify the CQT basis by discarding up to ``sparsity``
         fraction of the energy in each basis.
@@ -258,6 +262,13 @@ def hybrid_cqt(
     window : str, tuple, number, or function
         Window specification for the basis filters.
         See `filters.get_window` for details.
+
+    scale : bool
+        If ``True``, scale the CQT response by square-root the length of
+        each channel's filter.  This is analogous to ``norm='ortho'`` in FFT.
+
+        If ``False``, do not scale the CQT. This is analogous to
+        ``norm=None`` in FFT.
 
     pad_mode : string
         Padding mode for centered frame analysis.
@@ -422,6 +433,10 @@ def pseudo_cqt(
     filter_scale : float > 0
         Filter filter_scale factor. Larger values use longer windows.
 
+    norm : {inf, -inf, 0, float > 0}
+        Type of norm to use for basis function normalization.
+        See `librosa.util.normalize`.
+
     sparsity : float in [0, 1)
         Sparsify the CQT basis by discarding up to ``sparsity``
         fraction of the energy in each basis.
@@ -431,6 +446,13 @@ def pseudo_cqt(
     window : str, tuple, number, or function
         Window specification for the basis filters.
         See `filters.get_window` for details.
+
+    scale : bool
+        If ``True``, scale the CQT response by square-root the length of
+        each channel's filter.  This is analogous to ``norm='ortho'`` in FFT.
+
+        If ``False``, do not scale the CQT. This is analogous to
+        ``norm=None`` in FFT.
 
     pad_mode : string
         Padding mode for centered frame analysis.
@@ -538,11 +560,17 @@ def icqt(
     C : np.ndarray, [shape=(..., n_bins, n_frames)]
         Constant-Q representation as produced by `cqt`
 
+    sr : number > 0 [scalar]
+        sampling rate of the signal
+
     hop_length : int > 0 [scalar]
         number of samples between successive frames
 
     fmin : float > 0 [scalar]
         Minimum frequency. Defaults to `C1 ~= 32.70 Hz`
+
+    bins_per_octave : int > 0 [scalar]
+        Number of bins per octave
 
     tuning : float [scalar]
         Tuning offset in fractions of a bin.

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -533,7 +533,6 @@ def icqt(
     Given a constant-Q transform representation ``C`` of an audio signal ``y``,
     this function produces an approximation ``y_hat``.
 
-
     Parameters
     ----------
     C : np.ndarray, [shape=(..., n_bins, n_frames)]
@@ -1337,12 +1336,10 @@ def griffinlim_cqt(
 
         If ``None``, defaults to the current `np.random` object.
 
-
     Returns
     -------
     y : np.ndarray [shape=(..., n)]
         time-domain signal reconstructed from ``C``
-
 
     See Also
     --------

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -711,7 +711,12 @@ def icqt(
         y_oct = istft(D_oct, window="ones", hop_length=my_hop, dtype=dtype)
 
         y_oct = audio.resample(
-            y_oct, orig_sr=1, target_sr=sr // my_sr, res_type=res_type, scale=False, fix=False
+            y_oct,
+            orig_sr=1,
+            target_sr=sr // my_sr,
+            res_type=res_type,
+            scale=False,
+            fix=False,
         )
 
         if y is None:
@@ -1004,7 +1009,9 @@ def vqt(
         if my_hop % 2 == 0:
             my_hop //= 2
             my_sr /= 2.0
-            my_y = audio.resample(my_y, orig_sr=2, target_sr=1, res_type=res_type, scale=True)
+            my_y = audio.resample(
+                my_y, orig_sr=2, target_sr=1, res_type=res_type, scale=True
+            )
 
     V = __trim_stack(vqt_resp, n_bins, dtype)
 
@@ -1163,7 +1170,9 @@ def __early_downsample(
             )
 
         new_sr = sr / float(downsample_factor)
-        y = audio.resample(y, orig_sr=sr, target_sr=new_sr, res_type=res_type, scale=True)
+        y = audio.resample(
+            y, orig_sr=sr, target_sr=new_sr, res_type=res_type, scale=True
+        )
 
         # If we're not going to length-scale after CQT, we
         # need to compensate for the downsampling factor here
@@ -1382,7 +1391,7 @@ def griffinlim_cqt(
         warnings.warn(
             "Griffin-Lim with momentum={} > 1 can be unstable. "
             "Proceed with caution!".format(momentum),
-            stacklevel=2
+            stacklevel=2,
         )
     elif momentum < 0:
         raise ParameterError(

--- a/librosa/core/convert.py
+++ b/librosa/core/convert.py
@@ -1527,10 +1527,10 @@ def frequency_weighting(frequencies, *, kind="A", **kwargs):
     """
     if isinstance(kind, str):
         kind = kind.upper()
-    return WEIGHTING_FUNCTIONS[kind](frequencies, **kw)
+    return WEIGHTING_FUNCTIONS[kind](frequencies, **kwargs)
 
 
-def multi_frequency_weighting(frequencies, *, kinds="ZAC", **kw):
+def multi_frequency_weighting(frequencies, *, kinds="ZAC", **kwargs):
     """Compute multiple weightings of a set of frequencies.
 
     Parameters
@@ -1539,7 +1539,7 @@ def multi_frequency_weighting(frequencies, *, kinds="ZAC", **kw):
         One or more frequencies (in Hz)
     kinds : list or tuple or str
         An iterable of weighting kinds. e.g. `('Z', 'B')`, `'ZAD'`, `'C'`
-    **kw : keywords to pass to the weighting function.
+    **kwargs : keywords to pass to the weighting function.
 
     Returns
     -------
@@ -1572,7 +1572,7 @@ def multi_frequency_weighting(frequencies, *, kinds="ZAC", **kw):
     >>> ax.legend()
     """
     return np.stack(
-        [frequency_weighting(frequencies, kind=k, **kw) for k in kinds], axis=0
+        [frequency_weighting(frequencies, kind=k, **kwargs) for k in kinds], axis=0
     )
 
 

--- a/librosa/core/convert.py
+++ b/librosa/core/convert.py
@@ -1487,7 +1487,7 @@ WEIGHTING_FUNCTIONS = {
 }
 
 
-def frequency_weighting(frequencies, *, kind="A", **kw):
+def frequency_weighting(frequencies, *, kind="A", **kwargs):
     """Compute the weighting of a set of frequencies.
 
     Parameters
@@ -1496,9 +1496,8 @@ def frequency_weighting(frequencies, *, kind="A", **kw):
         One or more frequencies (in Hz)
     kind : str in
         The weighting kind. e.g. `'A'`, `'B'`, `'C'`, `'D'`, `'Z'`
-    min_db : float [scalar] or None
-        Clip weights below this threshold.
-        If `None`, no clipping is performed.
+    **kwargs
+        Additional keyword arguments to A_weighting, B_weighting, etc.
 
     Returns
     -------

--- a/librosa/core/convert.py
+++ b/librosa/core/convert.py
@@ -57,12 +57,10 @@ def frames_to_samples(frames, *, hop_length=512, n_fft=None):
 
     Parameters
     ----------
-    frames     : number or np.ndarray [shape=(n,)]
+    frames : number or np.ndarray [shape=(n,)]
         frame index or vector of frame indices
-
     hop_length : int > 0 [scalar]
         number of samples between successive frames
-
     n_fft : None or int > 0 [scalar]
         Optional: length of the FFT window.
         If given, time conversion will include an offset of ``n_fft // 2``
@@ -150,15 +148,12 @@ def frames_to_time(frames, *, sr=22050, hop_length=512, n_fft=None):
 
     Parameters
     ----------
-    frames     : np.ndarray [shape=(n,)]
+    frames : np.ndarray [shape=(n,)]
         frame index or vector of frame indices
-
-    sr         : number > 0 [scalar]
+    sr : number > 0 [scalar]
         audio sampling rate
-
     hop_length : int > 0 [scalar]
         number of samples between successive frames
-
     n_fft : None or int > 0 [scalar]
         Optional: length of the FFT window.
         If given, time conversion will include an offset of ``n_fft // 2``
@@ -243,7 +238,6 @@ def time_to_samples(times, *, sr=22050):
     ----------
     times : number or np.ndarray
         Time value or array of time values (in seconds)
-
     sr : number > 0
         Sampling rate
 
@@ -275,7 +269,6 @@ def samples_to_time(samples, *, sr=22050):
     ----------
     samples : np.ndarray
         Sample index or array of sample indices
-
     sr : number > 0
         Sampling rate
 
@@ -313,7 +306,6 @@ def blocks_to_frames(blocks, *, block_length):
     ----------
     blocks : np.ndarray
         Block index or array of block indices
-
     block_length : int > 0
         The number of frames per block
 
@@ -350,10 +342,8 @@ def blocks_to_samples(blocks, *, block_length, hop_length):
     ----------
     blocks : np.ndarray
         Block index or array of block indices
-
     block_length : int > 0
         The number of frames per block
-
     hop_length : int > 0
         The number of samples to advance between frames
 
@@ -395,13 +385,10 @@ def blocks_to_time(blocks, *, block_length, hop_length, sr):
     ----------
     blocks : np.ndarray
         Block index or array of block indices
-
     block_length : int > 0
         The number of frames per block
-
     hop_length : int > 0
         The number of samples to advance between frames
-
     sr : int > 0
         The sampling rate (samples per second)
 
@@ -457,7 +444,6 @@ def note_to_hz(note, **kwargs):
     ----------
     note : str or iterable of str
         One or more note names to convert
-
     kwargs : additional keyword arguments
         Additional parameters to `note_to_midi`
 
@@ -488,7 +474,6 @@ def note_to_midi(note, *, round_midi=True):
     ----------
     note : str or iterable of str
         One or more note names.
-
     round_midi : bool
         - If ``True``, allow for fractional midi notes
         - Otherwise, round cent deviations to the nearest note
@@ -619,7 +604,6 @@ def midi_to_note(midi, *, octave=True, cents=False, key="C:maj", unicode=True):
     >>> librosa.midi_to_note(range(12, 24), key='F:min')
     ['C0', 'D♭0', 'D0', 'E♭0', 'E0', 'F0', 'G♭0', 'G0', 'A♭0', 'A0', 'B♭0', 'B0']
 
-
     Parameters
     ----------
     midi : int or iterable of int
@@ -697,12 +681,12 @@ def midi_to_hz(notes):
 
     Parameters
     ----------
-    notes       : int or np.ndarray [shape=(n,), dtype=int]
+    notes : int or np.ndarray [shape=(n,), dtype=int]
         midi number(s) of the note(s)
 
     Returns
     -------
-    frequency   : number or np.ndarray [shape=(n,), dtype=float]
+    frequency : number or np.ndarray [shape=(n,), dtype=float]
         frequency (frequencies) of ``notes`` in Hz
 
     See Also
@@ -726,12 +710,12 @@ def hz_to_midi(frequencies):
 
     Parameters
     ----------
-    frequencies   : float or np.ndarray [shape=(n,), dtype=float]
+    frequencies : float or np.ndarray [shape=(n,), dtype=float]
         frequencies to convert
 
     Returns
     -------
-    note_nums     : number or np.ndarray [shape=(n,), dtype=float]
+    note_nums : number or np.ndarray [shape=(n,), dtype=float]
         MIDI notes to ``frequencies``
 
     See Also
@@ -751,10 +735,8 @@ def hz_to_note(frequencies, **kwargs):
     ----------
     frequencies : float or iterable of float
         Input frequencies, specified in Hz
-
     kwargs : additional keyword arguments
         Arguments passed through to `midi_to_note`
-
 
     Returns
     -------
@@ -762,13 +744,11 @@ def hz_to_note(frequencies, **kwargs):
         ``notes[i]`` is the closest note name to ``frequency[i]``
         (or ``frequency`` if the input is scalar)
 
-
     See Also
     --------
     hz_to_midi
     midi_to_note
     note_to_hz
-
 
     Examples
     --------
@@ -804,14 +784,14 @@ def hz_to_mel(frequencies, *, htk=False):
 
     Parameters
     ----------
-    frequencies   : number or np.ndarray [shape=(n,)] , float
+    frequencies : number or np.ndarray [shape=(n,)] , float
         scalar or array of frequencies
-    htk           : bool
+    htk : bool
         use HTK formula instead of Slaney
 
     Returns
     -------
-    mels        : number or np.ndarray [shape=(n,)]
+    mels : number or np.ndarray [shape=(n,)]
         input frequencies in Mels
 
     See Also
@@ -860,14 +840,14 @@ def mel_to_hz(mels, *, htk=False):
 
     Parameters
     ----------
-    mels          : np.ndarray [shape=(n,)], float
+    mels : np.ndarray [shape=(n,)], float
         mel bins to convert
-    htk           : bool
+    htk : bool
         use HTK formula instead of Slaney
 
     Returns
     -------
-    frequencies   : np.ndarray [shape=(n,)]
+    frequencies : np.ndarray [shape=(n,)]
         input mels in Hz
 
     See Also
@@ -913,18 +893,16 @@ def hz_to_octs(frequencies, *, tuning=0.0, bins_per_octave=12):
 
     Parameters
     ----------
-    frequencies   : number >0 or np.ndarray [shape=(n,)] or float
+    frequencies : number >0 or np.ndarray [shape=(n,)] or float
         scalar or vector of frequencies
-
-    tuning        : float
+    tuning : float
         Tuning deviation from A440 in (fractional) bins per octave.
-
     bins_per_octave : int > 0
         Number of bins per octave.
 
     Returns
     -------
-    octaves       : number or np.ndarray [shape=(n,)]
+    octaves : number or np.ndarray [shape=(n,)]
         octave number for each frequency
 
     See Also
@@ -951,18 +929,16 @@ def octs_to_hz(octs, *, tuning=0.0, bins_per_octave=12):
 
     Parameters
     ----------
-    octaves       : np.ndarray [shape=(n,)] or float
+    octaves : np.ndarray [shape=(n,)] or float
         octave number for each frequency
-
     tuning : float
         Tuning deviation from A440 in (fractional) bins per octave.
-
     bins_per_octave : int > 0
         Number of bins per octave.
 
     Returns
     -------
-    frequencies   : number or np.ndarray [shape=(n,)]
+    frequencies : number or np.ndarray [shape=(n,)]
         scalar or vector of frequencies
 
     See Also
@@ -1008,13 +984,12 @@ def A4_to_tuning(A4, *, bins_per_octave=12):
     ----------
     A4: float or np.ndarray [shape=(n,), dtype=float]
         Reference frequency(s) corresponding to A4.
-
     bins_per_octave : int > 0
         Number of bins per octave.
 
     Returns
     -------
-    tuning   : float or np.ndarray [shape=(n,), dtype=float]
+    tuning : float or np.ndarray [shape=(n,), dtype=float]
         Tuning deviation from A440 in (fractional) bins per octave.
 
     See Also
@@ -1059,13 +1034,12 @@ def tuning_to_A4(tuning, *, bins_per_octave=12):
     ----------
     tuning : float or np.ndarray [shape=(n,), dtype=float]
         Tuning deviation from A440 in fractional bins per octave.
-
     bins_per_octave : int > 0
         Number of bins per octave.
 
     Returns
     -------
-    A4  : float or np.ndarray [shape=(n,), dtype=float]
+    A4 : float or np.ndarray [shape=(n,), dtype=float]
         Reference frequency corresponding to A4.
 
     See Also
@@ -1082,16 +1056,13 @@ def fft_frequencies(*, sr=22050, n_fft=2048):
     ----------
     sr : number > 0 [scalar]
         Audio sampling rate
-
     n_fft : int > 0 [scalar]
         FFT window size
-
 
     Returns
     -------
     freqs : np.ndarray [shape=(1 + n_fft/2,)]
         Frequencies ``(0, sr/n_fft, 2*sr/n_fft, ..., sr/2)``
-
 
     Examples
     --------
@@ -1118,15 +1089,12 @@ def cqt_frequencies(n_bins, *, fmin, bins_per_octave=12, tuning=0.0):
 
     Parameters
     ----------
-    n_bins  : int > 0 [scalar]
+    n_bins : int > 0 [scalar]
         Number of constant-Q bins
-
-    fmin    : float > 0 [scalar]
+    fmin : float > 0 [scalar]
         Minimum frequency
-
     bins_per_octave : int > 0 [scalar]
         Number of bins per octave
-
     tuning : float
         Deviation from A440 tuning in fractional bins
 
@@ -1174,7 +1142,6 @@ def mel_frequencies(n_mels=128, *, fmin=0.0, fmax=11025.0, htk=False):
         Moore, G., Odell, J., Ollason, D., Povey, D., Valtchev, V., & Woodland, P.
         The HTK book, version 3.4. Cambridge University, March 2009.
 
-
     See Also
     --------
     hz_to_mel
@@ -1182,19 +1149,15 @@ def mel_frequencies(n_mels=128, *, fmin=0.0, fmax=11025.0, htk=False):
     librosa.feature.melspectrogram
     librosa.feature.mfcc
 
-
     Parameters
     ----------
-    n_mels    : int > 0 [scalar]
+    n_mels : int > 0 [scalar]
         Number of mel bins.
-
-    fmin      : float >= 0 [scalar]
+    fmin : float >= 0 [scalar]
         Minimum frequency (Hz).
-
-    fmax      : float >= 0 [scalar]
+    fmax : float >= 0 [scalar]
         Maximum frequency (Hz).
-
-    htk       : bool
+    htk : bool
         If True, use HTK formula to convert Hz to mel.
         Otherwise (False), use Slaney's Auditory Toolbox.
 
@@ -1237,10 +1200,8 @@ def tempo_frequencies(n_bins, *, hop_length=512, sr=22050):
     ----------
     n_bins : int > 0
         The number of lag bins
-
     hop_length : int > 0
         The number of samples between each bin
-
     sr : number > 0
         The audio sampling rate
 
@@ -1276,10 +1237,8 @@ def fourier_tempo_frequencies(*, sr=22050, win_length=384, hop_length=512):
     ----------
     sr : number > 0
         The audio sampling rate
-
     win_length : int > 0
         The number of frames per analysis window
-
     hop_length : int > 0
         The number of samples between each bin
 
@@ -1310,7 +1269,6 @@ def A_weighting(frequencies, *, min_db=-80.0):  # pylint: disable=invalid-name
     ----------
     frequencies : scalar or np.ndarray [shape=(n,)]
         One or more frequencies (in Hz)
-
     min_db : float [scalar] or None
         Clip weights below this threshold.
         If `None`, no clipping is performed.
@@ -1329,10 +1287,8 @@ def A_weighting(frequencies, *, min_db=-80.0):  # pylint: disable=invalid-name
     C_weighting
     D_weighting
 
-
     Examples
     --------
-
     Get the A-weighting for CQT frequencies
 
     >>> import matplotlib.pyplot as plt
@@ -1366,7 +1322,6 @@ def B_weighting(frequencies, *, min_db=-80.0):  # pylint: disable=invalid-name
     ----------
     frequencies : scalar or np.ndarray [shape=(n,)]
         One or more frequencies (in Hz)
-
     min_db : float [scalar] or None
         Clip weights below this threshold.
         If `None`, no clipping is performed.
@@ -1385,10 +1340,8 @@ def B_weighting(frequencies, *, min_db=-80.0):  # pylint: disable=invalid-name
     C_weighting
     D_weighting
 
-
     Examples
     --------
-
     Get the B-weighting for CQT frequencies
 
     >>> import matplotlib.pyplot as plt
@@ -1421,7 +1374,6 @@ def C_weighting(frequencies, *, min_db=-80.0):  # pylint: disable=invalid-name
     ----------
     frequencies : scalar or np.ndarray [shape=(n,)]
         One or more frequencies (in Hz)
-
     min_db : float [scalar] or None
         Clip weights below this threshold.
         If `None`, no clipping is performed.
@@ -1440,10 +1392,8 @@ def C_weighting(frequencies, *, min_db=-80.0):  # pylint: disable=invalid-name
     B_weighting
     D_weighting
 
-
     Examples
     --------
-
     Get the C-weighting for CQT frequencies
 
     >>> import matplotlib.pyplot as plt
@@ -1474,7 +1424,6 @@ def D_weighting(frequencies, *, min_db=-80.0):  # pylint: disable=invalid-name
     ----------
     frequencies : scalar or np.ndarray [shape=(n,)]
         One or more frequencies (in Hz)
-
     min_db : float [scalar] or None
         Clip weights below this threshold.
         If `None`, no clipping is performed.
@@ -1493,10 +1442,8 @@ def D_weighting(frequencies, *, min_db=-80.0):  # pylint: disable=invalid-name
     B_weighting
     C_weighting
 
-
     Examples
     --------
-
     Get the D-weighting for CQT frequencies
 
     >>> import matplotlib.pyplot as plt
@@ -1547,10 +1494,8 @@ def frequency_weighting(frequencies, *, kind="A", **kw):
     ----------
     frequencies : scalar or np.ndarray [shape=(n,)]
         One or more frequencies (in Hz)
-
     kind : str in
         The weighting kind. e.g. `'A'`, `'B'`, `'C'`, `'D'`, `'Z'`
-
     min_db : float [scalar] or None
         Clip weights below this threshold.
         If `None`, no clipping is performed.
@@ -1569,10 +1514,8 @@ def frequency_weighting(frequencies, *, kind="A", **kw):
     C_weighting
     D_weighting
 
-
     Examples
     --------
-
     Get the A-weighting for CQT frequencies
 
     >>> import matplotlib.pyplot as plt
@@ -1595,10 +1538,8 @@ def multi_frequency_weighting(frequencies, *, kinds="ZAC", **kw):
     ----------
     frequencies : scalar or np.ndarray [shape=(n,)]
         One or more frequencies (in Hz)
-
     kinds : list or tuple or str
         An iterable of weighting kinds. e.g. `('Z', 'B')`, `'ZAD'`, `'C'`
-
     **kw : keywords to pass to the weighting function.
 
     Returns
@@ -1616,10 +1557,8 @@ def multi_frequency_weighting(frequencies, *, kinds="ZAC", **kw):
     C_weighting
     D_weighting
 
-
     Examples
     --------
-
     Get the A, B, C, D, and Z weightings for CQT frequencies
 
     >>> import matplotlib.pyplot as plt
@@ -1646,18 +1585,14 @@ def times_like(X, *, sr=22050, hop_length=512, n_fft=None, axis=-1):
     X : np.ndarray or scalar
         - If ndarray, X is a feature matrix, e.g. STFT, chromagram, or mel spectrogram.
         - If scalar, X represents the number of frames.
-
     sr : number > 0 [scalar]
         audio sampling rate
-
     hop_length : int > 0 [scalar]
         number of samples between successive frames
-
     n_fft : None or int > 0 [scalar]
         Optional: length of the FFT window.
         If given, time conversion will include an offset of ``n_fft // 2``
         to counteract windowing effects when using a non-centered STFT.
-
     axis : int [scalar]
         The axis representing the time axis of X.
         By default, the last axis (-1) is taken.
@@ -1669,7 +1604,8 @@ def times_like(X, *, sr=22050, hop_length=512, n_fft=None, axis=-1):
 
     See Also
     --------
-    samples_like : Return an array of sample indices to match the time axis from a feature matrix.
+    samples_like :
+        Return an array of sample indices to match the time axis from a feature matrix.
 
     Examples
     --------
@@ -1701,15 +1637,12 @@ def samples_like(X, *, hop_length=512, n_fft=None, axis=-1):
     X : np.ndarray or scalar
         - If ndarray, X is a feature matrix, e.g. STFT, chromagram, or mel spectrogram.
         - If scalar, X represents the number of frames.
-
     hop_length : int > 0 [scalar]
         number of samples between successive frames
-
     n_fft : None or int > 0 [scalar]
         Optional: length of the FFT window.
         If given, time conversion will include an offset of ``n_fft // 2``
         to counteract windowing effects when using a non-centered STFT.
-
     axis : int [scalar]
         The axis representing the time axis of ``X``.
         By default, the last axis (-1) is taken.
@@ -1721,7 +1654,8 @@ def samples_like(X, *, hop_length=512, n_fft=None, axis=-1):
 
     See Also
     --------
-    times_like : Return an array of time values to match the time axis from a feature matrix.
+    times_like :
+        Return an array of time values to match the time axis from a feature matrix.
 
     Examples
     --------

--- a/librosa/core/convert.py
+++ b/librosa/core/convert.py
@@ -444,7 +444,7 @@ def note_to_hz(note, **kwargs):
     ----------
     note : str or iterable of str
         One or more note names to convert
-    kwargs : additional keyword arguments
+    **kwargs : additional keyword arguments
         Additional parameters to `note_to_midi`
 
     Returns
@@ -609,17 +609,17 @@ def midi_to_note(midi, *, octave=True, cents=False, key="C:maj", unicode=True):
     midi : int or iterable of int
         Midi numbers to convert.
 
-    octave: bool
+    octave : bool
         If True, include the octave number
 
-    cents: bool
+    cents : bool
         If true, cent markers will be appended for fractional notes.
         Eg, ``midi_to_note(69.3, cents=True) == 'A4+03'``
 
     key : str
         A key signature to use when resolving enharmonic equivalences.
 
-    unicode: bool
+    unicode : bool
         If ``True`` (default), accidentals will use Unicode notation: ♭ or ♯
 
         If ``False``, accidentals will use ASCII-compatible notation: b or #
@@ -735,7 +735,7 @@ def hz_to_note(frequencies, **kwargs):
     ----------
     frequencies : float or iterable of float
         Input frequencies, specified in Hz
-    kwargs : additional keyword arguments
+    **kwargs : additional keyword arguments
         Arguments passed through to `midi_to_note`
 
     Returns
@@ -929,7 +929,7 @@ def octs_to_hz(octs, *, tuning=0.0, bins_per_octave=12):
 
     Parameters
     ----------
-    octaves : np.ndarray [shape=(n,)] or float
+    octs : np.ndarray [shape=(n,)] or float
         octave number for each frequency
     tuning : float
         Tuning deviation from A440 in (fractional) bins per octave.
@@ -982,7 +982,7 @@ def A4_to_tuning(A4, *, bins_per_octave=12):
 
     Parameters
     ----------
-    A4: float or np.ndarray [shape=(n,), dtype=float]
+    A4 : float or np.ndarray [shape=(n,), dtype=float]
         Reference frequency(s) corresponding to A4.
     bins_per_octave : int > 0
         Number of bins per octave.

--- a/librosa/core/harmonic.py
+++ b/librosa/core/harmonic.py
@@ -141,23 +141,18 @@ def interp_harmonics(x, *, freqs, harmonics, kind="linear", fill_value=0, axis=-
     ----------
     x : np.ndarray
         The input energy
-
     freqs : np.ndarray, shape=(X.shape[axis])
         The frequency values corresponding to X's elements along the
         chosen axis.
-
     harmonics : list-like, non-negative
         Harmonics to compute as ``harmonics[i] * freqs``.
         The first harmonic (1) corresponds to ``freqs``.
         Values less than one (e.g., 1/2) correspond to sub-harmonics.
-
     kind : str
         Interpolation type.  See `scipy.interpolate.interp1d`.
-
     fill_value : float
         The value to fill when extrapolating beyond the observed
         frequency range.
-
     axis : int
         The axis along which to compute harmonics
 
@@ -172,7 +167,6 @@ def interp_harmonics(x, *, freqs, harmonics, kind="linear", fill_value=0, axis=-
     See Also
     --------
     scipy.interpolate.interp1d
-
 
     Examples
     --------

--- a/librosa/core/harmonic.py
+++ b/librosa/core/harmonic.py
@@ -227,7 +227,7 @@ def interp_harmonics(x, *, freqs, harmonics, kind="linear", fill_value=0, axis=-
         if not is_unique(freqs, axis=0):
             warnings.warn(
                 "Frequencies are not unique. This may produce incorrect harmonic interpolations.",
-                stacklevel=2
+                stacklevel=2,
             )
 
         f_interp = scipy.interpolate.interp1d(
@@ -250,7 +250,7 @@ def interp_harmonics(x, *, freqs, harmonics, kind="linear", fill_value=0, axis=-
         if not np.all(is_unique(freqs, axis=axis)):
             warnings.warn(
                 "Frequencies are not unique. This may produce incorrect harmonic interpolations.",
-                stacklevel=2
+                stacklevel=2,
             )
 
         # If we have time-varying frequencies, then it must match exactly the shape of the input

--- a/librosa/core/notation.py
+++ b/librosa/core/notation.py
@@ -483,7 +483,7 @@ def key_to_notes(key, *, unicode=True):
 
         Examples: ``C:maj, Db:min, A♭:min``.
 
-    unicode: bool
+    unicode : bool
         If ``True`` (default), use Unicode symbols (♯𝄪♭𝄫)for accidentals.
 
         If ``False``, Unicode symbols will be mapped to low-order ASCII representations::

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -160,7 +160,9 @@ def pitch_tuning(frequencies, *, resolution=0.01, bins_per_octave=12):
     frequencies = frequencies[frequencies > 0]
 
     if not np.any(frequencies):
-        warnings.warn("Trying to estimate tuning from empty frequency set.", stacklevel=2)
+        warnings.warn(
+            "Trying to estimate tuning from empty frequency set.", stacklevel=2
+        )
         return 0.0
 
     # Compute the residual relative to the number of bins

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -33,23 +33,17 @@ def estimate_tuning(
     ----------
     y: np.ndarray [shape=(..., n)] or None
         audio signal. Multi-channel is supported..
-
     sr : number > 0 [scalar]
         audio sampling rate of ``y``
-
     S: np.ndarray [shape=(..., d, t)] or None
         magnitude or power spectrogram
-
     n_fft : int > 0 [scalar] or None
         number of FFT bins to use, if ``y`` is provided.
-
     resolution : float in `(0, 1)`
         Resolution of the tuning as a fraction of a bin.
         0.01 corresponds to measurements in cents.
-
     bins_per_octave : int > 0 [scalar]
         How many frequency bins per octave
-
     kwargs : additional keyword arguments
         Additional arguments passed to `piptrack`
 
@@ -63,8 +57,7 @@ def estimate_tuning(
 
     See Also
     --------
-    piptrack
-        Pitch tracking by parabolic interpolation
+    piptrack : Pitch tracking by parabolic interpolation
 
     Examples
     --------
@@ -118,11 +111,9 @@ def pitch_tuning(frequencies, *, resolution=0.01, bins_per_octave=12):
     frequencies : array-like, float
         A collection of frequencies detected in the signal.
         See `piptrack`
-
     resolution : float in `(0, 1)`
         Resolution of the tuning as a fraction of a bin.
         0.01 corresponds to cents.
-
     bins_per_octave : int > 0 [scalar]
         How many frequency bins per octave
 
@@ -133,8 +124,7 @@ def pitch_tuning(frequencies, *, resolution=0.01, bins_per_octave=12):
 
     See Also
     --------
-    estimate_tuning
-        Estimating tuning from time-series or spectrogram input
+    estimate_tuning : Estimating tuning from time-series or spectrogram input
 
     Examples
     --------
@@ -389,16 +379,12 @@ def _cumulative_mean_normalized_difference(
     ----------
     y_frames : np.ndarray [shape=(frame_length, n_frames)]
         framed audio time series.
-
     frame_length : int > 0 [scalar]
-         length of the frames in samples.
-
+        length of the frames in samples.
     win_length : int > 0 [scalar]
         length of the window for calculating autocorrelation in samples.
-
     min_period : int > 0 [scalar]
         minimum period.
-
     max_period : int > 0 [scalar]
         maximum period.
 
@@ -494,43 +480,34 @@ def yin(
     ----------
     y : np.ndarray [shape=(..., n)]
         audio time series. Multi-channel is supported..
-
     fmin: number > 0 [scalar]
         minimum frequency in Hertz.
         The recommended minimum is ``librosa.note_to_hz('C2')`` (~65 Hz)
         though lower values may be feasible.
-
     fmax: number > 0 [scalar]
         maximum frequency in Hertz.
         The recommended maximum is ``librosa.note_to_hz('C7')`` (~2093 Hz)
         though higher values may be feasible.
-
     sr : number > 0 [scalar]
         sampling rate of ``y`` in Hertz.
-
     frame_length : int > 0 [scalar]
-         length of the frames in samples.
-         By default, ``frame_length=2048`` corresponds to a time scale of about 93 ms at
-         a sampling rate of 22050 Hz.
-
+        length of the frames in samples.
+        By default, ``frame_length=2048`` corresponds to a time scale of about 93 ms at
+        a sampling rate of 22050 Hz.
     win_length : None or int > 0 [scalar]
         length of the window for calculating autocorrelation in samples.
         If ``None``, defaults to ``frame_length // 2``
-
     hop_length : None or int > 0 [scalar]
-         number of audio samples between adjacent YIN predictions.
-         If ``None``, defaults to ``frame_length // 4``.
-
+        number of audio samples between adjacent YIN predictions.
+        If ``None``, defaults to ``frame_length // 4``.
     trough_threshold: number > 0 [scalar]
         absolute threshold for peak estimation.
-
     center : boolean
         If ``True``, the signal `y` is padded so that frame
         ``D[:, t]`` is centered at `y[t * hop_length]`.
         If ``False``, then ``D[:, t]`` begins at ``y[t * hop_length]``.
         Defaults to ``True``,  which simplifies the alignment of ``D`` onto a
         time grid by means of ``librosa.core.frames_to_samples``.
-
     pad_mode : string or function
         If ``center=True``, this argument is passed to ``np.pad`` for padding
         the edges of the signal ``y``. By default (``pad_mode="constant"``),
@@ -547,7 +524,7 @@ def yin(
 
     See Also
     --------
-    librosa.pyin
+    librosa.pyin :
         Fundamental frequency (F0) estimation using probabilistic YIN (pYIN).
 
     Examples
@@ -672,72 +649,55 @@ def pyin(
         "YIN, a fundamental frequency estimator for speech and music."
         The Journal of the Acoustical Society of America 111.4 (2002): 1917-1930.
 
-
     Parameters
     ----------
     y : np.ndarray [shape=(..., n)]
         audio time series. Multi-channel is supported.
-
     fmin: number > 0 [scalar]
         minimum frequency in Hertz.
         The recommended minimum is ``librosa.note_to_hz('C2')`` (~65 Hz)
         though lower values may be feasible.
-
     fmax: number > 0 [scalar]
         maximum frequency in Hertz.
         The recommended maximum is ``librosa.note_to_hz('C7')`` (~2093 Hz)
         though higher values may be feasible.
-
     sr : number > 0 [scalar]
         sampling rate of ``y`` in Hertz.
-
     frame_length : int > 0 [scalar]
-         length of the frames in samples.
-         By default, ``frame_length=2048`` corresponds to a time scale of about 93 ms at
-         a sampling rate of 22050 Hz.
-
+        length of the frames in samples.
+        By default, ``frame_length=2048`` corresponds to a time scale of about 93 ms at
+        a sampling rate of 22050 Hz.
     win_length : None or int > 0 [scalar]
         length of the window for calculating autocorrelation in samples.
         If ``None``, defaults to ``frame_length // 2``
-
     hop_length : None or int > 0 [scalar]
         number of audio samples between adjacent pYIN predictions.
         If ``None``, defaults to ``frame_length // 4``.
-
     n_thresholds : int > 0 [scalar]
         number of thresholds for peak estimation.
-
     beta_parameters : tuple
         shape parameters for the beta distribution prior over thresholds.
-
     boltzmann_parameter: number > 0 [scalar]
         shape parameter for the Boltzmann distribution prior over troughs.
         Larger values will assign more mass to smaller periods.
-
     resolution : float in `(0, 1)`
         Resolution of the pitch bins.
         0.01 corresponds to cents.
-
     max_transition_rate : float > 0
         maximum pitch transition rate in octaves per second.
-
     switch_prob : float in ``(0, 1)``
         probability of switching from voiced to unvoiced or vice versa.
-
     no_trough_prob : float in ``(0, 1)``
         maximum probability to add to global minimum if no trough is below threshold.
-
     fill_na : None, float, or ``np.nan``
         default value for unvoiced frames of ``f0``.
         If ``None``, the unvoiced frames will contain a best guess value.
-
     center : boolean
         If ``True``, the signal ``y`` is padded so that frame
         ``D[:, t]`` is centered at ``y[t * hop_length]``.
         If ``False``, then ``D[:, t]`` begins at ``y[t * hop_length]``.
         Defaults to ``True``,  which simplifies the alignment of ``D`` onto a
         time grid by means of ``librosa.core.frames_to_samples``.
-
     pad_mode : string or function
         If ``center=True``, this argument is passed to ``np.pad`` for padding
         the edges of the signal ``y``. By default (``pad_mode="constant"``),
@@ -749,18 +709,15 @@ def pyin(
     -------
     f0: np.ndarray [shape=(..., n_frames)]
         time series of fundamental frequencies in Hertz.
-
     voiced_flag: np.ndarray [shape=(..., n_frames)]
         time series containing boolean flags indicating whether a frame is voiced or not.
-
     voiced_prob: np.ndarray [shape=(..., n_frames)]
         time series containing the probability that a frame is voiced.
-
     .. note:: If multi-channel input is provided, f0 and voicing are estimated separately for each channel.
 
     See Also
     --------
-    librosa.yin
+    librosa.yin :
         Fundamental frequency (F0) estimation using the YIN algorithm.
 
     Examples
@@ -772,7 +729,6 @@ def pyin(
     ...                                              fmin=librosa.note_to_hz('C2'),
     ...                                              fmax=librosa.note_to_hz('C7'))
     >>> times = librosa.times_like(f0)
-
 
     Overlay F0 over a spectrogram
 

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -31,11 +31,11 @@ def estimate_tuning(
 
     Parameters
     ----------
-    y: np.ndarray [shape=(..., n)] or None
+    y : np.ndarray [shape=(..., n)] or None
         audio signal. Multi-channel is supported..
     sr : number > 0 [scalar]
         audio sampling rate of ``y``
-    S: np.ndarray [shape=(..., d, t)] or None
+    S : np.ndarray [shape=(..., d, t)] or None
         magnitude or power spectrogram
     n_fft : int > 0 [scalar] or None
         number of FFT bins to use, if ``y`` is provided.
@@ -44,7 +44,7 @@ def estimate_tuning(
         0.01 corresponds to measurements in cents.
     bins_per_octave : int > 0 [scalar]
         How many frequency bins per octave
-    kwargs : additional keyword arguments
+    **kwargs : additional keyword arguments
         Additional arguments passed to `piptrack`
 
     Returns
@@ -196,13 +196,13 @@ def piptrack(
 
     Parameters
     ----------
-    y: np.ndarray [shape=(..., n)] or None
+    y : np.ndarray [shape=(..., n)] or None
         audio signal. Multi-channel is supported..
 
     sr : number > 0 [scalar]
         audio sampling rate of ``y``
 
-    S: np.ndarray [shape=(..., d, t)] or None
+    S : np.ndarray [shape=(..., d, t)] or None
         magnitude or power spectrogram
 
     n_fft : int > 0 [scalar] or None
@@ -480,11 +480,11 @@ def yin(
     ----------
     y : np.ndarray [shape=(..., n)]
         audio time series. Multi-channel is supported..
-    fmin: number > 0 [scalar]
+    fmin : number > 0 [scalar]
         minimum frequency in Hertz.
         The recommended minimum is ``librosa.note_to_hz('C2')`` (~65 Hz)
         though lower values may be feasible.
-    fmax: number > 0 [scalar]
+    fmax : number > 0 [scalar]
         maximum frequency in Hertz.
         The recommended maximum is ``librosa.note_to_hz('C7')`` (~2093 Hz)
         though higher values may be feasible.
@@ -500,7 +500,7 @@ def yin(
     hop_length : None or int > 0 [scalar]
         number of audio samples between adjacent YIN predictions.
         If ``None``, defaults to ``frame_length // 4``.
-    trough_threshold: number > 0 [scalar]
+    trough_threshold : number > 0 [scalar]
         absolute threshold for peak estimation.
     center : boolean
         If ``True``, the signal `y` is padded so that frame
@@ -653,11 +653,11 @@ def pyin(
     ----------
     y : np.ndarray [shape=(..., n)]
         audio time series. Multi-channel is supported.
-    fmin: number > 0 [scalar]
+    fmin : number > 0 [scalar]
         minimum frequency in Hertz.
         The recommended minimum is ``librosa.note_to_hz('C2')`` (~65 Hz)
         though lower values may be feasible.
-    fmax: number > 0 [scalar]
+    fmax : number > 0 [scalar]
         maximum frequency in Hertz.
         The recommended maximum is ``librosa.note_to_hz('C7')`` (~2093 Hz)
         though higher values may be feasible.
@@ -677,7 +677,7 @@ def pyin(
         number of thresholds for peak estimation.
     beta_parameters : tuple
         shape parameters for the beta distribution prior over thresholds.
-    boltzmann_parameter: number > 0 [scalar]
+    boltzmann_parameter : number > 0 [scalar]
         shape parameter for the Boltzmann distribution prior over troughs.
         Larger values will assign more mass to smaller periods.
     resolution : float in `(0, 1)`

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -223,7 +223,7 @@ def stft(
                 "n_fft={} is too small for input signal of length={}".format(
                     n_fft, y.shape[-1]
                 ),
-                stacklevel=2
+                stacklevel=2,
             )
 
         padding = [(0, 0) for _ in range(y.ndim)]
@@ -1696,7 +1696,7 @@ def amplitude_to_db(S, *, ref=1.0, amin=1e-5, top_db=80.0):
             "amplitude_to_db was called on complex input so phase "
             "information will be discarded. To suppress this warning, "
             "call amplitude_to_db(np.abs(S)) instead.",
-            stacklevel=2
+            stacklevel=2,
         )
 
     magnitude = np.abs(S)
@@ -2229,7 +2229,7 @@ def pcen(
             "pcen was called on complex input so phase "
             "information will be discarded. To suppress this warning, "
             "call pcen(np.abs(D)) instead.",
-            stacklevel=2
+            stacklevel=2,
         )
         S = np.abs(S)
 
@@ -2430,7 +2430,7 @@ def griffinlim(
         warnings.warn(
             "Griffin-Lim with momentum={} > 1 can be unstable. "
             "Proceed with caution!".format(momentum),
-            stacklevel=2
+            stacklevel=2,
         )
     elif momentum < 0:
         raise ParameterError(

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -557,7 +557,7 @@ def __reassign_frequencies(
         Short-time Fourier transform
 
     Warns
-    --------
+    -----
     RuntimeWarning
         Frequencies with zero support will produce a divide-by-zero warning and
         will be returned as `np.nan`.
@@ -721,7 +721,7 @@ def __reassign_times(
         Short-time Fourier transform
 
     Warns
-    --------
+    -----
     RuntimeWarning
         Time estimates with zero support will produce a divide-by-zero warning
         and will be returned as `np.nan`.
@@ -964,7 +964,7 @@ def reassigned_spectrogram(
             ``mags[..., f, t]`` is the magnitude for bin ``f``, frame ``t``.
 
     Warns
-    --------
+    -----
     RuntimeWarning
         Frequency or time estimates with zero support will produce a
         divide-by-zero warning, and will be returned as `np.nan` unless

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1342,7 +1342,7 @@ def iirt(
           Can be unstable for high-order filters.
     res_type : string
         The resampling mode.  See `librosa.resample` for details.
-    kwargs : additional keyword arguments
+    **kwargs : additional keyword arguments
         Additional arguments for `librosa.filters.semitone_filterbank`
         (e.g., could be used to provide another set of ``center_freqs`` and ``sample_rates``).
 
@@ -1693,7 +1693,7 @@ def db_to_amplitude(S_db, *, ref=1.0):
     ----------
     S_db : np.ndarray
         dB-scaled spectrogram
-    ref: number > 0
+    ref : number > 0
         Optional reference power.
 
     Returns
@@ -1723,7 +1723,7 @@ def perceptual_weighting(S, frequencies, *, kind="A", **kwargs):
     kind : str
         The frequency weighting curve to use.
         e.g. `'A'`, `'B'`, `'C'`, `'D'`, `None or 'Z'`
-    kwargs : additional keyword arguments
+    **kwargs : additional keyword arguments
         Additional keyword arguments to `power_to_db`.
 
     Returns

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -67,7 +67,6 @@ def stft(
     The integers ``t`` and ``f`` can be converted to physical units by means
     of the utility functions `frames_to_sample` and `fft_frequencies`.
 
-
     Parameters
     ----------
     y : np.ndarray [shape=(..., n)], real-valued
@@ -143,29 +142,23 @@ def stft(
 
         .. see also:: `numpy.pad`
 
-
     Returns
     -------
     D : np.ndarray [shape=(..., 1 + n_fft/2, n_frames), dtype=dtype]
         Complex-valued matrix of short-term Fourier transform
         coefficients.
 
-
     See Also
     --------
     istft : Inverse STFT
-
     reassigned_spectrogram : Time-frequency reassigned spectrogram
-
 
     Notes
     -----
     This function caches at level 20.
 
-
     Examples
     --------
-
     >>> y, sr = librosa.load(librosa.ex('trumpet'))
     >>> S = np.abs(librosa.stft(y))
     >>> S
@@ -180,11 +173,9 @@ def stft(
 
     >>> S_left = librosa.stft(y, center=False)
 
-
     Use a shorter hop length
 
     >>> D_short = librosa.stft(y, hop_length=64)
-
 
     Display a spectrogram
 
@@ -552,7 +543,6 @@ def __reassign_frequencies(
     freqs : np.ndarray [shape=(..., 1 + n_fft/2, t), dtype=real]
         Instantaneous frequencies:
         ``freqs[f, t]`` is the frequency for bin ``f``, frame ``t``.
-
     S : np.ndarray [shape=(..., 1 + n_fft/2, t), dtype=complex]
         Short-time Fourier transform
 
@@ -716,7 +706,6 @@ def __reassign_times(
     times : np.ndarray [shape=(..., 1 + n_fft/2, t), dtype=real]
         Reassigned times:
         ``times[f, t]`` is the time for bin ``f``, frame ``t``.
-
     S : np.ndarray [shape=(..., 1 + n_fft/2, t), dtype=complex]
         Short-time Fourier transform
 
@@ -1123,25 +1112,20 @@ def magphase(D, *, power=1):
     """Separate a complex-valued spectrogram D into its magnitude (S)
     and phase (P) components, so that ``D = S * P``.
 
-
     Parameters
     ----------
     D : np.ndarray [shape=(..., d, t), dtype=complex]
         complex-valued spectrogram
-
     power : float > 0
         Exponent for the magnitude spectrogram,
         e.g., 1 for energy, 2 for power, etc.
-
 
     Returns
     -------
     D_mag : np.ndarray [shape=(..., d, t), dtype=real]
         magnitude of ``D``, raised to ``power``
-
     D_phase : np.ndarray [shape=(..., d, t), dtype=complex]
         ``exp(1.j * phi)`` where ``phi`` is the phase of ``D``
-
 
     Examples
     --------
@@ -1202,7 +1186,6 @@ def phase_vocoder(D, *, rate, hop_length=None, n_fft=None):
 
     .. [#] https://breakfastquay.com/rubberband/
 
-
     Examples
     --------
     >>> # Play at double speed
@@ -1222,7 +1205,7 @@ def phase_vocoder(D, *, rate, hop_length=None, n_fft=None):
     D : np.ndarray [shape=(..., d, t), dtype=complex]
         STFT matrix
 
-    rate :  float > 0 [scalar]
+    rate : float > 0 [scalar]
         Speed-up factor: ``rate > 1`` is faster, ``rate < 1`` is slower.
 
     hop_length : int > 0 [scalar] or None
@@ -1332,43 +1315,33 @@ def iirt(
            "Information Retrieval for Music and Motion."
            Springer Verlag. 2007.
 
-
     Parameters
     ----------
     y : np.ndarray [shape=(..., n)]
         audio time series. Multi-channel is supported.
-
     sr : number > 0 [scalar]
         sampling rate of ``y``
-
     win_length : int > 0, <= n_fft
         Window length.
-
     hop_length : int > 0 [scalar]
         Hop length, number samples between subsequent frames.
         If not supplied, defaults to ``win_length // 4``.
-
     center : boolean
         - If ``True``, the signal ``y`` is padded so that frame
           ``D[..., :, t]`` is centered at ``y[t * hop_length]``.
         - If ``False``, then `D[..., :, t]`` begins at ``y[t * hop_length]``
-
     tuning : float [scalar]
         Tuning deviation from A440 in fractions of a bin.
-
     pad_mode : string
         If ``center=True``, the padding mode to use at the edges of the signal.
         By default, this function uses zero padding.
-
     flayout : string
         - If `sos` (default), a series of second-order filters is used for filtering with `scipy.signal.sosfiltfilt`.
           Minimizes numerical precision errors for high-order filters, but is slower.
         - If `ba`, the standard difference equation is used for filtering with `scipy.signal.filtfilt`.
           Can be unstable for high-order filters.
-
     res_type : string
         The resampling mode.  See `librosa.resample` for details.
-
     kwargs : additional keyword arguments
         Additional arguments for `librosa.filters.semitone_filterbank`
         (e.g., could be used to provide another set of ``center_freqs`` and ``sample_rates``).
@@ -1540,7 +1513,6 @@ def power_to_db(S, *, ref=1.0, amin=1e-10, top_db=80.0):
     -----
     This function caches at level 30.
 
-
     Examples
     --------
     Get a power spectrogram from a waveform ``y``
@@ -1571,7 +1543,6 @@ def power_to_db(S, *, ref=1.0, amin=1e-10, top_db=80.0):
            ...,
            [16.578, 16.578, ..., 16.578, 16.578],
            [16.578, 16.578, ..., 16.578, 16.578]], dtype=float32)
-
 
     And plot the results
 
@@ -1633,7 +1604,6 @@ def db_to_power(S_db, *, ref=1.0):
     ----------
     S_db : np.ndarray
         dB-scaled spectrogram
-
     ref : number > 0
         Reference power: output will be scaled by this value
 
@@ -1673,7 +1643,6 @@ def amplitude_to_db(S, *, ref=1.0, amin=1e-5, top_db=80.0):
     top_db : float >= 0 [scalar]
         threshold the output at ``top_db`` below the peak:
         ``max(20 * log10(S)) - top_db``
-
 
     Returns
     -------
@@ -1724,7 +1693,6 @@ def db_to_amplitude(S_db, *, ref=1.0):
     ----------
     S_db : np.ndarray
         dB-scaled spectrogram
-
     ref: number > 0
         Optional reference power.
 
@@ -1750,14 +1718,11 @@ def perceptual_weighting(S, frequencies, *, kind="A", **kwargs):
     ----------
     S : np.ndarray [shape=(..., d, t)]
         Power spectrogram
-
     frequencies : np.ndarray [shape=(d,)]
         Center frequency for each row of` `S``
-
     kind : str
         The frequency weighting curve to use.
         e.g. `'A'`, `'B'`, `'C'`, `'D'`, `None or 'Z'`
-
     kwargs : additional keyword arguments
         Additional keyword arguments to `power_to_db`.
 
@@ -1773,7 +1738,6 @@ def perceptual_weighting(S, frequencies, *, kind="A", **kwargs):
     Notes
     -----
     This function caches at level 30.
-
 
     Examples
     --------
@@ -1826,7 +1790,6 @@ def fmt(y, *, t_min=0.5, n_fmt=None, kind="cubic", beta=0.5, over_sample=1, axis
     The scale transform can be useful for audio analysis because its magnitude is invariant
     to scaling of the domain (e.g., time stretching or compression).  This is analogous
     to the magnitude of the Fourier transform being invariant to shifts in the input domain.
-
 
     .. [#] De Sena, Antonio, and Davide Rocchesso.
         "A fast Mellin and scale transform."
@@ -1884,7 +1847,6 @@ def fmt(y, *, t_min=0.5, n_fmt=None, kind="cubic", beta=0.5, over_sample=1, axis
     Notes
     -----
     This function caches at level 30.
-
 
     Examples
     --------
@@ -2079,7 +2041,6 @@ def pcen(
        Kelling, S., and Bello, J. P. Per-Channel Energy Normalization: Why and How.
        IEEE Signal Processing Letters, 26(1), 39-43.
 
-
     Parameters
     ----------
     S : np.ndarray (non-negative)
@@ -2143,12 +2104,10 @@ def pcen(
 
         If ``False`` (default) only the PCEN values ``P`` are returned.
 
-
     Returns
     -------
     P : np.ndarray, non-negative [shape=(n, m)]
         The per-channel energy normalized version of ``S``.
-
     zf : np.ndarray (optional)
         The final filter delay values.  Only returned if ``return_zf=True``.
 
@@ -2159,7 +2118,6 @@ def pcen(
 
     Examples
     --------
-
     Compare PCEN to log amplitude (dB) scaling on Mel spectra
 
     >>> import matplotlib.pyplot as plt
@@ -2380,7 +2338,6 @@ def griffinlim(
 
         If `None`, defaults to the current `np.random` object.
 
-
     Returns
     -------
     y : np.ndarray [shape=(..., n)]
@@ -2518,7 +2475,6 @@ def _spectrogram(
     This is primarily used in feature extraction functions that can operate on
     either audio time-series or spectrogram input.
 
-
     Parameters
     ----------
     y : None or np.ndarray
@@ -2561,13 +2517,11 @@ def _spectrogram(
         If ``center=True``, the padding mode to use at the edges of the signal.
         By default, STFT uses zero padding.
 
-
     Returns
     -------
     S_out : np.ndarray [dtype=np.float]
         - If ``S`` is provided as input, then ``S_out == S``
         - Else, ``S_out = |stft(y, ...)|**power``
-
     n_fft : int > 0
         - If ``S`` is provided, then ``n_fft`` is inferred from ``S``
         - Else, copied from input

--- a/librosa/decompose.py
+++ b/librosa/decompose.py
@@ -91,7 +91,7 @@ def decompose(
         If `False`, components are assumed to be pre-computed and stored
         in ``transformer``, and are not changed.
 
-    kwargs : Additional keyword arguments to the default transformer
+    **kwargs : Additional keyword arguments to the default transformer
         `sklearn.decomposition.NMF`
 
     Returns
@@ -432,7 +432,7 @@ def nn_filter(S, *, rec=None, aggregate=None, axis=-1, **kwargs):
     axis : int
         The axis along which to filter (by default, columns)
 
-    kwargs
+    **kwargs
         Additional keyword arguments provided to
         `librosa.segment.recurrence_matrix` if ``rec`` is not provided
 

--- a/librosa/decompose.py
+++ b/librosa/decompose.py
@@ -38,7 +38,6 @@ def decompose(
     By default, this is done with with non-negative matrix factorization (NMF),
     but any `sklearn.decomposition`-type object will work.
 
-
     Parameters
     ----------
     S : np.ndarray [shape=(..., n_features, n_samples), dtype=float]
@@ -95,15 +94,12 @@ def decompose(
     kwargs : Additional keyword arguments to the default transformer
         `sklearn.decomposition.NMF`
 
-
     Returns
     -------
     components: np.ndarray [shape=(..., n_features, n_components)]
         matrix of components (basis elements).
-
     activations: np.ndarray [shape=(n_components, n_samples)]
         transformed matrix/activation matrix
-
 
     Raises
     ------
@@ -112,11 +108,9 @@ def decompose(
 
         if the input array is multi-channel and ``sort=True`` is specified.
 
-
     See Also
     --------
     sklearn.decomposition : SciKit-Learn matrix decomposition modules
-
 
     Examples
     --------
@@ -130,7 +124,6 @@ def decompose(
 
     >>> comps, acts = librosa.decompose.decompose(S, n_components=16,
     ...                                           sort=True)
-
 
     Or with sparse dictionary learning
 
@@ -254,7 +247,6 @@ def hpss(S, *, kernel_size=31, power=2.0, mask=False, margin=1.0):
         Components can be recovered by multiplying ``S * mask_H``
         or ``S * mask_P``.
 
-
     margin : float or tuple (margin_harmonic, margin_percussive)
         margin size(s) for the masks (as described in [2]_)
 
@@ -267,10 +259,8 @@ def hpss(S, *, kernel_size=31, power=2.0, mask=False, margin=1.0):
     -------
     harmonic : np.ndarray [shape=(..., d, n)]
         harmonic component (or mask)
-
     percussive : np.ndarray [shape=(..., d, n)]
         percussive component (or mask)
-
 
     See Also
     --------
@@ -306,7 +296,6 @@ def hpss(S, *, kernel_size=31, power=2.0, mask=False, margin=1.0):
     >>> ax[2].set(title='Percussive power spectrogram')
     >>> fig.colorbar(img, ax=ax, format='%+2.0f dB')
 
-
     Or with a narrower horizontal filter
 
     >>> H, P = librosa.decompose.hpss(D, kernel_size=(13, 31))
@@ -336,7 +325,6 @@ def hpss(S, *, kernel_size=31, power=2.0, mask=False, margin=1.0):
     >>> y_harm = librosa.istft(H)
     >>> y_perc = librosa.istft(P)
     >>> y_resi = librosa.istft(R)
-
 
     Get a more isolated percussive component by widening its margin
 
@@ -441,7 +429,6 @@ def nn_filter(S, *, rec=None, aggregate=None, axis=-1, **kwargs):
         For all other aggregation functions, all neighbors
         are treated equally.
 
-
     axis : int
         The axis along which to filter (by default, columns)
 
@@ -459,21 +446,18 @@ def nn_filter(S, *, rec=None, aggregate=None, axis=-1, **kwargs):
     ParameterError
         if ``rec`` is provided and its shape is incompatible with ``S``.
 
-    See also
+    See Also
     --------
     decompose
     hpss
     librosa.segment.recurrence_matrix
 
-
     Notes
     -----
     This function caches at level 30.
 
-
     Examples
     --------
-
     De-noise a chromagram by non-local median filtering.
     By default this would use euclidean distance to select neighbors,
     but this can be overridden directly by setting the ``metric`` parameter.
@@ -549,13 +533,10 @@ def __nn_filter_helper(R_data, R_indices, R_ptr, S, aggregate):
     ----------
     R_data, R_indices, R_ptr : np.ndarrays
         The ``data``, ``indices``, and ``indptr`` of a scipy.sparse matrix
-
     S : np.ndarray
         The observation data to filter
-
     aggregate : callable
         The aggregation operator
-
 
     Returns
     -------

--- a/librosa/display.py
+++ b/librosa/display.py
@@ -566,17 +566,13 @@ def cmap(
     ----------
     data : np.ndarray
         Input data
-
     robust : bool
         If True, discard the top and bottom 2% of data when calculating
         range.
-
     cmap_seq : str
         The sequential colormap name
-
     cmap_bool : str
         The boolean colormap name
-
     cmap_div : str
         The diverging colormap name
 
@@ -731,7 +727,6 @@ def specshow(
             using `feature.fourier_tempogram`.
 
     x_coords, y_coords : np.ndarray [shape=data.shape[0 or 1]]
-
         Optional positioning coordinates of the input data.
         These can be use to explicitly set the location of each
         element ``data[i, j]``, e.g., for displaying beat-synchronous
@@ -815,13 +810,10 @@ def specshow(
     colormesh : `matplotlib.collections.QuadMesh`
         The color mesh object produced by `matplotlib.pyplot.pcolormesh`
 
-
     See Also
     --------
     cmap : Automatic colormap detection
-
     matplotlib.pyplot.pcolormesh
-
 
     Examples
     --------
@@ -835,7 +827,6 @@ def specshow(
     ...                                sr=sr, ax=ax[0])
     >>> ax[0].set(title='Linear-frequency power spectrogram')
     >>> ax[0].label_outer()
-
 
     Or on a logarithmic scale, and using a larger hop
 
@@ -1326,7 +1317,6 @@ def waveshow(
         If you want to visualize both channels at the sample level, it is recommended to
         plot each signal independently.
 
-
     Parameters
     ----------
     y : np.ndarray [shape=(n,) or (2,n)]
@@ -1361,7 +1351,6 @@ def waveshow(
         - 'lag_ms' : same as lag, but in milliseconds.
 
         - `None`, 'none', or 'off': ticks and tick markers are hidden.
-
 
     ax : matplotlib.axes.Axes or None
         Axes to plot on instead of the default `plt.gca()`.
@@ -1398,13 +1387,12 @@ def waveshow(
     librosa.display.AdaptiveWaveplot
         An object of type `librosa.display.AdaptiveWaveplot`
 
-    See also
+    See Also
     --------
     AdaptiveWaveplot
     matplotlib.pyplot.step
     matplotlib.pyplot.fill_between
     matplotlib.markers
-
 
     Examples
     --------

--- a/librosa/display.py
+++ b/librosa/display.py
@@ -852,7 +852,7 @@ def specshow(
     if np.issubdtype(data.dtype, np.complexfloating):
         warnings.warn(
             "Trying to display complex-valued input. " "Showing magnitude instead.",
-            stacklevel=2
+            stacklevel=2,
         )
         data = np.abs(data)
 

--- a/librosa/display.py
+++ b/librosa/display.py
@@ -796,7 +796,7 @@ def specshow(
     ax : matplotlib.axes.Axes or None
         Axes to plot on instead of the default `plt.gca()`.
 
-    kwargs : additional keyword arguments
+    **kwargs : additional keyword arguments
         Arguments passed through to `matplotlib.pyplot.pcolormesh`.
 
         By default, the following options are set:
@@ -1375,7 +1375,7 @@ def waveshow(
         The label string applied to this plot.
         Note that the label
 
-    kwargs
+    **kwargs
         Additional keyword arguments to `matplotlib.pyplot.fill_between` and
         `matplotlib.pyplot.step`.
 

--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -64,7 +64,7 @@ def hpss(y, **kwargs):
     ----------
     y : np.ndarray [shape=(..., n)]
         audio time series. Multi-channel is supported.
-    kwargs : additional keyword arguments.
+    **kwargs : additional keyword arguments.
         See `librosa.decompose.hpss` for details.
 
     Returns
@@ -111,7 +111,7 @@ def harmonic(y, **kwargs):
     ----------
     y : np.ndarray [shape=(..., n)]
         audio time series. Multi-channel is supported.
-    kwargs : additional keyword arguments.
+    **kwargs : additional keyword arguments.
         See `librosa.decompose.hpss` for details.
 
     Returns
@@ -155,7 +155,7 @@ def percussive(y, **kwargs):
     ----------
     y : np.ndarray [shape=(..., n)]
         audio time series. Multi-channel is supported.
-    kwargs : additional keyword arguments.
+    **kwargs : additional keyword arguments.
         See `librosa.decompose.hpss` for details.
 
     Returns
@@ -202,7 +202,7 @@ def time_stretch(y, *, rate, **kwargs):
     rate : float > 0 [scalar]
         Stretch factor.  If ``rate > 1``, then the signal is sped up.
         If ``rate < 1``, then the signal is slowed down.
-    kwargs : additional keyword arguments.
+    **kwargs : additional keyword arguments.
         See `librosa.decompose.stft` for details.
 
     Returns
@@ -281,7 +281,7 @@ def pitch_shift(
 
         See `librosa.resample` for more information.
 
-    kwargs: additional keyword arguments.
+    **kwargs : additional keyword arguments.
         See `librosa.decompose.stft` for details.
 
     Returns
@@ -536,7 +536,7 @@ def split(
         The number of samples per analysis frame
     hop_length : int > 0
         The number of samples between analysis frames
-    aggregate callable [default: np.max]
+    aggregate : callable [default: np.max]
         Function to aggregate across channels (if y.ndim > 1)
 
     Returns

--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -60,21 +60,17 @@ def hpss(y, **kwargs):
     This function automates the STFT->HPSS->ISTFT pipeline, and ensures that
     the output waveforms have equal length to the input waveform ``y``.
 
-
     Parameters
     ----------
     y : np.ndarray [shape=(..., n)]
         audio time series. Multi-channel is supported.
-
     kwargs : additional keyword arguments.
         See `librosa.decompose.hpss` for details.
-
 
     Returns
     -------
     y_harmonic : np.ndarray [shape=(..., n)]
         audio time series of the harmonic elements
-
     y_percussive : np.ndarray [shape=(..., n)]
         audio time series of the percussive elements
 
@@ -83,7 +79,6 @@ def hpss(y, **kwargs):
     harmonic : Extract only the harmonic component
     percussive : Extract only the percussive component
     librosa.decompose.hpss : HPSS on spectrograms
-
 
     Examples
     --------
@@ -116,7 +111,6 @@ def harmonic(y, **kwargs):
     ----------
     y : np.ndarray [shape=(..., n)]
         audio time series. Multi-channel is supported.
-
     kwargs : additional keyword arguments.
         See `librosa.decompose.hpss` for details.
 
@@ -161,7 +155,6 @@ def percussive(y, **kwargs):
     ----------
     y : np.ndarray [shape=(..., n)]
         audio time series. Multi-channel is supported.
-
     kwargs : additional keyword arguments.
         See `librosa.decompose.hpss` for details.
 
@@ -202,16 +195,13 @@ def percussive(y, **kwargs):
 def time_stretch(y, *, rate, **kwargs):
     """Time-stretch an audio series by a fixed rate.
 
-
     Parameters
     ----------
     y : np.ndarray [shape=(..., n)]
         audio time series. Multi-channel is supported.
-
     rate : float > 0 [scalar]
         Stretch factor.  If ``rate > 1``, then the signal is sped up.
         If ``rate < 1``, then the signal is slowed down.
-
     kwargs : additional keyword arguments.
         See `librosa.decompose.stft` for details.
 
@@ -222,9 +212,12 @@ def time_stretch(y, *, rate, **kwargs):
 
     See Also
     --------
-    pitch_shift : pitch shifting
-    librosa.phase_vocoder : spectrogram phase vocoder
-    pyrubberband.pyrb.time_stretch : high-quality time stretching using RubberBand
+    pitch_shift :
+        pitch shifting
+    librosa.phase_vocoder :
+        spectrogram phase vocoder
+    pyrubberband.pyrb.time_stretch :
+        high-quality time stretching using RubberBand
 
     Examples
     --------
@@ -296,12 +289,14 @@ def pitch_shift(
     y_shift : np.ndarray [shape=(..., n)]
         The pitch-shifted audio time-series
 
-
     See Also
     --------
-    time_stretch : time stretching
-    librosa.phase_vocoder : spectrogram phase vocoder
-    pyrubberband.pyrb.pitch_shift : high-quality pitch shifting using RubberBand
+    time_stretch :
+        time stretching
+    librosa.phase_vocoder :
+        spectrogram phase vocoder
+    pyrubberband.pyrb.pitch_shift :
+        high-quality pitch shifting using RubberBand
 
     Examples
     --------
@@ -340,28 +335,23 @@ def pitch_shift(
 def remix(y, intervals, *, align_zeros=True):
     """Remix an audio signal by re-ordering time intervals.
 
-
     Parameters
     ----------
     y : np.ndarray [shape=(..., t)]
         Audio time series. Multi-channel is supported.
-
     intervals : iterable of tuples (start, end)
         An iterable (list-like or generator) where the ``i``th item
         ``intervals[i]`` indicates the start and end (in samples)
         of a slice of ``y``.
-
     align_zeros : boolean
         If ``True``, interval boundaries are mapped to the closest
         zero-crossing in ``y``.  If ``y`` is stereo, zero-crossings
         are computed after converting to mono.
 
-
     Returns
     -------
     y_remix : np.ndarray [shape=(..., d)]
         ``y`` remixed in the order specified by ``intervals``
-
 
     Examples
     --------
@@ -369,23 +359,19 @@ def remix(y, intervals, *, align_zeros=True):
 
     >>> y, sr = librosa.load(librosa.ex('choice'))
 
-
     Compute beats
 
     >>> _, beat_frames = librosa.beat.beat_track(y=y, sr=sr,
     ...                                          hop_length=512)
 
-
     Convert from frames to sample indices
 
     >>> beat_samples = librosa.frames_to_samples(beat_frames)
-
 
     Generate intervals from consecutive events
 
     >>> intervals = librosa.util.frame(beat_samples, frame_length=2,
     ...                                hop_length=1).T
-
 
     Reverse the beat intervals
 
@@ -468,21 +454,16 @@ def trim(
     ----------
     y : np.ndarray, shape=(..., n)
         Audio signal. Multi-channel is supported.
-
     top_db : number > 0
         The threshold (in decibels) below reference to consider as
         silence
-
     ref : number or callable
         The reference power.  By default, it uses `np.max` and compares
         to the peak power in the signal.
-
     frame_length : int > 0
         The number of samples per analysis frame
-
     hop_length : int > 0
         The number of samples between analysis frames
-
     aggregate : callable [default: np.max]
         Function to aggregate across channels (if y.ndim > 1)
 
@@ -490,12 +471,10 @@ def trim(
     -------
     y_trimmed : np.ndarray, shape=(..., m)
         The trimmed signal
-
     index : np.ndarray, shape=(2,)
         the interval of ``y`` corresponding to the non-silent region:
         ``y_trimmed = y[index[0]:index[1]]`` (for mono) or
         ``y_trimmed = y[:, index[0]:index[1]]`` (for stereo).
-
 
     Examples
     --------
@@ -547,21 +526,16 @@ def split(
     ----------
     y : np.ndarray, shape=(..., n)
         An audio signal. Multi-channel is supported.
-
     top_db : number > 0
         The threshold (in decibels) below reference to consider as
         silence
-
     ref : number or callable
         The reference power.  By default, it uses `np.max` and compares
         to the peak power in the signal.
-
     frame_length : int > 0
         The number of samples per analysis frame
-
     hop_length : int > 0
         The number of samples between analysis frames
-
     aggregate callable [default: np.max]
         Function to aggregate across channels (if y.ndim > 1)
 
@@ -613,7 +587,6 @@ def preemphasis(y, *, coef=0.97, zi=None, return_zf=False):
 
         y[n] -> y[n] - coef * y[n-1]
 
-
     Parameters
     ----------
     y : np.ndarray [shape=(..., n)]
@@ -646,7 +619,6 @@ def preemphasis(y, *, coef=0.97, zi=None, return_zf=False):
     -------
     y_out : np.ndarray
         pre-emphasized signal
-
     zf : number
         if ``return_zf=True``, the final filter state is also returned
 
@@ -734,12 +706,10 @@ def deemphasis(y, *, coef=0.97, zi=None, return_zf=False):
         If ``True``, return the final filter state.
         If ``False``, only return the pre-emphasized signal.
 
-
     Returns
     -------
     y_out : np.ndarray
         de-emphasized signal
-
     zf : number
         if ``return_zf=True``, the final filter state is also returned
 

--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -327,7 +327,10 @@ def pitch_shift(
 
     # Stretch in time, then resample
     y_shift = core.resample(
-        time_stretch(y, rate=rate, **kwargs), orig_sr=float(sr) / rate, target_sr=sr, res_type=res_type
+        time_stretch(y, rate=rate, **kwargs),
+        orig_sr=float(sr) / rate,
+        target_sr=sr,
+        res_type=res_type,
     )
 
     # Crop to the same dimension as the input

--- a/librosa/feature/inverse.py
+++ b/librosa/feature/inverse.py
@@ -24,26 +24,20 @@ def mel_to_stft(M, *, sr=22050, n_fft=2048, power=2.0, **kwargs):
     ----------
     M : np.ndarray [shape=(..., n_mels, n), non-negative]
         The spectrogram as produced by `feature.melspectrogram`
-
     sr : number > 0 [scalar]
         sampling rate of the underlying signal
-
     n_fft : int > 0 [scalar]
         number of FFT components in the resulting STFT
-
     power : float > 0 [scalar]
         Exponent for the magnitude melspectrogram
-
     kwargs : additional keyword arguments
         Mel filter bank parameters.
         See `librosa.filters.mel` for details
-
 
     Returns
     -------
     S : np.ndarray [shape=(..., n_fft, t), non-negative]
         An approximate linear magnitude spectrogram
-
 
     See Also
     --------
@@ -51,7 +45,6 @@ def mel_to_stft(M, *, sr=22050, n_fft=2048, power=2.0, **kwargs):
     librosa.stft
     librosa.filters.mel
     librosa.util.nnls
-
 
     Examples
     --------
@@ -118,46 +111,33 @@ def mel_to_audio(
     ----------
     M : np.ndarray [shape=(..., n_mels, n), non-negative]
         The spectrogram as produced by `feature.melspectrogram`
-
     sr : number > 0 [scalar]
         sampling rate of the underlying signal
-
     n_fft : int > 0 [scalar]
         number of FFT components in the resulting STFT
-
     hop_length : None or int > 0
         The hop length of the STFT.  If not provided, it will default to ``n_fft // 4``
-
     win_length : None or int > 0
         The window length of the STFT.  By default, it will equal ``n_fft``
-
     window : string, tuple, number, function, or np.ndarray [shape=(n_fft,)]
         A window specification as supported by `stft` or `istft`
-
     center : boolean
         If `True`, the STFT is assumed to use centered frames.
         If `False`, the STFT is assumed to use left-aligned frames.
-
     pad_mode : string
         If ``center=True``, the padding mode to use at the edges of the signal.
         By default, STFT uses zero padding.
-
     power : float > 0 [scalar]
         Exponent for the magnitude melspectrogram
-
     n_iter : int > 0
         The number of iterations for Griffin-Lim
-
     length : None or int > 0
         If provided, the output ``y`` is zero-padded or clipped to exactly ``length``
         samples.
-
     dtype : np.dtype
         Real numeric type for the time-domain signal.  Default is 32-bit float.
-
     kwargs : additional keyword arguments
         Mel filter bank parameters
-
 
     Returns
     -------
@@ -196,7 +176,6 @@ def mfcc_to_mel(mfcc, *, n_mels=128, dct_type=2, norm="ortho", ref=1.0, lifter=0
 
         1. The inverse DCT is applied to the MFCCs
         2. `librosa.db_to_power` is applied to map the dB-scaled result to a power spectrogram
-
 
     Parameters
     ----------
@@ -273,7 +252,6 @@ def mfcc_to_audio(
 
         1. Convert mfcc to Mel power spectrum (`mfcc_to_mel`)
         2. Convert Mel power spectrum to time-domain audio (`mel_to_audio`)
-
 
     Parameters
     ----------

--- a/librosa/feature/inverse.py
+++ b/librosa/feature/inverse.py
@@ -230,7 +230,7 @@ def mfcc_to_mel(mfcc, *, n_mels=128, dct_type=2, norm="ortho", ref=1.0, lifter=0
         An approximate Mel power spectrum recovered from ``mfcc``
 
     Warns
-    --------
+    -----
     UserWarning
         due to critical values in lifter array that invokes underflow.
 

--- a/librosa/feature/inverse.py
+++ b/librosa/feature/inverse.py
@@ -30,7 +30,7 @@ def mel_to_stft(M, *, sr=22050, n_fft=2048, power=2.0, **kwargs):
         number of FFT components in the resulting STFT
     power : float > 0 [scalar]
         Exponent for the magnitude melspectrogram
-    kwargs : additional keyword arguments
+    **kwargs : additional keyword arguments
         Mel filter bank parameters.
         See `librosa.filters.mel` for details
 
@@ -136,7 +136,7 @@ def mel_to_audio(
         samples.
     dtype : np.dtype
         Real numeric type for the time-domain signal.  Default is 32-bit float.
-    kwargs : additional keyword arguments
+    **kwargs : additional keyword arguments
         Mel filter bank parameters
 
     Returns
@@ -279,7 +279,7 @@ def mfcc_to_audio(
 
             M[n, :] <- M[n, :] / (1 + sin(pi * (n + 1) / lifter)) * lifter / 2
 
-    kwargs : additional keyword arguments
+    **kwargs : additional keyword arguments
         Parameters to pass through to `mel_to_audio`
 
     Returns

--- a/librosa/feature/rhythm.py
+++ b/librosa/feature/rhythm.py
@@ -87,7 +87,6 @@ def tempogram(
     librosa.util.normalize
     librosa.stft
 
-
     Examples
     --------
     >>> # Compute local onset autocorrelation
@@ -194,26 +193,20 @@ def fourier_tempogram(
     ----------
     y : np.ndarray [shape=(..., n)] or None
         Audio time series.  Multi-channel is supported.
-
     sr : number > 0 [scalar]
         sampling rate of ``y``
-
     onset_envelope : np.ndarray [shape=(..., n)] or None
         Optional pre-computed onset strength envelope as provided by
         ``librosa.onset.onset_strength``.
         Multi-channel is supported.
-
     hop_length : int > 0
         number of audio samples between successive onset measurements
-
     win_length : int > 0
         length of the onset window (in frames/onset measurements)
         The default settings (384) corresponds to ``384 * hop_length / sr ~= 8.9s``.
-
     center : bool
         If `True`, onset windows are centered.
         If `False`, windows are left-aligned.
-
     window : string, function, number, tuple, or np.ndarray [shape=(win_length,)]
         A window specification as in `stft`.
 
@@ -235,7 +228,6 @@ def fourier_tempogram(
     librosa.onset.onset_strength
     librosa.util.normalize
     librosa.stft
-
 
     Examples
     --------

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -116,7 +116,6 @@ def spectral_centroid(
         If ``center=True``, the padding mode to use at the edges of the signal.
         By default, STFT uses zero padding.
 
-
     Returns
     -------
     centroid : np.ndarray [shape=(..., 1, t)]
@@ -124,11 +123,8 @@ def spectral_centroid(
 
     See Also
     --------
-    librosa.stft
-        Short-time Fourier Transform
-
-    librosa.reassigned_spectrogram
-        Time-frequency reassigned spectrogram
+    librosa.stft : Short-time Fourier Transform
+    librosa.reassigned_spectrogram : Time-frequency reassigned spectrogram
 
     Examples
     --------
@@ -282,12 +278,10 @@ def spectral_bandwidth(
     p : float > 0
         Power to raise deviation from spectral centroid.
 
-
     Returns
     -------
     bandwidth : np.ndarray [shape=(..., 1, t)]
         frequency bandwidth for each frame
-
 
     Examples
     --------
@@ -471,13 +465,11 @@ def spectral_contrast(
         If `False`, return the logarithmic difference:
         ``log(peaks) - log(valleys)``.
 
-
     Returns
     -------
     contrast : np.ndarray [shape=(..., n_bands + 1, t)]
         each row of spectral contrast values corresponds to a given
         octave-based frequency
-
 
     Examples
     --------
@@ -653,7 +645,6 @@ def spectral_rolloff(
     rolloff : np.ndarray [shape=(..., 1, t)]
         roll-off frequency for each frame
 
-
     Examples
     --------
     From time-series input
@@ -814,7 +805,6 @@ def spectral_flatness(
         spectral flatness for each frame.
         The returned value is in [0, 1] and often converted to dB scale.
 
-
     Examples
     --------
     From time-series input
@@ -885,7 +875,6 @@ def rms(
     representation of energy over time because its frames can be windowed,
     thus prefer using ``S`` if it's already available.
 
-
     Parameters
     ----------
     y : np.ndarray [shape=(..., n)] or None
@@ -915,7 +904,6 @@ def rms(
     -------
     rms : np.ndarray [shape=(..., 1, t)]
         RMS value for each frame
-
 
     Examples
     --------
@@ -1173,8 +1161,7 @@ def zero_crossing_rate(y, *, frame_length=2048, hop_length=512, center=True, **k
 
     See Also
     --------
-    librosa.zero_crossings
-        Compute zero-crossings in a time-series
+    librosa.zero_crossings : Compute zero-crossings in a time-series
 
     Examples
     --------
@@ -1292,11 +1279,8 @@ def chroma_stft(
 
     See Also
     --------
-    librosa.filters.chroma
-        Chroma filter bank construction
-
-    librosa.util.normalize
-        Vector normalization
+    librosa.filters.chroma : Chroma filter bank construction
+    librosa.util.normalize : Vector normalization
 
     Examples
     --------
@@ -1430,7 +1414,6 @@ def chroma_cqt(
 
         If `None`, it will match ``n_chroma``.
 
-
     cqt_mode : ['full', 'hybrid']
         Constant-Q transform mode
 
@@ -1449,7 +1432,6 @@ def chroma_cqt(
     Examples
     --------
     Compare a long-window STFT chromagram to the CQT chromagram
-
 
     >>> y, sr = librosa.load(librosa.ex('nutcracker'), duration=15)
     >>> chroma_stft = librosa.feature.chroma_stft(y=y, sr=sr,
@@ -1601,19 +1583,13 @@ def chroma_cens(
 
     See Also
     --------
-    chroma_cqt
-        Compute a chromagram from a constant-Q transform.
-
-    chroma_stft
-        Compute a chromagram from an STFT spectrogram or waveform.
-
-    librosa.filters.get_window
-        Compute a window function.
+    chroma_cqt : Compute a chromagram from a constant-Q transform.
+    chroma_stft : Compute a chromagram from an STFT spectrogram or waveform.
+    librosa.filters.get_window : Compute a window function.
 
     Examples
     --------
     Compare standard cqt chroma to CENS.
-
 
     >>> y, sr = librosa.load(librosa.ex('nutcracker'), duration=15)
     >>> chroma_cens = librosa.feature.chroma_cens(y=y, sr=sr)
@@ -1726,11 +1702,8 @@ def tonnetz(*, y=None, sr=22050, chroma=None, **kwargs):
 
     See Also
     --------
-    chroma_cqt
-        Compute a chromagram from a constant-Q transform.
-
-    chroma_stft
-        Compute a chromagram from an STFT spectrogram or waveform.
+    chroma_cqt : Compute a chromagram from a constant-Q transform.
+    chroma_stft : Compute a chromagram from an STFT spectrogram or waveform.
 
     Examples
     --------
@@ -2016,12 +1989,8 @@ def melspectrogram(
 
     See Also
     --------
-    librosa.filters.mel
-        Mel filter bank construction
-
-    librosa.stft
-        Short-time Fourier Transform
-
+    librosa.filters.mel : Mel filter bank construction
+    librosa.stft : Short-time Fourier Transform
 
     Examples
     --------

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -1147,7 +1147,7 @@ def zero_crossing_rate(y, *, frame_length=2048, hop_length=512, center=True, **k
         This is similar to the padding in `librosa.stft`,
         but uses edge-value copies instead of zero-padding.
 
-    kwargs : additional keyword arguments
+    **kwargs : additional keyword arguments
         See `librosa.zero_crossings`
 
         .. note:: By default, the ``pad`` parameter is set to `False`, which
@@ -1268,7 +1268,7 @@ def chroma_stft(
     n_chroma : int > 0 [scalar]
         Number of chroma bins to produce (12 by default).
 
-    kwargs : additional keyword arguments
+    **kwargs : additional keyword arguments
         Arguments to parameterize chroma filters.
         See `librosa.filters.chroma` for details.
 
@@ -1683,7 +1683,7 @@ def tonnetz(*, y=None, sr=22050, chroma=None, **kwargs):
 
         If `None`, a cqt chromagram is performed.
 
-    kwargs
+    **kwargs
         Additional keyword arguments to `chroma_cqt`, if ``chroma`` is not
         pre-computed.
 
@@ -1785,7 +1785,7 @@ def mfcc(
     S : np.ndarray [shape=(..., d, t)] or None
         log-power Mel spectrogram
 
-    n_mfcc: int > 0 [scalar]
+    n_mfcc : int > 0 [scalar]
         number of MFCCs to return
 
     dct_type : {1, 2, 3}
@@ -1806,7 +1806,7 @@ def mfcc(
         Setting ``lifter >= 2 * n_mfcc`` emphasizes the higher-order coefficients.
         As ``lifter`` increases, the coefficient weighting becomes approximately linear.
 
-    kwargs : additional keyword arguments
+    **kwargs : additional keyword arguments
         Arguments to `melspectrogram`, if operating
         on time series input
 
@@ -1977,7 +1977,7 @@ def melspectrogram(
         Exponent for the magnitude melspectrogram.
         e.g., 1 for energy, 2 for power, etc.
 
-    kwargs : additional keyword arguments
+    **kwargs : additional keyword arguments
         Mel filter bank parameters.
 
         See `librosa.filters.mel` for details.

--- a/librosa/feature/utils.py
+++ b/librosa/feature/utils.py
@@ -21,20 +21,20 @@ def delta(data, *, width=9, order=1, axis=-1, mode="interp", **kwargs):
 
     Parameters
     ----------
-    data      : np.ndarray
+    data : np.ndarray
         the input data matrix (eg, spectrogram)
 
-    width     : int, positive, odd [scalar]
+    width : int, positive, odd [scalar]
         Number of frames over which to compute the delta features.
         Cannot exceed the length of ``data`` along the specified axis.
 
         If ``mode='interp'``, then ``width`` must be at least ``data.shape[axis]``.
 
-    order     : int > 0 [scalar]
+    order : int > 0 [scalar]
         the order of the difference operator.
         1 for first derivative, 2 for second, etc.
 
-    axis      : int [scalar]
+    axis : int [scalar]
         the axis along which to compute deltas.
         Default is -1 (columns).
 
@@ -46,7 +46,7 @@ def delta(data, *, width=9, order=1, axis=-1, mode="interp", **kwargs):
 
     Returns
     -------
-    delta_data   : np.ndarray [shape=(..., t)]
+    delta_data : np.ndarray [shape=(..., t)]
         delta matrix of ``data`` at specified order
 
     Notes
@@ -133,7 +133,6 @@ def stack_memory(data, *, n_steps=2, delay=1, **kwargs):
     overridden by supplying additional keyword arguments which are passed
     to `np.pad()`.
 
-
     Parameters
     ----------
     data : np.ndarray [shape=(..., d, t)]
@@ -151,7 +150,7 @@ def stack_memory(data, *, n_steps=2, delay=1, **kwargs):
         Negative values embed from the future (subsequent columns).
 
     kwargs : additional keyword arguments
-      Additional arguments to pass to `numpy.pad`
+        Additional arguments to pass to `numpy.pad`
 
     Returns
     -------
@@ -162,7 +161,6 @@ def stack_memory(data, *, n_steps=2, delay=1, **kwargs):
     Notes
     -----
     This function caches at level 40.
-
 
     Examples
     --------
@@ -270,11 +268,8 @@ def __stack(history, data, n_steps, delay):
     Parameters
     ----------
     history : output array (2-dimensional)
-
     data : pre-padded input array (2-dimensional)
-
     n_steps : int > 0, the number of steps to stack
-
     delay : int != 0, the amount of delay between steps
 
     Returns

--- a/librosa/feature/utils.py
+++ b/librosa/feature/utils.py
@@ -41,7 +41,7 @@ def delta(data, *, width=9, order=1, axis=-1, mode="interp", **kwargs):
     mode : str, {'interp', 'nearest', 'mirror', 'constant', 'wrap'}
         Padding mode for estimating differences at the boundaries.
 
-    kwargs : additional keyword arguments
+    **kwargs : additional keyword arguments
         See `scipy.signal.savgol_filter`
 
     Returns
@@ -149,7 +149,7 @@ def stack_memory(data, *, n_steps=2, delay=1, **kwargs):
 
         Negative values embed from the future (subsequent columns).
 
-    kwargs : additional keyword arguments
+    **kwargs : additional keyword arguments
         Additional arguments to pass to `numpy.pad`
 
     Returns

--- a/librosa/feature/utils.py
+++ b/librosa/feature/utils.py
@@ -212,8 +212,6 @@ def stack_memory(data, *, n_steps=2, delay=1, **kwargs):
     >>> ax.text(1.0, 1/6, "Lag=0", transform=ax.transAxes, rotation=-90, ha="left", va="center")
     >>> ax.text(1.0, 3/6, "Lag=1", transform=ax.transAxes, rotation=-90, ha="left", va="center")
     >>> ax.text(1.0, 5/6, "Lag=2", transform=ax.transAxes, rotation=-90, ha="left", va="center")
-    >>> ax.axline((0, 1/3), (1, 1/3), transform=ax.transAxes, color='w', alpha=0.75, linestyle='--')
-    >>> ax.axline((0, 2/3), (1, 2/3), transform=ax.transAxes, color='w', alpha=0.75, linestyle='--')
     >>> ax.set(title='Time-lagged chroma', ylabel="")
     """
 

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -140,23 +140,23 @@ def mel(
 
     Parameters
     ----------
-    sr        : number > 0 [scalar]
+    sr : number > 0 [scalar]
         sampling rate of the incoming signal
 
-    n_fft     : int > 0 [scalar]
+    n_fft : int > 0 [scalar]
         number of FFT components
 
-    n_mels    : int > 0 [scalar]
+    n_mels : int > 0 [scalar]
         number of Mel bands to generate
 
-    fmin      : float >= 0 [scalar]
+    fmin : float >= 0 [scalar]
         lowest frequency (in Hz)
 
-    fmax      : float >= 0 [scalar]
+    fmax : float >= 0 [scalar]
         highest frequency (in Hz).
         If `None`, use ``fmax = sr / 2.0``
 
-    htk       : bool [scalar]
+    htk : bool [scalar]
         use HTK formula instead of Slaney
 
     norm : {None, 'slaney', or number} [scalar]
@@ -175,10 +175,10 @@ def mel(
 
     Returns
     -------
-    M         : np.ndarray [shape=(n_mels, 1 + n_fft/2)]
+    M : np.ndarray [shape=(n_mels, 1 + n_fft/2)]
         Mel transform matrix
 
-    See also
+    See Also
     --------
     librosa.util.normalize
 
@@ -196,7 +196,6 @@ def mel(
            [ 0.   ,  0.   , ...,  0.   ,  0.   ],
            [ 0.   ,  0.   , ...,  0.   ,  0.   ]])
 
-
     Clip the maximum frequency to 8KHz
 
     >>> librosa.filters.mel(sr=22050, n_fft=2048, fmax=8000)
@@ -205,7 +204,6 @@ def mel(
            ...,
            [ 0.  ,  0.  , ...,  0.  ,  0.  ],
            [ 0.  ,  0.  , ...,  0.  ,  0.  ]])
-
 
     >>> import matplotlib.pyplot as plt
     >>> fig, ax = plt.subplots()
@@ -277,24 +275,23 @@ def chroma(
     This creates a linear transformation matrix to project
     FFT bins onto chroma bins (i.e. pitch classes).
 
-
     Parameters
     ----------
-    sr        : number > 0 [scalar]
+    sr : number > 0 [scalar]
         audio sampling rate
 
-    n_fft     : int > 0 [scalar]
+    n_fft : int > 0 [scalar]
         number of FFT bins
 
-    n_chroma  : int > 0 [scalar]
+    n_chroma : int > 0 [scalar]
         number of chroma bins
 
     tuning : float
         Tuning deviation from A440 in fractions of a chroma bin.
 
-    ctroct    : float > 0 [scalar]
+    ctroct : float > 0 [scalar]
 
-    octwidth  : float > 0 or None [scalar]
+    octwidth : float > 0 or None [scalar]
         ``ctroct`` and ``octwidth`` specify a dominance window:
         a Gaussian weighting centered on ``ctroct`` (in octs, A0 = 27.5Hz)
         and with a gaussian half-width of ``octwidth``.
@@ -345,7 +342,6 @@ def chroma(
     ...,
            [  1.162e-05,   2.372e-04, ...,   6.417e-38,   9.923e-38],
            [  1.180e-05,   2.260e-04, ...,   4.697e-50,   7.772e-50]])
-
 
     Equally weight all octaves
 
@@ -510,7 +506,6 @@ def constant_q(
     -------
     filters : np.ndarray, ``len(filters) == n_bins``
         ``filters[i]`` is ``i``\ th time-domain CQT basis filter
-
     lengths : np.ndarray, ``len(lengths) == n_bins``
         The (fractional) length of each filter
 
@@ -525,7 +520,6 @@ def constant_q(
     librosa.cqt
     librosa.vqt
     librosa.util.normalize
-
 
     Examples
     --------
@@ -615,19 +609,14 @@ def constant_q_lengths(
     ----------
     sr : number > 0 [scalar]
         Audio sampling rate
-
     fmin : float > 0 [scalar]
         Minimum frequency bin.
-
     n_bins : int > 0 [scalar]
         Number of frequencies.  Defaults to 7 octaves (84 bins).
-
     bins_per_octave : int > 0 [scalar]
         Number of bins per octave
-
     window : str or callable
         Window function to use on filters
-
     filter_scale : float > 0 [scalar]
         Resolution of filter windows. Larger values use longer windows.
 
@@ -744,7 +733,6 @@ def wavelet_lengths(
     -------
     lengths : np.ndarray
         The length of each filter.
-
     f_cutoff : float
         The lowest frequency at which all filters' main lobes have decayed by
         at least 3dB.
@@ -834,7 +822,6 @@ def wavelet(
 
     Parameters
     ----------
-
     freqs : np.ndarray (positive)
         Center frequencies of the filters (in Hz).
         Must be in ascending order.
@@ -880,7 +867,6 @@ def wavelet(
     -------
     filters : np.ndarray, ``len(filters) == n_bins``
         each ``filters[i]`` is a (complex) time-domain filter
-
     lengths : np.ndarray, ``len(lengths) == n_bins``
         The (fractional) length of each filter in samples
 
@@ -894,7 +880,6 @@ def wavelet(
     librosa.cqt
     librosa.vqt
     librosa.util.normalize
-
 
     Examples
     --------
@@ -979,34 +964,26 @@ def cq_to_chroma(
     """Construct a linear transformation matrix to map Constant-Q bins
     onto chroma bins (i.e., pitch classes).
 
-
     Parameters
     ----------
     n_input : int > 0 [scalar]
         Number of input components (CQT bins)
-
     bins_per_octave : int > 0 [scalar]
         How many bins per octave in the CQT
-
     n_chroma : int > 0 [scalar]
         Number of output bins (per octave) in the chroma
-
     fmin : None or float > 0
         Center frequency of the first constant-Q channel.
         Default: 'C1' ~= 32.7 Hz
-
     window : None or np.ndarray
         If provided, the cq_to_chroma filter bank will be
         convolved with ``window``.
-
     base_c : bool
         If True, the first chroma bin will start at 'C'
         If False, the first chroma bin will start at 'A'
-
     dtype : np.dtype
         The data type of the output basis.
         By default, uses 32-bit (single-precision) floating point.
-
 
     Returns
     -------
@@ -1103,7 +1080,6 @@ def cq_to_chroma(
 def window_bandwidth(window, n=1000):
     """Get the equivalent noise bandwidth of a window function.
 
-
     Parameters
     ----------
     window : callable or string
@@ -1111,7 +1087,6 @@ def window_bandwidth(window, n=1000):
         Examples:
         - scipy.signal.hann
         - 'boxcar'
-
     n : int > 0
         The number of coefficients to use in estimating the
         window bandwidth
@@ -1228,7 +1203,6 @@ def _multirate_fb(
 
      This implementation uses `scipy.signal.iirdesign` to design the filters.
 
-
     Parameters
     ----------
     center_freqs : np.ndarray [shape=(n,), dtype=float]
@@ -1266,12 +1240,10 @@ def _multirate_fb(
 
         - If `zpk`, returns zeros, poles, and system gains of the transfer functions.
 
-
     Returns
     -------
     filterbank : list [shape=(n,), dtype=float]
         Each list entry comprises the filter coefficients for a single filter.
-
     sample_rates : np.ndarray [shape=(n,), dtype=float]
         Samplerate for each filter.
 
@@ -1346,7 +1318,6 @@ def mr_frequencies(tuning):
            "Information Retrieval for Music and Motion."
            Springer Verlag. 2007.
 
-
     Parameters
     ----------
     tuning : float [scalar]
@@ -1358,14 +1329,12 @@ def mr_frequencies(tuning):
     center_freqs : np.ndarray [shape=(n,), dtype=float]
         Center frequencies of the filter kernels.
         Also defines the number of filters in the filterbank.
-
     sample_rates : np.ndarray [shape=(n,), dtype=float]
         Sample rate for each filter, used for multirate filterbank.
 
     Notes
     -----
     This function caches at level 10.
-
 
     See Also
     --------
@@ -1415,26 +1384,21 @@ def semitone_filterbank(
            "Information Retrieval for Music and Motion."
            Springer Verlag. 2007.
 
-
     Parameters
     ----------
     center_freqs : np.ndarray [shape=(n,), dtype=float]
         Center frequencies of the filter kernels.
         Also defines the number of filters in the filterbank.
-
     tuning : float [scalar]
         Tuning deviation from A440 as a fraction of a semitone (1/12 of an octave
         in equal temperament).
-
     sample_rates : np.ndarray [shape=(n,), dtype=float]
         Sample rates of each filter in the multirate filterbank.
-
     flayout : string
         - If `ba`, the standard difference equation is used for filtering with `scipy.signal.filtfilt`.
           Can be unstable for high-order filters.
         - If `sos`, a series of second-order filters is used for filtering with `scipy.signal.sosfiltfilt`.
           Minimizes numerical precision errors for high-order filters, but is slower.
-
     kwargs : additional keyword arguments
         Additional arguments to the private function `_multirate_fb()`.
 
@@ -1442,7 +1406,6 @@ def semitone_filterbank(
     -------
     filterbank : list [shape=(n,), dtype=float]
         Each list entry contains the filter coefficients for a single filter.
-
     fb_sample_rates : np.ndarray [shape=(n,), dtype=float]
         Sample rate for each filter.
 
@@ -1507,19 +1470,14 @@ def window_sumsquare(
     ----------
     window : string, tuple, number, callable, or list-like
         Window specification, as in `get_window`
-
     n_frames : int > 0
         The number of analysis frames
-
     hop_length : int > 0
         The number of samples to advance between frames
-
     win_length : [optional]
         The length of the window function.  By default, this matches ``n_fft``.
-
     n_fft : int > 0
         The length of each analysis frame.
-
     dtype : np.dtype
         The data type of the output
 
@@ -1597,12 +1555,10 @@ def diagonal_filter(window, n, *, slope=1.0, angle=None, zero_mean=False):
         This should be enabled if you want to enhance paths and suppress
         blocks.
 
-
     Returns
     -------
     kernel : np.ndarray, shape=[(m, m)]
         The 2-dimensional filter kernel
-
 
     Notes
     -----

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -461,6 +461,9 @@ def constant_q(
     Frequencies are spaced geometrically, increasing by a factor of
     ``(2**(1./bins_per_octave))`` at each successive band.
 
+    .. warning:: This function is deprecated as of v0.9 and will be removed in 1.0.
+        See `librosa.filters.wavelet`.
+
     Parameters
     ----------
     sr : number > 0 [scalar]
@@ -604,6 +607,9 @@ def constant_q_lengths(
     *, sr, fmin, n_bins=84, bins_per_octave=12, window="hann", filter_scale=1, gamma=0
 ):
     r"""Return length of each filter in a constant-Q basis.
+
+    .. warning:: This function is deprecated as of v0.9 and will be removed in 1.0.
+        See `librosa.filters.wavelet_lengths`.
 
     Parameters
     ----------

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -619,6 +619,9 @@ def constant_q_lengths(
         Window function to use on filters
     filter_scale : float > 0 [scalar]
         Resolution of filter windows. Larger values use longer windows.
+    gamma : number >= 0
+        Bandwidth offset for variable-Q transforms.
+        ``gamma=0`` produces a constant-Q filterbank.
 
     Returns
     -------
@@ -1480,6 +1483,9 @@ def window_sumsquare(
         The length of each analysis frame.
     dtype : np.dtype
         The data type of the output
+    norm : {np.inf, -np.inf, 0, float > 0, None}
+        Normalization mode used in window construction.
+        Note that this does not affect the squaring operation.
 
     Returns
     -------

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -499,7 +499,7 @@ def constant_q(
         The data type of the output basis.
         By default, uses 64-bit (single precision) complex floating point.
 
-    kwargs : additional keyword arguments
+    **kwargs : additional keyword arguments
         Arguments to `np.pad()` when ``pad==True``.
 
     Returns
@@ -860,7 +860,7 @@ def wavelet(
 
         If two or more frequencies are provided, this parameter is ignored.
 
-    kwargs : additional keyword arguments
+    **kwargs : additional keyword arguments
         Arguments to `np.pad()` when ``pad==True``.
 
     Returns
@@ -1399,7 +1399,7 @@ def semitone_filterbank(
           Can be unstable for high-order filters.
         - If `sos`, a series of second-order filters is used for filtering with `scipy.signal.sosfiltfilt`.
           Minimizes numerical precision errors for high-order filters, but is slower.
-    kwargs : additional keyword arguments
+    **kwargs : additional keyword arguments
         Additional arguments to the private function `_multirate_fb()`.
 
     Returns

--- a/librosa/onset.py
+++ b/librosa/onset.py
@@ -44,16 +44,15 @@ def onset_detect(
 
     .. [#] https://github.com/CPJKU/onset_db
 
-
     Parameters
     ----------
-    y          : np.ndarray [shape=(n,)]
+    y : np.ndarray [shape=(n,)]
         audio time series, must be monophonic
 
-    sr         : number > 0 [scalar]
+    sr : number > 0 [scalar]
         sampling rate of ``y``
 
-    onset_envelope     : np.ndarray [shape=(m,)]
+    onset_envelope : np.ndarray [shape=(m,)]
         (optional) pre-computed onset strength envelope
 
     hop_length : int > 0 [scalar]
@@ -85,10 +84,8 @@ def onset_detect(
 
         See `librosa.util.peak_pick` for details.
 
-
     Returns
     -------
-
     onsets : np.ndarray [shape=(n_onsets,)]
         estimated positions of detected onsets, in whichever units
         are specified.  By default, frame indices.
@@ -96,7 +93,6 @@ def onset_detect(
         .. note::
             If no onset strength could be detected, onset_detect returns
             an empty list.
-
 
     Raises
     ------
@@ -110,7 +106,6 @@ def onset_detect(
     onset_strength : compute onset strength per-frame
     onset_backtrack : backtracking onset events
     librosa.util.peak_pick : pick peaks from a time series
-
 
     Examples
     --------
@@ -126,7 +121,6 @@ def onset_detect(
     >>> o_env = librosa.onset.onset_strength(y=y, sr=sr)
     >>> times = librosa.times_like(o_env, sr=sr)
     >>> onset_frames = librosa.onset.onset_detect(onset_envelope=o_env, sr=sr)
-
 
     >>> import matplotlib.pyplot as plt
     >>> D = np.abs(librosa.stft(y))
@@ -224,16 +218,16 @@ def onset_strength(
 
     Parameters
     ----------
-    y        : np.ndarray [shape=(..., n)]
+    y : np.ndarray [shape=(..., n)]
         audio time-series. Multi-channel is supported.
 
-    sr       : number > 0 [scalar]
+    sr : number > 0 [scalar]
         sampling rate of ``y``
 
-    S        : np.ndarray [shape=(..., d, m)]
+    S : np.ndarray [shape=(..., d, m)]
         pre-computed (log-power) spectrogram
 
-    lag      : int > 0
+    lag : int > 0
         time lag for computing differences
 
     max_size : int > 0
@@ -266,13 +260,11 @@ def onset_strength(
     kwargs : additional keyword arguments
         Additional parameters to ``feature()``, if ``S`` is not provided.
 
-
     Returns
     -------
-    onset_envelope   : np.ndarray [shape=(..., m,)]
+    onset_envelope : np.ndarray [shape=(..., m,)]
         vector containing the onset strength envelope.
         If the input contains multiple channels, then onset envelope is computed for each channel.
-
 
     Raises
     ------
@@ -281,12 +273,10 @@ def onset_strength(
 
         or if ``lag`` or ``max_size`` are not positive integers
 
-
     See Also
     --------
     onset_detect
     onset_strength_multi
-
 
     Examples
     --------
@@ -308,7 +298,6 @@ def onset_strength(
     >>> ax[1].plot(times, 2 + onset_env / onset_env.max(), alpha=0.8,
     ...            label='Mean (mel)')
 
-
     Median aggregation, and custom mel options
 
     >>> onset_env = librosa.onset.onset_strength(y=y, sr=sr,
@@ -316,7 +305,6 @@ def onset_strength(
     ...                                          fmax=8000, n_mels=256)
     >>> ax[1].plot(times, 1 + onset_env / onset_env.max(), alpha=0.8,
     ...            label='Median (custom mel)')
-
 
     Constant-Q spectrogram instead of Mel
 
@@ -370,7 +358,6 @@ def onset_backtrack(events, energy):
     ----------
     events : np.ndarray, dtype=int
         List of onset event frame indices, as computed by `onset_detect`
-
     energy : np.ndarray, shape=(m,)
         An energy function
 
@@ -451,16 +438,15 @@ def onset_strength_multi(
 
         mean_{f in channels[i]} max(0, S[f, t+1] - S[f, t])
 
-
     Parameters
     ----------
-    y        : np.ndarray [shape=(..., n,)]
+    y : np.ndarray [shape=(..., n,)]
         audio time-series. Multi-channel is supported.
 
-    sr       : number > 0 [scalar]
+    sr : number > 0 [scalar]
         sampling rate of ``y``
 
-    S        : np.ndarray [shape=(..., d, m)]
+    S : np.ndarray [shape=(..., d, m)]
         pre-computed (log-power) spectrogram
 
     n_fft : int > 0 [scalar]
@@ -469,7 +455,7 @@ def onset_strength_multi(
     hop_length : int > 0 [scalar]
         hop length for use in ``feature()`` if ``S`` is not provided.
 
-    lag      : int > 0
+    lag : int > 0
         time lag for computing differences
 
     max_size : int > 0
@@ -510,18 +496,15 @@ def onset_strength_multi(
     kwargs : additional keyword arguments
         Additional parameters to ``feature()``, if ``S`` is not provided.
 
-
     Returns
     -------
-    onset_envelope   : np.ndarray [shape=(..., n_channels, m)]
+    onset_envelope : np.ndarray [shape=(..., n_channels, m)]
         array containing the onset strength envelope for each specified channel
-
 
     Raises
     ------
     ParameterError
         if neither ``(y, sr)`` nor ``S`` are provided
-
 
     See Also
     --------

--- a/librosa/onset.py
+++ b/librosa/onset.py
@@ -79,7 +79,7 @@ def onset_detect(
 
         Otherwise, the onset envelope is left unnormalized.
 
-    kwargs : additional keyword arguments
+    **kwargs : additional keyword arguments
         Additional parameters for peak picking.
 
         See `librosa.util.peak_pick` for details.
@@ -257,7 +257,7 @@ def onset_strength(
 
         Default: `np.mean`
 
-    kwargs : additional keyword arguments
+    **kwargs : additional keyword arguments
         Additional parameters to ``feature()``, if ``S`` is not provided.
 
     Returns
@@ -493,7 +493,7 @@ def onset_strength_multi(
         Array of channel boundaries or slice objects.
         If `None`, then a single channel is generated to span all bands.
 
-    kwargs : additional keyword arguments
+    **kwargs : additional keyword arguments
         Additional parameters to ``feature()``, if ``S`` is not provided.
 
     Returns

--- a/librosa/segment.py
+++ b/librosa/segment.py
@@ -1053,7 +1053,7 @@ def path_enhance(
         If True, the smoothed similarity matrix will be thresholded at 0, and will not contain
         negative entries.
 
-    kwargs : additional keyword arguments
+    **kwargs : additional keyword arguments
         Additional arguments to pass to `scipy.ndimage.convolve`
 
     Returns

--- a/librosa/segment.py
+++ b/librosa/segment.py
@@ -70,7 +70,6 @@ def cross_similarity(
     The output is a matrix ``xsim``, where ``xsim[i, j]`` is non-zero
     if ``data_ref[..., i]`` is a k-nearest neighbor of ``data[..., j]``.
 
-
     Parameters
     ----------
     data : np.ndarray [shape=(..., d, n)]
@@ -301,7 +300,6 @@ def recurrence_matrix(
           known as a (sparse) self-distance matrix.
 
     The general term *recurrence matrix* can refer to any of the three forms above.
-
 
     Parameters
     ----------
@@ -648,7 +646,6 @@ def lag_to_recurrence(lag, *, axis=-1):
     ----------
     lag : np.ndarray or scipy.sparse.spmatrix
         A lag matrix, as produced by ``recurrence_to_lag``
-
     axis : int
         The axis corresponding to the time dimension.
         The alternate axis will be interpreted in lag coordinates.
@@ -735,14 +732,11 @@ def timelag_filter(function, pad=True, index=0):
     ----------
     function : callable
         The filtering function to wrap, e.g., `scipy.ndimage.median_filter`
-
     pad : bool
         Whether to zero-pad the structure feature matrix
-
     index : int >= 0
         If ``function`` accepts input data as a positional argument, it should be
         indexed by ``index``
-
 
     Returns
     -------
@@ -750,10 +744,8 @@ def timelag_filter(function, pad=True, index=0):
         A new filter function which applies in time-lag space rather than
         time-time space.
 
-
     Examples
     --------
-
     Apply a 31-bin median filter to the diagonal of a recurrence matrix.
     With default, parameters, this corresponds to a time window of about
     0.72 seconds.
@@ -820,16 +812,13 @@ def subsegment(data, frames, *, n_segments=4, axis=-1):
     ----------
     data : np.ndarray
         Data matrix to use in clustering
-
     frames : np.ndarray [shape=(n_boundaries,)], dtype=int, non-negative]
         Array of beat or segment boundaries, as provided by
         `librosa.beat.beat_track`,
         `librosa.onset.onset_detect`,
         or `agglomerative`.
-
     n_segments : int > 0
         Maximum number of frames to sub-divide each interval.
-
     axis : int
         Axis along which to apply the segmentation.
         By default, the last index (-1) is taken.
@@ -902,16 +891,13 @@ def agglomerative(data, k, *, clusterer=None, axis=-1):
 
     Parameters
     ----------
-    data     : np.ndarray
+    data : np.ndarray
         data to cluster
-
-    k        : int > 0 [scalar]
+    k : int > 0 [scalar]
         number of segments to produce
-
     clusterer : sklearn.cluster.AgglomerativeClustering, optional
         An optional AgglomerativeClustering object.
         If `None`, a constrained Ward object is instantiated.
-
     axis : int
         axis along which to cluster.
         By default, the last axis (-1) is chosen.
@@ -1070,7 +1056,6 @@ def path_enhance(
     kwargs : additional keyword arguments
         Additional arguments to pass to `scipy.ndimage.convolve`
 
-
     Returns
     -------
     R_smooth : np.ndarray, shape=R.shape
@@ -1080,7 +1065,6 @@ def path_enhance(
     --------
     librosa.filters.diagonal_filter
     recurrence_matrix
-
 
     Examples
     --------

--- a/librosa/sequence.py
+++ b/librosa/sequence.py
@@ -128,12 +128,10 @@ def dtw(
         accumulated cost matrix.
         D[N, M] is the total alignment cost.
         When doing subsequence DTW, D[N,:] indicates a matching function.
-
     wp : np.ndarray [shape=(N, 2)]
         Warping path with index pairs.
         Each row of the array contains an index pair (n, m).
         Only returned when ``backtrack`` is True.
-
     steps : np.ndarray [shape=(N, M)]
         Step matrix, containing the indices of the used steps from the cost
         accumulation step.
@@ -363,26 +361,19 @@ def __dtw_calc_accu_cost(
     ----------
     C : np.ndarray [shape=(N, M)]
         pre-computed cost matrix
-
     D : np.ndarray [shape=(N, M)]
         accumulated cost matrix
-
     steps : np.ndarray [shape=(N, M)]
         Step matrix, containing the indices of the used steps from the cost
         accumulation step.
-
     step_sizes_sigma : np.ndarray [shape=[n, 2]]
         Specifies allowed step sizes as used by the dtw.
-
     weights_add : np.ndarray [shape=[n, ]]
         Additive weights to penalize certain step sizes.
-
     weights_mul : np.ndarray [shape=[n, ]]
         Multiplicative weights to penalize certain step sizes.
-
     max_0 : int
         maximum number of steps in step_sizes_sigma in dim 0.
-
     max_1 : int
         maximum number of steps in step_sizes_sigma in dim 1.
 
@@ -392,7 +383,6 @@ def __dtw_calc_accu_cost(
         accumulated cost matrix.
         D[N, M] is the total alignment cost.
         When doing subsequence DTW, D[N,:] indicates a matching function.
-
     steps : np.ndarray [shape=(N, M)]
         Step matrix, containing the indices of the used steps from the cost
         accumulation step.
@@ -433,19 +423,15 @@ def __dtw_backtracking(steps, step_sizes_sigma, subseq, start=None):  # pragma: 
     step to backtrack the index pairs for an optimal
     warping path.
 
-
     Parameters
     ----------
     steps : np.ndarray [shape=(N, M)]
         Step matrix, containing the indices of the used steps from the cost
         accumulation step.
-
     step_sizes_sigma : np.ndarray [shape=[n, 2]]
         Specifies allowed step sizes as used by the dtw.
-
     subseq : bool
         Enable subsequence DTW, e.g., for retrieval tasks.
-
     start : int
         Start column index for backtraing (only allowed for ``subseq=True``)
 
@@ -499,19 +485,15 @@ def dtw_backtracking(steps, *, step_sizes_sigma=None, subseq=False, start=None):
     Uses the saved step sizes from the cost accumulation
     step to backtrack the index pairs for a warping path.
 
-
     Parameters
     ----------
     steps : np.ndarray [shape=(N, M)]
         Step matrix, containing the indices of the used steps from the cost
         accumulation step.
-
     step_sizes_sigma : np.ndarray [shape=[n, 2]]
         Specifies allowed step sizes as used by the dtw.
-
     subseq : bool
         Enable subsequence DTW, e.g., for retrieval tasks.
-
     start : int
         Start column index for backtraing (only allowed for ``subseq=True``)
 
@@ -583,7 +565,6 @@ def rqa(sim, *, gap_onset=1, gap_extend=1, knight_moves=True, backtrack=True):
     Note that setting ``gap_onset`` and ``gap_extend`` to `np.inf` recovers the second
     method, and disabling knight moves recovers the first.
 
-
     .. [#] Serrà, Joan, Xavier Serra, and Ralph G. Andrzejak.
         "Cross recurrence quantification for cover song identification."
         New Journal of Physics 11, no. 9 (2009): 093017.
@@ -591,7 +572,6 @@ def rqa(sim, *, gap_onset=1, gap_extend=1, knight_moves=True, backtrack=True):
     .. [#] Eckmann, J. P., S. Oliffson Kamphorst, and D. Ruelle.
         "Recurrence plots of dynamical systems."
         World Scientific Series on Nonlinear Science Series A 16 (1995): 441-446.
-
 
     Parameters
     ----------
@@ -623,7 +603,6 @@ def rqa(sim, *, gap_onset=1, gap_extend=1, knight_moves=True, backtrack=True):
     score : np.ndarray [shape=(N, M)]
         The alignment score matrix.  ``score[n, m]`` is the cumulative value of
         the best alignment sequence ending in frames ``n`` and ``m``.
-
     path : np.ndarray [shape=(k, 2)] (optional)
         If ``backtrack=True``, ``path`` contains a list of pairs of aligned frames
         in the best alignment sequence.
@@ -907,11 +886,9 @@ def _viterbi(log_prob, log_trans, log_p_init):  # pragma: no cover
     log_prob : np.ndarray [shape=(T, m)]
         ``log_prob[t, s]`` is the conditional log-likelihood
         ``log P[X = X(t) | State(t) = s]``
-
     log_trans : np.ndarray [shape=(m, m)]
         The log transition matrix
         ``log_trans[i, j] = log P[State(t+1) = j | State(t) = i]``
-
     log_p_init : np.ndarray [shape=(m,)]
         log of the initial state distribution
 
@@ -979,27 +956,22 @@ def viterbi(prob, transition, *, p_init=None, return_logp=False):
     prob : np.ndarray [shape=(..., n_states, n_steps), non-negative]
         ``prob[..., s, t]`` is the probability of observation at time ``t``
         being generated by state ``s``.
-
     transition : np.ndarray [shape=(n_states, n_states), non-negative]
         ``transition[i, j]`` is the probability of a transition from i->j.
         Each row must sum to 1.
-
     p_init : np.ndarray [shape=(n_states,)]
         Optional: initial state distribution.
         If not provided, a uniform distribution is assumed.
-
     return_logp : bool
         If ``True``, return the log-likelihood of the state sequence.
 
     Returns
     -------
     Either ``states`` or ``(states, logp)``:
-
     states : np.ndarray [shape=(..., n_steps,)]
         The most likely state sequence.
         If ``prob`` contains multiple channels of input, then each channel is
         decoded independently.
-
     logp : scalar [float] or np.ndarray
         If ``return_logp=True``, the log probability of ``states`` given
         the observations.
@@ -1007,7 +979,6 @@ def viterbi(prob, transition, *, p_init=None, return_logp=False):
     See Also
     --------
     viterbi_discriminative : Viterbi decoding from state likelihoods
-
 
     Examples
     --------
@@ -1126,40 +1097,36 @@ def viterbi_discriminative(
         ``prob[s, t]`` is the probability of state ``s`` conditional on
         the observation at time ``t``.
         Must be non-negative and sum to 1 along each column.
-
     transition : np.ndarray [shape=(n_states, n_states), non-negative]
         ``transition[i, j]`` is the probability of a transition from i->j.
         Each row must sum to 1.
-
     p_state : np.ndarray [shape=(n_states,)]
         Optional: marginal probability distribution over states,
         must be non-negative and sum to 1.
         If not provided, a uniform distribution is assumed.
-
     p_init : np.ndarray [shape=(n_states,)]
         Optional: initial state distribution.
         If not provided, it is assumed to be uniform.
-
     return_logp : bool
         If ``True``, return the log-likelihood of the state sequence.
 
     Returns
     -------
     Either ``states`` or ``(states, logp)``:
-
     states : np.ndarray [shape=(..., n_steps,)]
         The most likely state sequence.
         If ``prob`` contains multiple input channels,
         then each channel is decoded independently.
-
     logp : scalar [float] or np.ndarray
         If ``return_logp=True``, the log probability of ``states`` given
         the observations.
 
     See Also
     --------
-    viterbi : Viterbi decoding from observation likelihoods
-    viterbi_binary: Viterbi decoding for multi-label, conditional state likelihoods
+    viterbi :
+        Viterbi decoding from observation likelihoods
+    viterbi_binary :
+        Viterbi decoding for multi-label, conditional state likelihoods
 
     Examples
     --------
@@ -1363,18 +1330,18 @@ def viterbi_binary(prob, transition, *, p_state=None, p_init=None, return_logp=F
     Returns
     -------
     Either ``states`` or ``(states, logp)``:
-
     states : np.ndarray [shape=(..., n_states, n_steps)]
         The most likely state sequence.
-
     logp : np.ndarray [shape=(..., n_states,)]
         If ``return_logp=True``, the log probability of each state activation
         sequence ``states``
 
     See Also
     --------
-    viterbi : Viterbi decoding from observation likelihoods
-    viterbi_discriminative : Viterbi decoding for discriminative (mutually exclusive) state predictions
+    viterbi :
+        Viterbi decoding from observation likelihoods
+    viterbi_discriminative :
+        Viterbi decoding for discriminative (mutually exclusive) state predictions
 
     Examples
     --------
@@ -1485,7 +1452,6 @@ def transition_uniform(n_states):
 
     Examples
     --------
-
     >>> librosa.sequence.transition_uniform(3)
     array([[0.333, 0.333, 0.333],
            [0.333, 0.333, 0.333],
@@ -1667,7 +1633,6 @@ def transition_local(n_states, width, *, window="triangle", wrap=False):
             so and effectively have ``width-2`` non-zero values.  You may have to expand
             ``width`` to get the desired behavior.
 
-
     wrap : bool
         If ``True``, then state locality ``|i - j|`` is computed modulo ``n_states``.
         If ``False`` (default), then locality is absolute.
@@ -1683,7 +1648,6 @@ def transition_local(n_states, width, *, window="triangle", wrap=False):
 
     Examples
     --------
-
     Triangular distributions with and without wrapping
 
     >>> librosa.sequence.transition_local(5, 3, window='triangle', wrap=False)

--- a/librosa/sequence.py
+++ b/librosa/sequence.py
@@ -1729,7 +1729,9 @@ def transition_local(n_states, width, *, window="triangle", wrap=False):
 
     # Fill in the widths.  This is inefficient, but simple
     for i, width_i in enumerate(width):
-        trans_row = pad_center(get_window(window, width_i, fftbins=False), size=n_states)
+        trans_row = pad_center(
+            get_window(window, width_i, fftbins=False), size=n_states
+        )
         trans_row = np.roll(trans_row, n_states // 2 + i + 1)
 
         if not wrap:

--- a/librosa/util/_nnls.py
+++ b/librosa/util/_nnls.py
@@ -48,7 +48,7 @@ def _nnls_lbfgs_block(A, B, x_init=None, **kwargs):
         The regression targets
     x_init : np.ndarray [shape=(d, N)]
         An initial guess
-    kwargs
+    **kwargs
         Additional keyword arguments to `scipy.optimize.fmin_l_bfgs_b`
 
     Returns
@@ -92,7 +92,7 @@ def nnls(A, B, **kwargs):
         The basis matrix
     B : np.ndarray [shape=(..., m, N)]
         The target array.  Additional leading dimensions are supported.
-    kwargs
+    **kwargs
         Additional keyword arguments to `scipy.optimize.fmin_l_bfgs_b`
 
     Returns

--- a/librosa/util/_nnls.py
+++ b/librosa/util/_nnls.py
@@ -44,13 +44,10 @@ def _nnls_lbfgs_block(A, B, x_init=None, **kwargs):
     ----------
     A : np.ndarray [shape=(m, d)]
         The basis matrix
-
     B : np.ndarray [shape=(m, N)]
         The regression targets
-
     x_init : np.ndarray [shape=(d, N)]
         An initial guess
-
     kwargs
         Additional keyword arguments to `scipy.optimize.fmin_l_bfgs_b`
 
@@ -93,10 +90,8 @@ def nnls(A, B, **kwargs):
     ----------
     A : np.ndarray [shape=(m, n)]
         The basis matrix
-
     B : np.ndarray [shape=(..., m, N)]
         The target array.  Additional leading dimensions are supported.
-
     kwargs
         Additional keyword arguments to `scipy.optimize.fmin_l_bfgs_b`
 

--- a/librosa/util/decorators.py
+++ b/librosa/util/decorators.py
@@ -26,7 +26,7 @@ def moved(*, moved_from, version, version_removed):
                 moved_from, func.__module__, func.__name__, version, version_removed
             ),
             category=DeprecationWarning,
-            stacklevel=3  # Would be 2, but the decorator adds a level
+            stacklevel=3,  # Would be 2, but the decorator adds a level
         )
         return func(*args, **kwargs)
 
@@ -47,7 +47,7 @@ def deprecated(*, version, version_removed):
                 func.__module__, func.__name__, version, version_removed
             ),
             category=DeprecationWarning,
-            stacklevel=3  # Would be 2, but the decorator adds a level
+            stacklevel=3,  # Would be 2, but the decorator adds a level
         )
         return func(*args, **kwargs)
 

--- a/librosa/util/deprecation.py
+++ b/librosa/util/deprecation.py
@@ -23,14 +23,11 @@ def rename_kw(
     old_name : str
     old_value
         The name and value of the old argument
-
     new_name : str
     new_value
         The name and value of the new argument
-
     version_deprecated : str
         The version at which the old name became deprecated
-
     version_removed : str
         The version at which the old name will be removed
 

--- a/librosa/util/files.py
+++ b/librosa/util/files.py
@@ -55,12 +55,10 @@ def example(key, *, hq=False):
     >>> os.environ['LIBROSA_DATA_DIR'] = '/path/to/store/data'
     >>> import librosa
 
-
     Parameters
     ----------
     key : str
         The identifier for the track to load
-
     hq : bool
         If ``True``, return the high-quality version of the recording.
         If ``False``, return the 22KHz mono version of the recording.

--- a/librosa/util/matching.py
+++ b/librosa/util/matching.py
@@ -144,10 +144,8 @@ def match_intervals(intervals_from, intervals_to, strict=True):
         to ``intervals_from[i, 1]``.
         ``intervals_from[0, 0]`` should be 0, ``intervals_from[-1, 1]``
         should be the track duration.
-
     intervals_to : np.ndarray [shape=(m, 2)]
         Analogous to ``intervals_from``.
-
     strict : bool
         If ``True``, intervals can only match if they intersect.
         If ``False``, disjoint intervals can match.
@@ -239,12 +237,10 @@ def match_events(events_from, events_to, left=True, right=True):
     Parameters
     ----------
     events_from : ndarray [shape=(n,)]
-      Array of events (eg, times, sample or frame indices) to match from.
-
+        Array of events (eg, times, sample or frame indices) to match from.
     events_to : ndarray [shape=(m,)]
-      Array of events (eg, times, sample or frame indices) to
-      match against.
-
+        Array of events (eg, times, sample or frame indices) to
+        match against.
     left : bool
     right : bool
         If ``False``, then matched events cannot be to the left (or right)

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -392,7 +392,7 @@ def pad_center(data, *, size, axis=-1, **kwargs):
         Length to pad ``data``
     axis : int
         Axis along which to pad and center the data
-    kwargs : additional keyword arguments
+    **kwargs : additional keyword arguments
         arguments passed to `np.pad`
 
     Returns
@@ -525,7 +525,7 @@ def fix_length(data, *, size, axis=-1, **kwargs):
         desired length of the array
     axis : int, <= data.ndim
         axis along which to fix length
-    kwargs : additional keyword arguments
+    **kwargs : additional keyword arguments
         Parameters to ``np.pad``
 
     Returns
@@ -1805,7 +1805,7 @@ def cyclic_gradient(data, *, edge_order=1, axis=-1):
     data : np.ndarray
         The function values observed at uniformly spaced positions on
         a periodic domain
-    edge_order: {1, 2}
+    edge_order : {1, 2}
         The order of the difference approximation used for estimating
         the gradient
     axis : int

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -79,26 +79,20 @@ def frame(x, *, frame_length, hop_length, axis=-1, writeable=False, subok=False)
     adding a new "frame axis" either before the framing axis (if ``axis < 0``)
     or after the framing axis (if ``axis >= 0``).
 
-
     Parameters
     ----------
     x : np.ndarray
         Array to frame
-
     frame_length : int > 0 [scalar]
         Length of the frame
-
     hop_length : int > 0 [scalar]
         Number of steps to advance between frames
-
     axis : int
         The axis along which to frame.
-
     writeable : bool
         If ``True``, then the framed view of ``x`` is read-only.
         If ``False``, then the framed view is read-write.  Note that writing to the framed view
         will also write to the input array ``x`` in this case.
-
     subok : bool
         If True, sub-classes will be passed-through, otherwise the returned array will be
         forced to be a base-class array (default).
@@ -231,13 +225,13 @@ def valid_audio(y, *, mono=Deprecated()):
     Parameters
     ----------
     y : np.ndarray
-      The input data to validate
+        The input data to validate
 
     mono : bool
-      Whether or not to require monophonic audio
+        Whether or not to require monophonic audio
 
-      .. warning:: The ``mono`` parameter is deprecated in version 0.9 and will be
-        removed in 0.10.
+        .. warning:: The ``mono`` parameter is deprecated in version 0.9 and will be
+          removed in 0.10.
 
     Returns
     -------
@@ -266,7 +260,7 @@ def valid_audio(y, *, mono=Deprecated()):
     >>> librosa.util.valid_audio(y_stereo, mono=False)
     True
 
-    See also
+    See Also
     --------
     numpy.float32
     """
@@ -308,7 +302,6 @@ def valid_int(x, *, cast=None):
     ----------
     x : number
         A scalar value to be cast to int
-
     cast : function [optional]
         A function to modify ``x`` before casting.
         Default: `np.floor`
@@ -395,15 +388,12 @@ def pad_center(data, *, size, axis=-1, **kwargs):
     ----------
     data : np.ndarray
         Vector to be padded and centered
-
     size : int >= len(data) [scalar]
         Length to pad ``data``
-
     axis : int
         Axis along which to pad and center the data
-
     kwargs : additional keyword arguments
-      arguments passed to `np.pad`
+        arguments passed to `np.pad`
 
     Returns
     -------
@@ -445,10 +435,8 @@ def expand_to(x, *, ndim, axes):
     ----------
     x : np.ndarray
         The input array
-
     ndim : int
         The number of dimensions to expand to.  Must be at least ``x.ndim``
-
     axes : int or slice
         The target axis or axes to preserve from x.
         All other axes will have length 1.
@@ -532,14 +520,11 @@ def fix_length(data, *, size, axis=-1, **kwargs):
     Parameters
     ----------
     data : np.ndarray
-      array to be length-adjusted
-
+        array to be length-adjusted
     size : int >= 0 [scalar]
-      desired length of the array
-
+        desired length of the array
     axis : int, <= data.ndim
-      axis along which to fix length
-
+        axis along which to fix length
     kwargs : additional keyword arguments
         Parameters to ``np.pad``
 
@@ -604,18 +589,14 @@ def fix_frames(frames, *, x_min=0, x_max=None, pad=True):
     array([  0, 200, 233, 266, 299, 332, 365, 398, 431, 464, 497,
            500])
 
-
     Parameters
     ----------
     frames : np.ndarray [shape=(n_frames,)]
         List of non-negative frame indices
-
     x_min : int >= 0 or None
         Minimum allowed frame index
-
     x_max : int >= 0 or None
         Maximum allowed frame index
-
     pad : boolean
         If ``True``, then ``frames`` is expanded to span the full range
         ``[x_min, x_max]``
@@ -723,7 +704,6 @@ def axis_sort(S, *, axis=-1, index=False, value=None):
     -------
     S_sort : np.ndarray [shape=(d, n)]
         ``S`` with the columns or rows permuted in sorting order
-
     idx : np.ndarray (optional) [shape=(d,) or (n,)]
         If ``index == True``, the sorting index used to permute ``S``.
         Length of ``idx`` corresponds to the selected ``axis``.
@@ -773,7 +753,6 @@ def normalize(S, *, norm=np.inf, axis=0, threshold=None, fill=None):
     Note: the semantics of this function differ from
     `scipy.linalg.norm` in two ways: multi-dimensional arrays
     are supported, but matrix-norms are not.
-
 
     Parameters
     ----------
@@ -1012,15 +991,14 @@ def localmax(x, *, axis=0):
 
     Parameters
     ----------
-    x     : np.ndarray [shape=(d1,d2,...)]
-      input vector or array
-
+    x : np.ndarray [shape=(d1,d2,...)]
+        input vector or array
     axis : int
-      axis along which to compute local maximality
+        axis along which to compute local maximality
 
     Returns
     -------
-    m     : np.ndarray [shape=x.shape, dtype=bool]
+    m : np.ndarray [shape=x.shape, dtype=bool]
         indicator array of local maximality along ``axis``
 
     See Also
@@ -1074,15 +1052,14 @@ def localmin(x, *, axis=0):
 
     Parameters
     ----------
-    x     : np.ndarray [shape=(d1,d2,...)]
-      input vector or array
-
+    x : np.ndarray [shape=(d1,d2,...)]
+        input vector or array
     axis : int
-      axis along which to compute local minimality
+        axis along which to compute local minimality
 
     Returns
     -------
-    m     : np.ndarray [shape=x.shape, dtype=bool]
+    m : np.ndarray [shape=x.shape, dtype=bool]
         indicator array of local minimality along ``axis``
 
     See Also
@@ -1124,33 +1101,26 @@ def peak_pick(x, *, pre_max, post_max, pre_avg, post_avg, delta, wait):
 
     .. [#] https://github.com/CPJKU/onset_detection/blob/master/onset_program.py
 
-
     Parameters
     ----------
-    x         : np.ndarray [shape=(n,)]
+    x : np.ndarray [shape=(n,)]
         input signal to peak picks from
-
-    pre_max   : int >= 0 [scalar]
+    pre_max : int >= 0 [scalar]
         number of samples before ``n`` over which max is computed
-
-    post_max  : int >= 1 [scalar]
+    post_max : int >= 1 [scalar]
         number of samples after ``n`` over which max is computed
-
-    pre_avg   : int >= 0 [scalar]
+    pre_avg : int >= 0 [scalar]
         number of samples before ``n`` over which mean is computed
-
-    post_avg  : int >= 1 [scalar]
+    post_avg : int >= 1 [scalar]
         number of samples after ``n`` over which mean is computed
-
-    delta     : float >= 0 [scalar]
+    delta : float >= 0 [scalar]
         threshold offset for mean
-
-    wait      : int >= 0 [scalar]
+    wait : int >= 0 [scalar]
         number of samples to wait after picking a peak
 
     Returns
     -------
-    peaks     : np.ndarray [shape=(n_peaks,), dtype=int]
+    peaks : np.ndarray [shape=(n_peaks,), dtype=int]
         indices of peaks in ``x``
 
     Raises
@@ -1275,10 +1245,8 @@ def sparsify_rows(x, *, quantile=0.01, dtype=None):
     ----------
     x : np.ndarray [ndim <= 2]
         The input matrix to sparsify.
-
     quantile : float in [0, 1.0)
         Percentage of magnitude to discard in each row of ``x``
-
     dtype : np.dtype, optional
         The dtype of the output array.
         If not provided, then ``x.dtype`` will be used.
@@ -1377,10 +1345,8 @@ def buf_to_float(x, *, n_bytes=2, dtype=np.float32):
     ----------
     x : np.ndarray [dtype=int]
         The integer-valued data buffer
-
     n_bytes : int [1, 2, 4]
         The number of bytes per sample in ``x``
-
     dtype : numeric type
         The target output type (default: 32-bit float)
 
@@ -1407,14 +1373,11 @@ def index_to_slice(idx, *, idx_min=None, idx_max=None, step=None, pad=True):
     ----------
     idx : list-like
         Array of index boundaries
-
     idx_min, idx_max : None or int
         Minimum and maximum allowed indices
-
     step : None or int
         Step size for each slice.  If `None`, then the default
         step of 1 is used.
-
     pad : boolean
         If `True`, pad ``idx`` to span the range ``idx_min:idx_max``.
 
@@ -1468,20 +1431,15 @@ def sync(data, idx, *, aggregate=None, pad=True, axis=-1):
 
     Parameters
     ----------
-    data      : np.ndarray
+    data : np.ndarray
         multi-dimensional array of features
-
     idx : iterable of ints or slices
         Either an ordered array of boundary indices, or
         an iterable collection of slice objects.
-
-
     aggregate : function
         aggregation function (default: `np.mean`)
-
     pad : boolean
         If `True`, ``idx`` is padded to span the full range ``[0, data.shape[axis]]``
-
     axis : int
         The axis along which to aggregate data
 
@@ -1527,7 +1485,6 @@ def sync(data, idx, *, aggregate=None, pad=True, axis=-1):
     >>> sub_beats = librosa.segment.subsegment(C, beats)
     >>> sub_beats = librosa.util.fix_frames(sub_beats)
     >>> C_med_sub = librosa.util.sync(C, sub_beats, aggregate=np.median)
-
 
     Plot the results
 
@@ -1590,7 +1547,6 @@ def softmask(X, X_ref, *, power=1, split_zeros=False):
 
         ``M = X**power / (X**power + X_ref**power)``
 
-
     Parameters
     ----------
     X : np.ndarray
@@ -1606,13 +1562,11 @@ def softmask(X, X_ref, *, power=1, split_zeros=False):
         If infinite, returns a hard (binary) mask equivalent to ``X > X_ref``.
         Note: for hard masks, ties are always broken in favor of ``X_ref`` (``mask=0``).
 
-
     split_zeros : bool
         If `True`, entries where ``X`` and ``X_ref`` are both small (close to 0)
         will receive mask values of 0.5.
 
         Otherwise, the mask is set to 0 for these entries.
-
 
     Returns
     -------
@@ -1630,7 +1584,6 @@ def softmask(X, X_ref, *, power=1, split_zeros=False):
 
     Examples
     --------
-
     >>> X = 2 * np.ones((3, 3))
     >>> X_ref = np.vander(np.arange(3.0))
     >>> X
@@ -1731,7 +1684,6 @@ def tiny(x):
 
     Examples
     --------
-
     For a standard double-precision floating point number:
 
     >>> librosa.util.tiny(1.0)
@@ -1853,11 +1805,9 @@ def cyclic_gradient(data, *, edge_order=1, axis=-1):
     data : np.ndarray
         The function values observed at uniformly spaced positions on
         a periodic domain
-
     edge_order: {1, 2}
         The order of the difference approximation used for estimating
         the gradient
-
     axis : int
         The axis along which gradients are calculated.
 
@@ -1963,15 +1913,12 @@ def shear(X, *, factor=1, axis=-1):
     to a horizontal.  Shearing with ``factor=1`` converts a horizontal to
     a diagonal.
 
-
     Parameters
     ----------
     X : np.ndarray [ndim=2] or scipy.sparse matrix
         The array to be sheared
-
     factor : integer
         The shear factor: ``X[:, n] -> np.roll(X[:, n], factor * n)``
-
     axis : integer
         The axis along which to shear
 
@@ -2020,11 +1967,9 @@ def stack(arrays, *, axis=0):
     ----------
     arrays : list
         one or more `np.ndarray`
-
     axis : integer
         The target axis along which to stack.  ``axis=0`` creates a new first axis,
         and ``axis=-1`` creates a new last axis.
-
 
     Returns
     -------
@@ -2038,7 +1983,6 @@ def stack(arrays, *, axis=0):
     Raises
     ------
     ParameterError
-
         - If ``arrays`` do not all have the same shape
         - If no ``arrays`` are given
 
@@ -2122,13 +2066,11 @@ def dtype_r2c(d, *, default=np.complex64):
     A `float32` (single-precision) type maps to `complex64`,
     while a `float64` (double-precision) maps to `complex128`.
 
-
     Parameters
     ----------
     d : np.dtype
         The real-valued dtype to convert to complex.
         If ``d`` is a complex type already, it will be returned.
-
     default : np.dtype, optional
         The default complex target type, if ``d`` does not match a
         known dtype
@@ -2180,13 +2122,11 @@ def dtype_c2r(d, *, default=np.float32):
     A `complex64` (single-precision) type maps to `float32`,
     while a `complex128` (double-precision) maps to `float64`.
 
-
     Parameters
     ----------
     d : np.dtype
         The complex-valued dtype to convert to real.
         If ``d`` is a real (float) type already, it will be returned.
-
     default : np.dtype, optional
         The default real target type, if ``d`` does not match a
         known dtype
@@ -2250,7 +2190,6 @@ def count_unique(data, *, axis=-1):
     ----------
     data : np.ndarray
         The input array
-
     axis : int
         The target axis to count
 
@@ -2266,7 +2205,6 @@ def count_unique(data, *, axis=-1):
 
     Examples
     --------
-
     >>> x = np.vander(np.arange(5))
     >>> x
     array([[  0,   0,   0,   0,   1],
@@ -2304,7 +2242,6 @@ def is_unique(data, *, axis=-1):
     ----------
     data : np.ndarray
         The input array
-
     axis : int
         The target axis
 
@@ -2321,7 +2258,6 @@ def is_unique(data, *, axis=-1):
 
     Examples
     --------
-
     >>> x = np.vander(np.arange(5))
     >>> x
     array([[  0,   0,   0,   0,   1],

--- a/librosa/version.py
+++ b/librosa/version.py
@@ -5,8 +5,8 @@
 import sys
 import importlib
 
-short_version = "0.8"
-version = "0.8.1"
+short_version = "0.9"
+version = "0.9.0rc0"
 
 
 def __get_mod_version(modname):


### PR DESCRIPTION
#### Reference Issue
Fixes #1438 


#### What does this implement/fix? Explain your changes.

This PR implements our usual release audit, in preparation for the 0.9.0 series.

#### Any other comments?

This one will be a release candidate (0.9.0rc0) when merged.

I've used a new tool [velin](https://pypi.org/project/velin/) to automate corrections to numpydoc format.  It has the option to act as a linter/checker, should we add this to our lint CI?  If so, I'll roll that change into this PR as well.