### PR TITLE
Fix function name in docs of STFT

### DIFF
--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -67,7 +67,7 @@ def stft(
       at frame ``t``.
 
     The integers ``t`` and ``f`` can be converted to physical units by means
-    of the utility functions `frames_to_sample` and `fft_frequencies`.
+    of the utility functions `frames_to_samples` and `fft_frequencies`.
 
     Parameters
     ----------


### PR DESCRIPTION
The function is named frames_to_samples (see: https://librosa.org/doc/main/generated/librosa.frames_to_samples.html).

This should also be the reason why the link on http://librosa.org/doc/main/generated/librosa.stft.html is not working.


