### PR TITLE
pinned sphinx version to 4.5 for doc site

### DIFF
--- a/.github/environment-docs.yml
+++ b/.github/environment-docs.yml
@@ -19,7 +19,7 @@ dependencies:
   - pooch>=1.0.0
   - packaging>=20.0
   - matplotlib<3.5
-  - sphinx>=4.4.0
+  - sphinx==4.5.0
   - sphinx-gallery>=0.10.1
   - sphinx_rtd_theme>=1.0.0
   - ffmpeg


### PR DESCRIPTION
#### Reference Issue
Fixes #1490 


#### What does this implement/fix? Explain your changes.

This PR pins sphinx to 4.5 until our build chain updates to work with 5.0.

No changes to docs or code here, so we can merge asap.


