### PR TITLE
switched submodule url to https in advance of git:// deprecation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tests/data"]
 	path = tests/data
-	url = git://github.com/librosa/librosa-test-data.git
+	url = https://github.com/librosa/librosa-test-data.git


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Github is deprecating the `git://` protocol on March 15: https://github.blog/2021-09-01-improving-git-protocol-security-github/

This affects the recent change to use a submodule for the test data.  Since our submodule use is read-only, this can be easily switched out to https protocol.


#### Any other comments?

No changes to the code here, just the git configuration.  If tests run smoothly, I'll merge.
