### PR TITLE
Fix db_to_amplitude docs

### DIFF
--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1503,7 +1503,7 @@ def power_to_db(S, *, ref=1.0, amin=1e-10, top_db=80.0):
 
     top_db : float >= 0 [scalar]
         threshold the output at ``top_db`` below the peak:
-        ``max(10 * log10(S)) - top_db``
+        ``max(10 * log10(S/ref)) - top_db``
 
     Returns
     -------
@@ -1633,7 +1633,7 @@ def db_to_power(S_db, *, ref=1.0):
 def amplitude_to_db(S, *, ref=1.0, amin=1e-5, top_db=80.0):
     """Convert an amplitude spectrogram to dB-scaled spectrogram.
 
-    This is equivalent to ``power_to_db(S**2, ref=ref**2, amin=amin**2)``, but is provided for convenience.
+    This is equivalent to ``power_to_db(S**2, ref=ref**2, amin=amin**2, top_db)``, but is provided for convenience.
 
     Parameters
     ----------
@@ -1652,7 +1652,7 @@ def amplitude_to_db(S, *, ref=1.0, amin=1e-5, top_db=80.0):
 
     top_db : float >= 0 [scalar]
         threshold the output at ``top_db`` below the peak:
-        ``max(20 * log10(S)) - top_db``
+        ``max(20 * log10(S/ref)) - top_db``
 
     Returns
     -------

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1633,7 +1633,7 @@ def db_to_power(S_db, *, ref=1.0):
 def amplitude_to_db(S, *, ref=1.0, amin=1e-5, top_db=80.0):
     """Convert an amplitude spectrogram to dB-scaled spectrogram.
 
-    This is equivalent to ``power_to_db(S**2)``, but is provided for convenience.
+    This is equivalent to ``power_to_db(S**2, ref=ref**2, amin=amin**2)``, but is provided for convenience.
 
     Parameters
     ----------
@@ -1698,7 +1698,7 @@ def db_to_amplitude(S_db, *, ref=1.0):
 
     This effectively inverts `amplitude_to_db`::
 
-        db_to_amplitude(S_db) ~= 10.0**(0.5 * (S_db + log10(ref)/10))
+        db_to_amplitude(S_db) ~= 10.0**(0.5 * S_db/10 + log10(ref))
 
     Parameters
     ----------

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1633,7 +1633,8 @@ def db_to_power(S_db, *, ref=1.0):
 def amplitude_to_db(S, *, ref=1.0, amin=1e-5, top_db=80.0):
     """Convert an amplitude spectrogram to dB-scaled spectrogram.
 
-    This is equivalent to ``power_to_db(S**2, ref=ref**2, amin=amin**2, top_db)``, but is provided for convenience.
+    This is equivalent to ``power_to_db(S**2, ref=ref**2, amin=amin**2, top_db=top_db)``,
+    but is provided for convenience.
 
     Parameters
     ----------


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

I modified two docs about `db_to_amplitude` and `amplitude_to_db`.

1. Fix an equation explaining the behavior of `db_to_amplitude`.
2. Improve the explanation of `amplitude_to_db` to make it more informative.

I appreciate it if you review this.

(1) The equation about  `db_to_amplitude` looks wrong. That should be fixed in the following way:

```
   db_to_amplitude(S_db) ~= 10.0**(0.5 * (S_db + log10(ref)/10))
-> db_to_amplitude(S_db) ~= 10.0**(0.5 * S_db/10 + log10(ref))

```

This is a piece of evidence:

```python
from numpy import log10
S_db = 10
ref = 5
print("Actual :", librosa.db_to_amplitude(S_db, ref=ref))
print("Current:", 10.0**(0.5 * (S_db + log10(ref)/10)))
print("Fixed  :", 10.0**(0.5 * S_db/10 + log10(ref)))

# Actual : 15.811388300841896
# Current: 108379.8386734369
# Fixed  : 15.811388300841895
```

(2) Adding information about `ref` and `amin` is helpful.  Because I think there are some possibilities, like `power_to_db(S**2, ref**2, amin**2)` or `power_to_db(S**2, ref, amin)`, but it is difficult to say which is employed without seeing source code.