### PR TITLE
deprecation shim for positional arguments

### DIFF
--- a/librosa/beat.py
+++ b/librosa/beat.py
@@ -21,10 +21,12 @@ from . import onset
 from . import util
 from .feature import tempogram, fourier_tempogram
 from .util.exceptions import ParameterError
+from .util.decorators import deprecate_positional_args
 
 __all__ = ["beat_track", "tempo", "plp"]
 
 
+@deprecate_positional_args
 def beat_track(
     *,
     y=None,
@@ -191,6 +193,7 @@ def beat_track(
 
 
 @cache(level=30)
+@deprecate_positional_args
 def tempo(
     *,
     y=None,
@@ -355,6 +358,7 @@ def tempo(
     return np.take(bpms, best_period)
 
 
+@deprecate_positional_args
 def plp(
     *,
     y=None,

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -17,6 +17,7 @@ from .convert import frames_to_samples, time_to_samples
 from .._cache import cache
 from .. import util
 from ..util.exceptions import ParameterError
+from ..util.decorators import deprecate_positional_args
 
 __all__ = [
     "load",
@@ -43,6 +44,7 @@ BW_FASTEST = resampy.filters.get_filter("kaiser_fast")[2]
 # -- CORE ROUTINES --#
 # Load should never be cached, since we cannot verify that the contents of
 # 'path' are unchanged across calls.
+@deprecate_positional_args
 def load(
     path,
     *,
@@ -241,6 +243,7 @@ def __audioread_load(path, offset, duration, dtype):
     return y, sr_native
 
 
+@deprecate_positional_args
 def stream(
     path,
     *,
@@ -468,6 +471,7 @@ def to_mono(y):
     return y
 
 
+@deprecate_positional_args
 @cache(level=20)
 def resample(
     y, *, orig_sr, target_sr, res_type="kaiser_best", fix=True, scale=False, **kwargs
@@ -621,6 +625,7 @@ def resample(
     return y_hat.astype(y.dtype)
 
 
+@deprecate_positional_args
 def get_duration(
     *, y=None, sr=22050, S=None, n_fft=2048, hop_length=512, center=True, filename=None
 ):
@@ -763,6 +768,7 @@ def get_samplerate(path):
             return fdesc.samplerate
 
 
+@deprecate_positional_args
 @cache(level=20)
 def autocorrelate(y, *, max_size=None, axis=-1):
     """Bounded-lag auto-correlation
@@ -832,6 +838,7 @@ def autocorrelate(y, *, max_size=None, axis=-1):
     return autocorr
 
 
+@deprecate_positional_args
 def lpc(y, *, order, axis=-1):
     """Linear Prediction Coefficients via Burg's method
 
@@ -1016,6 +1023,7 @@ def __lpc(y, order, ar_coeffs, ar_coeffs_prev, reflect_coeff, den, epsilon):
     return ar_coeffs
 
 
+@deprecate_positional_args
 @cache(level=20)
 def zero_crossings(
     y, *, threshold=1e-10, ref_magnitude=None, pad=True, zero_pos=True, axis=-1
@@ -1145,6 +1153,7 @@ def zero_crossings(
     )
 
 
+@deprecate_positional_args
 def clicks(
     *,
     times=None,
@@ -1282,6 +1291,7 @@ def clicks(
     return click_signal
 
 
+@deprecate_positional_args
 def tone(frequency, *, sr=22050, length=None, duration=None, phi=None):
     """Construct a pure tone (cosine) signal at a given frequency.
 
@@ -1347,6 +1357,7 @@ def tone(frequency, *, sr=22050, length=None, duration=None, phi=None):
     return np.cos(2 * np.pi * frequency * np.arange(length) / sr + phi)
 
 
+@deprecate_positional_args
 def chirp(*, fmin, fmax, sr=22050, length=None, duration=None, linear=False, phi=None):
     """Construct a "chirp" or "sine-sweep" signal.
 
@@ -1452,6 +1463,7 @@ def chirp(*, fmin, fmax, sr=22050, length=None, duration=None, linear=False, phi
     )
 
 
+@deprecate_positional_args
 def mu_compress(x, *, mu=255, quantize=True):
     """mu-law compression
 
@@ -1546,6 +1558,7 @@ def mu_compress(x, *, mu=255, quantize=True):
     return x_comp
 
 
+@deprecate_positional_args
 def mu_expand(x, *, mu=255.0, quantize=True):
     """mu-law expansion
 

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -14,12 +14,14 @@ from .._cache import cache
 from .. import filters
 from .. import util
 from ..util.exceptions import ParameterError
+from ..util.decorators import deprecate_positional_args
 
 __all__ = ["cqt", "hybrid_cqt", "pseudo_cqt", "icqt", "griffinlim_cqt", "vqt"]
 
 # TODO: ivqt, griffinlim_vqt
 
 
+@deprecate_positional_args
 @cache(level=20)
 def cqt(
     y,
@@ -193,6 +195,7 @@ def cqt(
     )
 
 
+@deprecate_positional_args
 @cache(level=20)
 def hybrid_cqt(
     y,
@@ -376,6 +379,7 @@ def hybrid_cqt(
     return __trim_stack(cqt_resp, n_bins, cqt_resp[-1].dtype)
 
 
+@deprecate_positional_args
 @cache(level=20)
 def pseudo_cqt(
     y,
@@ -532,6 +536,7 @@ def pseudo_cqt(
     return C
 
 
+@deprecate_positional_args
 @cache(level=40)
 def icqt(
     C,
@@ -756,6 +761,7 @@ def icqt(
     return y
 
 
+@deprecate_positional_args
 @cache(level=20)
 def vqt(
     y,
@@ -1227,6 +1233,7 @@ def __num_two_factors(x):
     return num_twos
 
 
+@deprecate_positional_args
 def griffinlim_cqt(
     C,
     *,

--- a/librosa/core/convert.py
+++ b/librosa/core/convert.py
@@ -6,6 +6,7 @@ import re
 import numpy as np
 from . import notation
 from ..util.exceptions import ParameterError
+from ..util.decorators import deprecate_positional_args
 
 __all__ = [
     "frames_to_samples",
@@ -52,6 +53,7 @@ __all__ = [
 ]
 
 
+@deprecate_positional_args
 def frames_to_samples(frames, *, hop_length=512, n_fft=None):
     """Converts frame indices to audio sample indices.
 
@@ -92,6 +94,7 @@ def frames_to_samples(frames, *, hop_length=512, n_fft=None):
     return (np.asanyarray(frames) * hop_length + offset).astype(int)
 
 
+@deprecate_positional_args
 def samples_to_frames(samples, *, hop_length=512, n_fft=None):
     """Converts sample indices into STFT frames.
 
@@ -143,6 +146,7 @@ def samples_to_frames(samples, *, hop_length=512, n_fft=None):
     return np.floor((samples - offset) // hop_length).astype(int)
 
 
+@deprecate_positional_args
 def frames_to_time(frames, *, sr=22050, hop_length=512, n_fft=None):
     """Converts frame counts to time (seconds).
 
@@ -183,6 +187,7 @@ def frames_to_time(frames, *, sr=22050, hop_length=512, n_fft=None):
     return samples_to_time(samples, sr=sr)
 
 
+@deprecate_positional_args
 def time_to_frames(times, *, sr=22050, hop_length=512, n_fft=None):
     """Converts time stamps into STFT frames.
 
@@ -231,6 +236,7 @@ def time_to_frames(times, *, sr=22050, hop_length=512, n_fft=None):
     return samples_to_frames(samples, hop_length=hop_length, n_fft=n_fft)
 
 
+@deprecate_positional_args
 def time_to_samples(times, *, sr=22050):
     """Convert timestamps (in seconds) to sample indices.
 
@@ -262,6 +268,7 @@ def time_to_samples(times, *, sr=22050):
     return (np.asanyarray(times) * sr).astype(int)
 
 
+@deprecate_positional_args
 def samples_to_time(samples, *, sr=22050):
     """Convert sample indices to time (in seconds).
 
@@ -299,6 +306,7 @@ def samples_to_time(samples, *, sr=22050):
     return np.asanyarray(samples) / float(sr)
 
 
+@deprecate_positional_args
 def blocks_to_frames(blocks, *, block_length):
     """Convert block indices to frame indices
 
@@ -335,6 +343,7 @@ def blocks_to_frames(blocks, *, block_length):
     return block_length * np.asanyarray(blocks)
 
 
+@deprecate_positional_args
 def blocks_to_samples(blocks, *, block_length, hop_length):
     """Convert block indices to sample indices
 
@@ -378,6 +387,7 @@ def blocks_to_samples(blocks, *, block_length, hop_length):
     return frames_to_samples(frames, hop_length=hop_length)
 
 
+@deprecate_positional_args
 def blocks_to_time(blocks, *, block_length, hop_length, sr):
     """Convert block indices to time (in seconds)
 
@@ -461,6 +471,7 @@ def note_to_hz(note, **kwargs):
     return midi_to_hz(note_to_midi(note, **kwargs))
 
 
+@deprecate_positional_args
 def note_to_midi(note, *, round_midi=True):
     """Convert one or more spelled notes to MIDI number(s).
 
@@ -569,6 +580,7 @@ def note_to_midi(note, *, round_midi=True):
     return note_value
 
 
+@deprecate_positional_args
 def midi_to_note(midi, *, octave=True, cents=False, key="C:maj", unicode=True):
     """Convert one or more MIDI numbers to note strings.
 
@@ -772,6 +784,7 @@ def hz_to_note(frequencies, **kwargs):
     return midi_to_note(hz_to_midi(frequencies), **kwargs)
 
 
+@deprecate_positional_args
 def hz_to_mel(frequencies, *, htk=False):
     """Convert Hz to Mels
 
@@ -827,6 +840,7 @@ def hz_to_mel(frequencies, *, htk=False):
     return mels
 
 
+@deprecate_positional_args
 def mel_to_hz(mels, *, htk=False):
     """Convert mel bin numbers to frequencies
 
@@ -881,6 +895,7 @@ def mel_to_hz(mels, *, htk=False):
     return freqs
 
 
+@deprecate_positional_args
 def hz_to_octs(frequencies, *, tuning=0.0, bins_per_octave=12):
     """Convert frequencies (Hz) to (fractional) octave numbers.
 
@@ -915,6 +930,7 @@ def hz_to_octs(frequencies, *, tuning=0.0, bins_per_octave=12):
     return np.log2(np.asanyarray(frequencies) / (float(A440) / 16))
 
 
+@deprecate_positional_args
 def octs_to_hz(octs, *, tuning=0.0, bins_per_octave=12):
     """Convert octaves numbers to frequencies.
 
@@ -950,6 +966,7 @@ def octs_to_hz(octs, *, tuning=0.0, bins_per_octave=12):
     return (float(A440) / 16) * (2.0 ** np.asanyarray(octs))
 
 
+@deprecate_positional_args
 def A4_to_tuning(A4, *, bins_per_octave=12):
     """Convert a reference pitch frequency (e.g., ``A4=435``) to a tuning
     estimation, in fractions of a bin per octave.
@@ -999,6 +1016,7 @@ def A4_to_tuning(A4, *, bins_per_octave=12):
     return bins_per_octave * (np.log2(np.asanyarray(A4)) - np.log2(440.0))
 
 
+@deprecate_positional_args
 def tuning_to_A4(tuning, *, bins_per_octave=12):
     """Convert a tuning deviation (from 0) in fractions of a bin per
     octave (e.g., ``tuning=-0.1``) to a reference pitch frequency
@@ -1049,6 +1067,7 @@ def tuning_to_A4(tuning, *, bins_per_octave=12):
     return 440.0 * 2.0 ** (np.asanyarray(tuning) / bins_per_octave)
 
 
+@deprecate_positional_args
 def fft_frequencies(*, sr=22050, n_fft=2048):
     """Alternative implementation of `np.fft.fftfreq`
 
@@ -1075,6 +1094,7 @@ def fft_frequencies(*, sr=22050, n_fft=2048):
     return np.fft.rfftfreq(n=n_fft, d=1.0 / sr)
 
 
+@deprecate_positional_args
 def cqt_frequencies(n_bins, *, fmin, bins_per_octave=12, tuning=0.0):
     """Compute the center frequencies of Constant-Q bins.
 
@@ -1110,6 +1130,7 @@ def cqt_frequencies(n_bins, *, fmin, bins_per_octave=12, tuning=0.0):
     return correction * fmin * frequencies
 
 
+@deprecate_positional_args
 def mel_frequencies(n_mels=128, *, fmin=0.0, fmax=11025.0, htk=False):
     """Compute an array of acoustic frequencies tuned to the mel scale.
 
@@ -1192,6 +1213,7 @@ def mel_frequencies(n_mels=128, *, fmin=0.0, fmax=11025.0, htk=False):
     return mel_to_hz(mels, htk=htk)
 
 
+@deprecate_positional_args
 def tempo_frequencies(n_bins, *, hop_length=512, sr=22050):
     """Compute the frequencies (in beats per minute) corresponding
     to an onset auto-correlation or tempogram matrix.
@@ -1229,6 +1251,7 @@ def tempo_frequencies(n_bins, *, hop_length=512, sr=22050):
     return bin_frequencies
 
 
+@deprecate_positional_args
 def fourier_tempo_frequencies(*, sr=22050, win_length=384, hop_length=512):
     """Compute the frequencies (in beats per minute) corresponding
     to a Fourier tempogram matrix.
@@ -1262,6 +1285,7 @@ def fourier_tempo_frequencies(*, sr=22050, win_length=384, hop_length=512):
 
 
 # A-weighting should be capitalized: suppress the naming warning
+@deprecate_positional_args
 def A_weighting(frequencies, *, min_db=-80.0):  # pylint: disable=invalid-name
     """Compute the A-weighting of a set of frequencies.
 
@@ -1315,6 +1339,7 @@ def A_weighting(frequencies, *, min_db=-80.0):  # pylint: disable=invalid-name
     return weights if min_db is None else np.maximum(min_db, weights)
 
 
+@deprecate_positional_args
 def B_weighting(frequencies, *, min_db=-80.0):  # pylint: disable=invalid-name
     """Compute the B-weighting of a set of frequencies.
 
@@ -1367,6 +1392,7 @@ def B_weighting(frequencies, *, min_db=-80.0):  # pylint: disable=invalid-name
     return weights if min_db is None else np.maximum(min_db, weights)
 
 
+@deprecate_positional_args
 def C_weighting(frequencies, *, min_db=-80.0):  # pylint: disable=invalid-name
     """Compute the C-weighting of a set of frequencies.
 
@@ -1417,6 +1443,7 @@ def C_weighting(frequencies, *, min_db=-80.0):  # pylint: disable=invalid-name
     return weights if min_db is None else np.maximum(min_db, weights)
 
 
+@deprecate_positional_args
 def D_weighting(frequencies, *, min_db=-80.0):  # pylint: disable=invalid-name
     """Compute the D-weighting of a set of frequencies.
 
@@ -1472,6 +1499,7 @@ def D_weighting(frequencies, *, min_db=-80.0):  # pylint: disable=invalid-name
     return weights if min_db is None else np.maximum(min_db, weights)
 
 
+@deprecate_positional_args
 def Z_weighting(frequencies, *, min_db=None):  # pylint: disable=invalid-name
     weights = np.zeros(len(frequencies))
     return weights if min_db is None else np.maximum(min_db, weights)
@@ -1487,6 +1515,7 @@ WEIGHTING_FUNCTIONS = {
 }
 
 
+@deprecate_positional_args
 def frequency_weighting(frequencies, *, kind="A", **kwargs):
     """Compute the weighting of a set of frequencies.
 
@@ -1530,6 +1559,7 @@ def frequency_weighting(frequencies, *, kind="A", **kwargs):
     return WEIGHTING_FUNCTIONS[kind](frequencies, **kwargs)
 
 
+@deprecate_positional_args
 def multi_frequency_weighting(frequencies, *, kinds="ZAC", **kwargs):
     """Compute multiple weightings of a set of frequencies.
 
@@ -1576,6 +1606,7 @@ def multi_frequency_weighting(frequencies, *, kinds="ZAC", **kwargs):
     )
 
 
+@deprecate_positional_args
 def times_like(X, *, sr=22050, hop_length=512, n_fft=None, axis=-1):
     """Return an array of time values to match the time axis from a feature matrix.
 
@@ -1628,6 +1659,7 @@ def times_like(X, *, sr=22050, hop_length=512, n_fft=None, axis=-1):
     return samples_to_time(samples, sr=sr)
 
 
+@deprecate_positional_args
 def samples_like(X, *, hop_length=512, n_fft=None, axis=-1):
     """Return an array of sample indices to match the time axis from a feature matrix.
 
@@ -1680,6 +1712,7 @@ def samples_like(X, *, hop_length=512, n_fft=None, axis=-1):
     return frames_to_samples(frames, hop_length=hop_length, n_fft=n_fft)
 
 
+@deprecate_positional_args
 def midi_to_svara_h(midi, *, Sa, abbr=True, octave=True, unicode=True):
     """Convert MIDI numbers to Hindustani svara
 
@@ -1788,6 +1821,7 @@ def midi_to_svara_h(midi, *, Sa, abbr=True, octave=True, unicode=True):
     return svara
 
 
+@deprecate_positional_args
 def hz_to_svara_h(frequencies, *, Sa, abbr=True, octave=True, unicode=True):
     """Convert frequencies (in Hz) to Hindustani svara
 
@@ -1850,6 +1884,7 @@ def hz_to_svara_h(frequencies, *, Sa, abbr=True, octave=True, unicode=True):
     )
 
 
+@deprecate_positional_args
 def note_to_svara_h(notes, *, Sa, abbr=True, octave=True, unicode=True):
     """Convert western notes to Hindustani svara
 
@@ -1909,6 +1944,7 @@ def note_to_svara_h(notes, *, Sa, abbr=True, octave=True, unicode=True):
     )
 
 
+@deprecate_positional_args
 def midi_to_svara_c(midi, *, Sa, mela, abbr=True, octave=True, unicode=True):
     """Convert MIDI numbers to Carnatic svara within a given melakarta raga
 
@@ -1983,6 +2019,7 @@ def midi_to_svara_c(midi, *, Sa, mela, abbr=True, octave=True, unicode=True):
     return svara
 
 
+@deprecate_positional_args
 def hz_to_svara_c(frequencies, *, Sa, mela, abbr=True, octave=True, unicode=True):
     """Convert frequencies (in Hz) to Carnatic svara
 
@@ -2049,6 +2086,7 @@ def hz_to_svara_c(frequencies, *, Sa, mela, abbr=True, octave=True, unicode=True
     )
 
 
+@deprecate_positional_args
 def note_to_svara_c(notes, *, Sa, mela, abbr=True, octave=True, unicode=True):
     """Convert western notes to Carnatic svara
 

--- a/librosa/core/harmonic.py
+++ b/librosa/core/harmonic.py
@@ -9,10 +9,12 @@ import scipy.interpolate
 import scipy.signal
 from ..util.exceptions import ParameterError
 from ..util import is_unique
+from ..util.decorators import deprecate_positional_args
 
 __all__ = ["salience", "interp_harmonics"]
 
 
+@deprecate_positional_args
 def salience(
     S,
     *,
@@ -128,6 +130,7 @@ def salience(
     return S_sal
 
 
+@deprecate_positional_args
 def interp_harmonics(x, *, freqs, harmonics, kind="linear", fill_value=0, axis=-2):
     """Compute the energy at harmonics of time-frequency representation.
 

--- a/librosa/core/notation.py
+++ b/librosa/core/notation.py
@@ -6,6 +6,7 @@ import re
 import numpy as np
 from .._cache import cache
 from ..util.exceptions import ParameterError
+from ..util.decorators import deprecate_positional_args
 
 __all__ = [
     "key_to_degrees",
@@ -243,6 +244,7 @@ def mela_to_degrees(mela):
     return np.array(degrees)
 
 
+@deprecate_positional_args
 @cache(level=10)
 def mela_to_svara(mela, *, abbr=True, unicode=True):
     """Spell the Carnatic svara names for a given melakarta raga
@@ -454,6 +456,7 @@ def list_thaat():
     return list(THAAT_MAP.keys())
 
 
+@deprecate_positional_args
 @cache(level=10)
 def key_to_notes(key, *, unicode=True):
     """Lists all 12 note names in the chromatic scale, as spelled according to

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -13,10 +13,12 @@ from .._cache import cache
 from .. import util
 from .. import sequence
 from ..util.exceptions import ParameterError
+from ..util.decorators import deprecate_positional_args
 
 __all__ = ["estimate_tuning", "pitch_tuning", "piptrack", "yin", "pyin"]
 
 
+@deprecate_positional_args
 def estimate_tuning(
     *,
     y=None,
@@ -102,6 +104,7 @@ def estimate_tuning(
     )
 
 
+@deprecate_positional_args
 def pitch_tuning(frequencies, *, resolution=0.01, bins_per_octave=12):
     """Given a collection of pitches, estimate its tuning offset
     (in fractions of a bin) relative to A440=440.0Hz.
@@ -171,6 +174,7 @@ def pitch_tuning(frequencies, *, resolution=0.01, bins_per_octave=12):
     return tuning[np.argmax(counts)]
 
 
+@deprecate_positional_args
 @cache(level=30)
 def piptrack(
     *,
@@ -450,6 +454,7 @@ def _parabolic_interpolation(y_frames):
     return parabolic_shifts
 
 
+@deprecate_positional_args
 def yin(
     y,
     *,
@@ -615,6 +620,7 @@ def yin(
     return f0
 
 
+@deprecate_positional_args
 def pyin(
     y,
     *,

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -19,6 +19,7 @@ from .. import util
 from ..util.exceptions import ParameterError
 from ..filters import get_window, semitone_filterbank
 from ..filters import window_sumsquare
+from ..util.decorators import deprecate_positional_args
 
 __all__ = [
     "stft",
@@ -38,6 +39,7 @@ __all__ = [
 ]
 
 
+@deprecate_positional_args
 @cache(level=20)
 def stft(
     y,
@@ -255,6 +257,7 @@ def stft(
     return stft_matrix
 
 
+@deprecate_positional_args
 @cache(level=30)
 def istft(
     stft_matrix,
@@ -804,6 +807,7 @@ def __reassign_times(
     return times, S_h
 
 
+@deprecate_positional_args
 def reassigned_spectrogram(
     y,
     *,
@@ -1108,6 +1112,7 @@ def reassigned_spectrogram(
     return freqs, times, mags
 
 
+@deprecate_positional_args
 def magphase(D, *, power=1):
     """Separate a complex-valued spectrogram D into its magnitude (S)
     and phase (P) components, so that ``D = S * P``.
@@ -1169,6 +1174,7 @@ def magphase(D, *, power=1):
     return mag, phase
 
 
+@deprecate_positional_args
 def phase_vocoder(D, *, rate, hop_length=None, n_fft=None):
     """Phase vocoder.  Given an STFT matrix D, speed up by a factor of ``rate``
 
@@ -1276,6 +1282,7 @@ def phase_vocoder(D, *, rate, hop_length=None, n_fft=None):
     return d_stretch
 
 
+@deprecate_positional_args
 @cache(level=20)
 def iirt(
     y,
@@ -1469,6 +1476,7 @@ def iirt(
     return bands_power
 
 
+@deprecate_positional_args
 @cache(level=30)
 def power_to_db(S, *, ref=1.0, amin=1e-10, top_db=80.0):
     """Convert a power spectrogram (amplitude squared) to decibel (dB) units
@@ -1592,6 +1600,7 @@ def power_to_db(S, *, ref=1.0, amin=1e-10, top_db=80.0):
     return log_spec
 
 
+@deprecate_positional_args
 @cache(level=30)
 def db_to_power(S_db, *, ref=1.0):
     """Convert a dB-scale spectrogram to a power spectrogram.
@@ -1619,6 +1628,7 @@ def db_to_power(S_db, *, ref=1.0):
     return ref * np.power(10.0, 0.1 * S_db)
 
 
+@deprecate_positional_args
 @cache(level=30)
 def amplitude_to_db(S, *, ref=1.0, amin=1e-5, top_db=80.0):
     """Convert an amplitude spectrogram to dB-scaled spectrogram.
@@ -1681,6 +1691,7 @@ def amplitude_to_db(S, *, ref=1.0, amin=1e-5, top_db=80.0):
     return power_to_db(power, ref=ref_value ** 2, amin=amin ** 2, top_db=top_db)
 
 
+@deprecate_positional_args
 @cache(level=30)
 def db_to_amplitude(S_db, *, ref=1.0):
     """Convert a dB-scaled spectrogram to an amplitude spectrogram.
@@ -1708,6 +1719,7 @@ def db_to_amplitude(S_db, *, ref=1.0):
     return db_to_power(S_db, ref=ref ** 2) ** 0.5
 
 
+@deprecate_positional_args
 @cache(level=30)
 def perceptual_weighting(S, frequencies, *, kind="A", **kwargs):
     """Perceptual weighting of a power spectrogram::
@@ -1779,6 +1791,7 @@ def perceptual_weighting(S, frequencies, *, kind="A", **kwargs):
     return offset + power_to_db(S, **kwargs)
 
 
+@deprecate_positional_args
 @cache(level=30)
 def fmt(y, *, t_min=0.5, n_fmt=None, kind="cubic", beta=0.5, over_sample=1, axis=-1):
     """The fast Mellin transform (FMT)
@@ -1969,6 +1982,7 @@ def fmt(y, *, t_min=0.5, n_fmt=None, kind="cubic", beta=0.5, over_sample=1, axis
     )
 
 
+@deprecate_positional_args
 @cache(level=30)
 def pcen(
     S,
@@ -2238,6 +2252,7 @@ def pcen(
         return S_out
 
 
+@deprecate_positional_args
 def griffinlim(
     S,
     *,

--- a/librosa/decompose.py
+++ b/librosa/decompose.py
@@ -23,10 +23,12 @@ from ._cache import cache
 from . import segment
 from . import util
 from .util.exceptions import ParameterError
+from .util.decorators import deprecate_positional_args
 
 __all__ = ["decompose", "hpss", "nn_filter"]
 
 
+@deprecate_positional_args
 def decompose(
     S, *, n_components=None, transformer=None, sort=False, fit=True, **kwargs
 ):
@@ -198,6 +200,7 @@ def decompose(
 
 
 @cache(level=30)
+@deprecate_positional_args
 def hpss(S, *, kernel_size=31, power=2.0, mask=False, margin=1.0):
     """Median-filtering harmonic percussive source separation (HPSS).
 
@@ -388,6 +391,7 @@ def hpss(S, *, kernel_size=31, power=2.0, mask=False, margin=1.0):
 
 
 @cache(level=30)
+@deprecate_positional_args
 def nn_filter(S, *, rec=None, aggregate=None, axis=-1, **kwargs):
     """Filtering by nearest-neighbors.
 

--- a/librosa/display.py
+++ b/librosa/display.py
@@ -50,6 +50,7 @@ from packaging.version import parse as version_parse
 from . import core
 from . import util
 from .util.exceptions import ParameterError
+from .util.decorators import deprecate_positional_args
 
 __all__ = [
     "specshow",
@@ -550,6 +551,7 @@ class AdaptiveWaveplot:
         ax.figure.canvas.draw_idle()
 
 
+@deprecate_positional_args
 def cmap(
     data, *, robust=True, cmap_seq="magma", cmap_bool="gray_r", cmap_div="coolwarm"
 ):
@@ -615,6 +617,7 @@ def __envelope(x, hop):
     return x_frame.max(axis=1)
 
 
+@deprecate_positional_args
 def specshow(
     data,
     *,
@@ -1279,6 +1282,7 @@ def __same_axes(x_axis, y_axis, xlim, ylim):
     return axes_same_and_not_none and axes_same_lim
 
 
+@deprecate_positional_args
 def waveshow(
     y,
     *,

--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -41,6 +41,7 @@ from . import decompose
 from . import feature
 from . import util
 from .util.exceptions import ParameterError
+from .util.decorators import deprecate_positional_args
 
 __all__ = [
     "hpss",
@@ -192,6 +193,7 @@ def percussive(y, **kwargs):
     return y_perc
 
 
+@deprecate_positional_args
 def time_stretch(y, *, rate, **kwargs):
     """Time-stretch an audio series by a fixed rate.
 
@@ -255,6 +257,7 @@ def time_stretch(y, *, rate, **kwargs):
     return y_stretch
 
 
+@deprecate_positional_args
 def pitch_shift(
     y, *, sr, n_steps, bins_per_octave=12, res_type="kaiser_best", **kwargs
 ):
@@ -332,6 +335,7 @@ def pitch_shift(
     return util.fix_length(y_shift, size=y.shape[-1])
 
 
+@deprecate_positional_args
 def remix(y, intervals, *, align_zeros=True):
     """Remix an audio signal by re-ordering time intervals.
 
@@ -445,6 +449,7 @@ def _signal_to_frame_nonsilent(
     return db > -top_db
 
 
+@deprecate_positional_args
 def trim(
     y, *, top_db=60, ref=np.max, frame_length=2048, hop_length=512, aggregate=np.max
 ):
@@ -517,6 +522,7 @@ def trim(
     return y[tuple(full_index)], np.asarray([start, end])
 
 
+@deprecate_positional_args
 def split(
     y, *, top_db=60, ref=np.max, frame_length=2048, hop_length=512, aggregate=np.max
 ):
@@ -582,6 +588,7 @@ def split(
     return edges.reshape((-1, 2))
 
 
+@deprecate_positional_args
 def preemphasis(y, *, coef=0.97, zi=None, return_zf=False):
     """Pre-emphasize an audio signal with a first-order auto-regressive filter:
 
@@ -669,6 +676,7 @@ def preemphasis(y, *, coef=0.97, zi=None, return_zf=False):
     return y_out
 
 
+@deprecate_positional_args
 def deemphasis(y, *, coef=0.97, zi=None, return_zf=False):
     """De-emphasize an audio signal with the inverse operation of preemphasis():
 

--- a/librosa/feature/inverse.py
+++ b/librosa/feature/inverse.py
@@ -12,11 +12,13 @@ from ..core.spectrum import db_to_power
 from ..util.utils import tiny
 from .. import filters
 from ..util import nnls, expand_to
+from ..util.decorators import deprecate_positional_args
 
 
 __all__ = ["mel_to_stft", "mel_to_audio", "mfcc_to_mel", "mfcc_to_audio"]
 
 
+@deprecate_positional_args
 def mel_to_stft(M, *, sr=22050, n_fft=2048, power=2.0, **kwargs):
     """Approximate STFT magnitude from a Mel power spectrogram.
 
@@ -84,6 +86,7 @@ def mel_to_stft(M, *, sr=22050, n_fft=2048, power=2.0, **kwargs):
     return np.power(inverse, 1.0 / power, out=inverse)
 
 
+@deprecate_positional_args
 def mel_to_audio(
     M,
     *,
@@ -168,6 +171,7 @@ def mel_to_audio(
     )
 
 
+@deprecate_positional_args
 def mfcc_to_mel(mfcc, *, n_mels=128, dct_type=2, norm="ortho", ref=1.0, lifter=0):
     """Invert Mel-frequency cepstral coefficients to approximate a Mel power
     spectrogram.
@@ -243,6 +247,7 @@ def mfcc_to_mel(mfcc, *, n_mels=128, dct_type=2, norm="ortho", ref=1.0, lifter=0
     return db_to_power(logmel, ref=ref)
 
 
+@deprecate_positional_args
 def mfcc_to_audio(
     mfcc, *, n_mels=128, dct_type=2, norm="ortho", ref=1.0, lifter=0, **kwargs
 ):

--- a/librosa/feature/rhythm.py
+++ b/librosa/feature/rhythm.py
@@ -9,6 +9,7 @@ from .. import util
 from ..core.audio import autocorrelate
 from ..core.spectrum import stft
 from ..util.exceptions import ParameterError
+from ..util.decorators import deprecate_positional_args
 from ..filters import get_window
 
 
@@ -16,6 +17,7 @@ __all__ = ["tempogram", "fourier_tempogram"]
 
 
 # -- Rhythmic features -- #
+@deprecate_positional_args
 def tempogram(
     *,
     y=None,
@@ -172,6 +174,7 @@ def tempogram(
     )
 
 
+@deprecate_positional_args
 def fourier_tempogram(
     *,
     y=None,

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -10,6 +10,7 @@ import scipy.fftpack
 from .. import util
 from .. import filters
 from ..util.exceptions import ParameterError
+from ..util.decorators import deprecate_positional_args
 
 from ..core.convert import fft_frequencies
 from ..core.audio import zero_crossings
@@ -37,6 +38,7 @@ __all__ = [
 
 
 # -- Spectral features -- #
+@deprecate_positional_args
 def spectral_centroid(
     *,
     y=None,
@@ -194,6 +196,7 @@ def spectral_centroid(
     return np.sum(freq * util.normalize(S, norm=1, axis=-2), axis=-2, keepdims=True)
 
 
+@deprecate_positional_args
 def spectral_bandwidth(
     *,
     y=None,
@@ -368,6 +371,7 @@ def spectral_bandwidth(
     return np.sum(S * deviation ** p, axis=-2, keepdims=True) ** (1.0 / p)
 
 
+@deprecate_positional_args
 def spectral_contrast(
     *,
     y=None,
@@ -567,6 +571,7 @@ def spectral_contrast(
         return power_to_db(peak) - power_to_db(valley)
 
 
+@deprecate_positional_args
 def spectral_rolloff(
     *,
     y=None,
@@ -728,6 +733,7 @@ def spectral_rolloff(
     return np.nanmin(ind * freq, axis=-2, keepdims=True)
 
 
+@deprecate_positional_args
 def spectral_flatness(
     *,
     y=None,
@@ -858,6 +864,7 @@ def spectral_flatness(
     return gmean / amean
 
 
+@deprecate_positional_args
 def rms(
     *,
     y=None,
@@ -973,6 +980,7 @@ def rms(
     return np.sqrt(power)
 
 
+@deprecate_positional_args
 def poly_features(
     *,
     y=None,
@@ -1128,6 +1136,7 @@ def poly_features(
     return coefficients
 
 
+@deprecate_positional_args
 def zero_crossing_rate(y, *, frame_length=2048, hop_length=512, center=True, **kwargs):
     """Compute the zero-crossing rate of an audio time series.
 
@@ -1190,6 +1199,7 @@ def zero_crossing_rate(y, *, frame_length=2048, hop_length=512, center=True, **k
 
 
 # -- Chroma --#
+@deprecate_positional_args
 def chroma_stft(
     *,
     y=None,
@@ -1351,6 +1361,7 @@ def chroma_stft(
     return util.normalize(raw_chroma, norm=norm, axis=-2)
 
 
+@deprecate_positional_args
 def chroma_cqt(
     *,
     y=None,
@@ -1493,6 +1504,7 @@ def chroma_cqt(
     return chroma
 
 
+@deprecate_positional_args
 def chroma_cens(
     *,
     y=None,
@@ -1658,6 +1670,7 @@ def chroma_cens(
     return util.normalize(cens, norm=norm, axis=-2)
 
 
+@deprecate_positional_args
 def tonnetz(*, y=None, sr=22050, chroma=None, **kwargs):
     """Computes the tonal centroid features (tonnetz)
 
@@ -1764,6 +1777,7 @@ def tonnetz(*, y=None, sr=22050, chroma=None, **kwargs):
 
 
 # -- Mel spectrogram and MFCCs -- #
+@deprecate_positional_args
 def mfcc(
     *, y=None, sr=22050, S=None, n_mfcc=20, dct_type=2, norm="ortho", lifter=0, **kwargs
 ):
@@ -1905,6 +1919,7 @@ def mfcc(
         )
 
 
+@deprecate_positional_args
 def melspectrogram(
     *,
     y=None,

--- a/librosa/feature/utils.py
+++ b/librosa/feature/utils.py
@@ -8,10 +8,12 @@ from numba import jit
 
 from .._cache import cache
 from ..util.exceptions import ParameterError
+from ..util.decorators import deprecate_positional_args
 
 __all__ = ["delta", "stack_memory"]
 
 
+@deprecate_positional_args
 @cache(level=40)
 def delta(data, *, width=9, order=1, axis=-1, mode="interp", **kwargs):
     r"""Compute delta features: local estimate of the derivative
@@ -116,6 +118,7 @@ def delta(data, *, width=9, order=1, axis=-1, mode="interp", **kwargs):
     )
 
 
+@deprecate_positional_args
 @cache(level=40)
 def stack_memory(data, *, n_steps=2, delay=1, **kwargs):
     """Short-term history embedding: vertically concatenate a data

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -54,7 +54,7 @@ from numba import jit
 from ._cache import cache
 from . import util
 from .util.exceptions import ParameterError
-from .util.decorators import deprecated
+from .util.decorators import deprecated, deprecate_positional_args
 
 from .core.convert import note_to_hz, hz_to_midi, midi_to_hz, hz_to_octs
 from .core.convert import fft_frequencies, mel_frequencies
@@ -121,6 +121,7 @@ WINDOW_BANDWIDTHS = {
 }
 
 
+@deprecate_positional_args
 @cache(level=10)
 def mel(
     *,
@@ -257,6 +258,7 @@ def mel(
     return weights
 
 
+@deprecate_positional_args
 @cache(level=10)
 def chroma(
     *,
@@ -431,6 +433,7 @@ def __float_window(window_spec):
 
 
 @deprecated(version="0.9.0", version_removed="1.0")
+@deprecate_positional_args
 def constant_q(
     *,
     sr,
@@ -596,6 +599,7 @@ def constant_q(
 
 
 @deprecated(version="0.9.0", version_removed="1.0")
+@deprecate_positional_args
 @cache(level=10)
 def constant_q_lengths(
     *, sr, fmin, n_bins=84, bins_per_octave=12, window="hann", filter_scale=1, gamma=0
@@ -670,6 +674,7 @@ def constant_q_lengths(
     return lengths
 
 
+@deprecate_positional_args
 @cache(level=10)
 def wavelet_lengths(
     *, freqs, sr=22050, window="hann", filter_scale=1, gamma=0, alpha=None
@@ -804,6 +809,7 @@ def wavelet_lengths(
     return lengths, f_cutoff
 
 
+@deprecate_positional_args
 @cache(level=10)
 def wavelet(
     *,
@@ -953,6 +959,7 @@ def wavelet(
     return filters, lengths
 
 
+@deprecate_positional_args
 @cache(level=10)
 def cq_to_chroma(
     n_input,
@@ -1121,6 +1128,7 @@ def window_bandwidth(window, n=1000):
     return WINDOW_BANDWIDTHS[key]
 
 
+@deprecate_positional_args
 @cache(level=10)
 def get_window(window, Nx, *, fftbins=True):
     """Compute a window function.
@@ -1364,6 +1372,7 @@ def mr_frequencies(tuning):
     return center_freqs, sample_rates
 
 
+@deprecate_positional_args
 def semitone_filterbank(
     *, center_freqs=None, tuning=0.0, sample_rates=None, flayout="ba", **kwargs
 ):
@@ -1454,6 +1463,7 @@ def __window_ss_fill(x, win_sq, n_frames, hop_length):  # pragma: no cover
         x[sample : min(n, sample + n_fft)] += win_sq[: max(0, min(n_fft, n - sample))]
 
 
+@deprecate_positional_args
 def window_sumsquare(
     *,
     window,
@@ -1528,6 +1538,7 @@ def window_sumsquare(
     return x
 
 
+@deprecate_positional_args
 @cache(level=10)
 def diagonal_filter(window, n, *, slope=1.0, angle=None, zero_mean=False):
     """Build a two-dimensional diagonal filter.

--- a/librosa/onset.py
+++ b/librosa/onset.py
@@ -19,12 +19,14 @@ from ._cache import cache
 from . import core
 from . import util
 from .util.exceptions import ParameterError
+from .util.decorators import deprecate_positional_args
 
 from .feature.spectral import melspectrogram
 
 __all__ = ["onset_detect", "onset_strength", "onset_strength_multi", "onset_backtrack"]
 
 
+@deprecate_positional_args
 def onset_detect(
     *,
     y=None,
@@ -185,6 +187,7 @@ def onset_detect(
     return onsets
 
 
+@deprecate_positional_args
 def onset_strength(
     *,
     y=None,
@@ -414,6 +417,7 @@ def onset_backtrack(events, energy):
     return minima[util.match_events(events, minima, right=False)]
 
 
+@deprecate_positional_args
 @cache(level=30)
 def onset_strength_multi(
     *,

--- a/librosa/segment.py
+++ b/librosa/segment.py
@@ -41,6 +41,7 @@ from ._cache import cache
 from . import util
 from .filters import diagonal_filter
 from .util.exceptions import ParameterError
+from .util.decorators import deprecate_positional_args
 
 __all__ = [
     "cross_similarity",
@@ -54,6 +55,7 @@ __all__ = [
 ]
 
 
+@deprecate_positional_args
 @cache(level=30)
 def cross_similarity(
     data,
@@ -269,6 +271,7 @@ def cross_similarity(
     return xsim
 
 
+@deprecate_positional_args
 @cache(level=30)
 def recurrence_matrix(
     data,
@@ -536,6 +539,7 @@ def recurrence_matrix(
     return rec
 
 
+@deprecate_positional_args
 def recurrence_to_lag(rec, *, pad=True, axis=-1):
     """Convert a recurrence matrix into a lag matrix.
 
@@ -639,6 +643,7 @@ def recurrence_to_lag(rec, *, pad=True, axis=-1):
     return lag
 
 
+@deprecate_positional_args
 def lag_to_recurrence(lag, *, axis=-1):
     """Convert a lag matrix into a recurrence matrix.
 
@@ -796,6 +801,7 @@ def timelag_filter(function, pad=True, index=0):
     return decorator(__my_filter, function)
 
 
+@deprecate_positional_args
 @cache(level=30)
 def subsegment(data, frames, *, n_segments=4, axis=-1):
     """Sub-divide a segmentation by feature clustering.
@@ -883,6 +889,7 @@ def subsegment(data, frames, *, n_segments=4, axis=-1):
     return np.array(boundaries)
 
 
+@deprecate_positional_args
 def agglomerative(data, k, *, clusterer=None, axis=-1):
     """Bottom-up temporal segmentation.
 
@@ -968,6 +975,7 @@ def agglomerative(data, k, *, clusterer=None, axis=-1):
     return np.asarray(boundaries)
 
 
+@deprecate_positional_args
 def path_enhance(
     R,
     n,

--- a/librosa/sequence.py
+++ b/librosa/sequence.py
@@ -38,6 +38,7 @@ from numba import jit
 from .util import pad_center, fill_off_diagonal, tiny, expand_to
 from .util.exceptions import ParameterError
 from .filters import get_window
+from .util.decorators import deprecate_positional_args
 
 __all__ = [
     "dtw",
@@ -53,6 +54,7 @@ __all__ = [
 ]
 
 
+@deprecate_positional_args
 def dtw(
     X=None,
     Y=None,
@@ -479,6 +481,7 @@ def __dtw_backtracking(steps, step_sizes_sigma, subseq, start=None):  # pragma: 
     return wp
 
 
+@deprecate_positional_args
 def dtw_backtracking(steps, *, step_sizes_sigma=None, subseq=False, start=None):
     """Backtrack a warping path.
 
@@ -528,6 +531,7 @@ def dtw_backtracking(steps, *, step_sizes_sigma=None, subseq=False, start=None):
     return np.asarray(wp, dtype=int)
 
 
+@deprecate_positional_args
 def rqa(sim, *, gap_onset=1, gap_extend=1, knight_moves=True, backtrack=True):
     """Recurrence quantification analysis (RQA)
 
@@ -937,6 +941,7 @@ def _viterbi(log_prob, log_trans, log_p_init):  # pragma: no cover
     return state, logp
 
 
+@deprecate_positional_args
 def viterbi(prob, transition, *, p_init=None, return_logp=False):
     """Viterbi decoding from observation likelihoods.
 
@@ -1073,6 +1078,7 @@ def viterbi(prob, transition, *, p_init=None, return_logp=False):
     return states
 
 
+@deprecate_positional_args
 def viterbi_discriminative(
     prob, transition, *, p_state=None, p_init=None, return_logp=False
 ):
@@ -1277,6 +1283,7 @@ def viterbi_discriminative(
     return states
 
 
+@deprecate_positional_args
 def viterbi_binary(prob, transition, *, p_state=None, p_init=None, return_logp=False):
     """Viterbi decoding from binary (multi-label), discriminative state predictions.
 
@@ -1601,6 +1608,7 @@ def transition_cycle(n_states, prob):
     return transition
 
 
+@deprecate_positional_args
 def transition_local(n_states, width, *, window="triangle", wrap=False):
     """Construct a localized transition matrix.
 

--- a/librosa/util/decorators.py
+++ b/librosa/util/decorators.py
@@ -4,9 +4,12 @@
 """Helpful tools for deprecation"""
 
 import warnings
+from inspect import signature, isclass, Parameter
+from functools import wraps
 from decorator import decorator
 
-__all__ = ["moved", "deprecated"]
+
+__all__ = ["moved", "deprecated", "deprecate_positional_args"]
 
 
 def moved(*, moved_from, version, version_removed):
@@ -52,3 +55,57 @@ def deprecated(*, version, version_removed):
         return func(*args, **kwargs)
 
     return decorator(__wrapper)
+
+
+# Borrowed from sklearn
+def deprecate_positional_args(func=None, *, version="0.10"):
+    """Decorator for methods that issues warnings for positional arguments.
+    Using the keyword-only argument syntax in pep 3102, arguments after the
+    * will issue a warning when passed as a positional argument.
+    Parameters
+    ----------
+    func : callable, default=None
+        Function to check arguments on.
+    version : callable, default="0.10"
+        The version when positional arguments will result in error.
+    """
+
+    def _inner_deprecate_positional_args(f):
+        sig = signature(f)
+        kwonly_args = []
+        all_args = []
+
+        for name, param in sig.parameters.items():
+            if param.kind == Parameter.POSITIONAL_OR_KEYWORD:
+                all_args.append(name)
+            elif param.kind == Parameter.KEYWORD_ONLY:
+                kwonly_args.append(name)
+
+        @wraps(f)
+        def inner_f(*args, **kwargs):
+            extra_args = len(args) - len(all_args)
+            if extra_args <= 0:
+                return f(*args, **kwargs)
+
+            # extra_args > 0
+            args_msg = [
+                "{}={}".format(name, arg)
+                for name, arg in zip(kwonly_args[:extra_args], args[-extra_args:])
+            ]
+            args_msg = ", ".join(args_msg)
+            warnings.warn(
+                f"Pass {args_msg} as keyword args. From version "
+                f"{version} passing these as positional arguments "
+                "will result in an error",
+                FutureWarning,
+                stacklevel=2,
+            )
+            kwargs.update(zip(sig.parameters, args))
+            return f(**kwargs)
+
+        return inner_f
+
+    if func is not None:
+        return _inner_deprecate_positional_args(func)
+
+    return _inner_deprecate_positional_args

--- a/librosa/util/files.py
+++ b/librosa/util/files.py
@@ -11,6 +11,7 @@ from pkg_resources import resource_filename
 import pooch
 
 from .exceptions import ParameterError
+from .decorators import deprecate_positional_args
 
 
 __all__ = [
@@ -38,6 +39,7 @@ with open(
     __TRACKMAP = json.load(fdesc)
 
 
+@deprecate_positional_args
 def example(key, *, hq=False):
     """Retrieve the example recording identified by 'key'.
 
@@ -156,6 +158,7 @@ def example_info(key):
             print(line)
 
 
+@deprecate_positional_args
 def find_files(
     directory, *, ext=None, recurse=True, case_sensitive=False, limit=None, offset=0
 ):

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -12,6 +12,7 @@ from numpy.lib.stride_tricks import as_strided
 from .._cache import cache
 from .exceptions import ParameterError
 from .deprecation import Deprecated
+from .decorators import deprecate_positional_args
 
 # Constrain STFT block sizes to 256 KB
 MAX_MEM_BLOCK = 2 ** 8 * 2 ** 10
@@ -48,6 +49,7 @@ __all__ = [
 ]
 
 
+@deprecate_positional_args
 def frame(x, *, frame_length, hop_length, axis=-1, writeable=False, subok=False):
     """Slice a data array into (overlapping) frames.
 
@@ -208,6 +210,7 @@ def frame(x, *, frame_length, hop_length, axis=-1, writeable=False, subok=False)
     return xw[tuple(slices)]
 
 
+@deprecate_positional_args
 @cache(level=20)
 def valid_audio(y, *, mono=Deprecated()):
     """Determine whether a variable contains valid audio data.
@@ -293,6 +296,7 @@ def valid_audio(y, *, mono=Deprecated()):
     return True
 
 
+@deprecate_positional_args
 def valid_int(x, *, cast=None):
     """Ensure that an input value is integer-typed.
     This is primarily useful for ensuring integrable-valued
@@ -355,6 +359,7 @@ def valid_intervals(intervals):
     return True
 
 
+@deprecate_positional_args
 def pad_center(data, *, size, axis=-1, **kwargs):
     """Pad an array to a target length along a target axis.
 
@@ -428,6 +433,7 @@ def pad_center(data, *, size, axis=-1, **kwargs):
     return np.pad(data, lengths, **kwargs)
 
 
+@deprecate_positional_args
 def expand_to(x, *, ndim, axes):
     """Expand the dimensions of an input array with
 
@@ -498,6 +504,7 @@ def expand_to(x, *, ndim, axes):
     return x.reshape(shape)
 
 
+@deprecate_positional_args
 def fix_length(data, *, size, axis=-1, **kwargs):
     """Fix the length an array ``data`` to exactly ``size`` along a target axis.
 
@@ -556,6 +563,7 @@ def fix_length(data, *, size, axis=-1, **kwargs):
     return data
 
 
+@deprecate_positional_args
 def fix_frames(frames, *, x_min=0, x_max=None, pad=True):
     """Fix a list of frames to lie within [x_min, x_max]
 
@@ -637,6 +645,7 @@ def fix_frames(frames, *, x_min=0, x_max=None, pad=True):
     return np.unique(frames).astype(int)
 
 
+@deprecate_positional_args
 def axis_sort(S, *, axis=-1, index=False, value=None):
     """Sort an array along its rows or columns.
 
@@ -732,6 +741,7 @@ def axis_sort(S, *, axis=-1, index=False, value=None):
         return S[tuple(sort_slice)]
 
 
+@deprecate_positional_args
 @cache(level=40)
 def normalize(S, *, norm=np.inf, axis=0, threshold=None, fill=None):
     """Normalize an array along a chosen axis.
@@ -960,6 +970,7 @@ def normalize(S, *, norm=np.inf, axis=0, threshold=None, fill=None):
     return Snorm
 
 
+@deprecate_positional_args
 def localmax(x, *, axis=0):
     """Find local maxima in an array
 
@@ -1020,6 +1031,7 @@ def localmax(x, *, axis=0):
     return (x > x_pad[tuple(inds1)]) & (x >= x_pad[tuple(inds2)])
 
 
+@deprecate_positional_args
 def localmin(x, *, axis=0):
     """Find local minima in an array
 
@@ -1081,6 +1093,7 @@ def localmin(x, *, axis=0):
     return (x < x_pad[tuple(inds1)]) & (x <= x_pad[tuple(inds2)])
 
 
+@deprecate_positional_args
 def peak_pick(x, *, pre_max, post_max, pre_avg, post_avg, delta, wait):
     """Uses a flexible heuristic to pick peaks in a signal.
 
@@ -1237,6 +1250,7 @@ def peak_pick(x, *, pre_max, post_max, pre_avg, post_avg, delta, wait):
     return np.array(peaks)
 
 
+@deprecate_positional_args
 @cache(level=40)
 def sparsify_rows(x, *, quantile=0.01, dtype=None):
     """Return a row-sparse matrix approximating the input
@@ -1336,6 +1350,7 @@ def sparsify_rows(x, *, quantile=0.01, dtype=None):
     return x_sparse.tocsr()
 
 
+@deprecate_positional_args
 def buf_to_float(x, *, n_bytes=2, dtype=np.float32):
     """Convert an integer buffer to floating point values.
     This is primarily useful when loading integer-valued wav data
@@ -1366,6 +1381,7 @@ def buf_to_float(x, *, n_bytes=2, dtype=np.float32):
     return scale * np.frombuffer(x, fmt).astype(dtype)
 
 
+@deprecate_positional_args
 def index_to_slice(idx, *, idx_min=None, idx_max=None, step=None, pad=True):
     """Generate a slice array from an index array.
 
@@ -1418,6 +1434,7 @@ def index_to_slice(idx, *, idx_min=None, idx_max=None, step=None, pad=True):
     return [slice(start, end, step) for (start, end) in zip(idx_fixed, idx_fixed[1:])]
 
 
+@deprecate_positional_args
 @cache(level=40)
 def sync(data, idx, *, aggregate=None, pad=True, axis=-1):
     """Synchronous aggregation of a multi-dimensional array between boundaries
@@ -1542,6 +1559,7 @@ def sync(data, idx, *, aggregate=None, pad=True, axis=-1):
     return data_agg
 
 
+@deprecate_positional_args
 def softmask(X, X_ref, *, power=1, split_zeros=False):
     """Robustly compute a soft-mask operation.
 
@@ -1724,6 +1742,7 @@ def tiny(x):
     return np.finfo(dtype).tiny
 
 
+@deprecate_positional_args
 def fill_off_diagonal(x, *, radius, value=0):
     """Sets all cells of a matrix to a given ``value``
     if they lie outside a constraint region.
@@ -1792,6 +1811,7 @@ def fill_off_diagonal(x, *, radius, value=0):
     x[idx_l] = value
 
 
+@deprecate_positional_args
 def cyclic_gradient(data, *, edge_order=1, axis=-1):
     """Estimate the gradient of a function over a uniformly sampled,
     periodic domain.
@@ -1902,6 +1922,7 @@ def __shear_sparse(X, *, factor=+1, axis=-1):
     return X_shear.asformat(fmt)
 
 
+@deprecate_positional_args
 def shear(X, *, factor=1, axis=-1):
     """Shear a matrix by a given factor.
 
@@ -1953,6 +1974,7 @@ def shear(X, *, factor=1, axis=-1):
         return __shear_dense(X, factor=factor, axis=axis)
 
 
+@deprecate_positional_args
 def stack(arrays, *, axis=0):
     """Stack one or more arrays along a target axis.
 
@@ -2056,6 +2078,7 @@ def stack(arrays, *, axis=0):
         return result
 
 
+@deprecate_positional_args
 def dtype_r2c(d, *, default=np.complex64):
     """Find the complex numpy dtype corresponding to a real dtype.
 
@@ -2112,6 +2135,7 @@ def dtype_r2c(d, *, default=np.complex64):
     return np.dtype(mapping.get(dt, default))
 
 
+@deprecate_positional_args
 def dtype_c2r(d, *, default=np.float32):
     """Find the real numpy dtype corresponding to a complex dtype.
 
@@ -2182,6 +2206,7 @@ def __count_unique(x):
     return uniques.shape[0]
 
 
+@deprecate_positional_args
 def count_unique(data, *, axis=-1):
     """Count the number of unique values in a multi-dimensional array
     along a given axis.
@@ -2234,6 +2259,7 @@ def __is_unique(x):
     return uniques.shape[0] == x.size
 
 
+@deprecate_positional_args
 def is_unique(data, *, axis=-1):
     """Determine if the input array consists of all unique values
     along a given axis.

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -773,6 +773,24 @@ def test_warning_moved():
         assert "moved" in str(out[0].message).lower()
 
 
+def test_warning_positional_deprecation():
+    @librosa.util.decorators.deprecate_positional_args
+    def __dummy(*, x):
+        pass
+
+    with warnings.catch_warnings(record=True) as out:
+        __dummy(x=1)
+        # No warning here, we're doing it correctly
+        assert len(out) == 0
+
+    with warnings.catch_warnings(record=True) as out:
+        __dummy(1)
+        # Should be a warning here
+        assert len(out) > 0
+        assert out[0].category is FutureWarning
+        assert "positional arguments" in str(out[0].message).lower()
+
+
 def test_warning_rename_kw_pass():
 
     ov = librosa.util.Deprecated()


### PR DESCRIPTION
#### Reference Issue
Fixes #1449 


#### What does this implement/fix? Explain your changes.
This PR borrows scikit-learn's deprecation wrapper for positional arguments, and adds it to all public-facing functions impacted by #1114 .

This somewhat reverts the API-breakage induced at 0.9, so code from 0.8.1 should basically resume working without change.  Users will receive warnings indicating where the problematic call sites are.

#### Any other comments?

Having extra decorator levels in the mix messes up our stacklevel counting #1436 ; this is theoretically fixable, but a bunch of work for marginal payoff.  I'm content to leave it be for now, and let the dust settle in the 0.10 release.