### PR TITLE
bug-fix for multichannel splitting

### DIFF
--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -445,6 +445,9 @@ def _signal_to_frame_nonsilent(
     # Aggregate everything but the time dimension
     if db.ndim > 1:
         db = np.apply_over_axes(aggregate, db, range(db.ndim - 1))
+        # Squeeze out leading singleton dimensions here
+        # We always want to keep the trailing dimension though
+        db = np.squeeze(db, axis=tuple(range(db.ndim - 1)))
 
     return db > -top_db
 

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -252,6 +252,19 @@ def test_trim_empty():
     assert idx[1] == 0
 
 
+def test_trim_multi(y_multi):
+    # Test for https://github.com/librosa/librosa/issues/1489
+    y, sr = y_multi
+    librosa.effects.trim(y=y)
+
+
+def test_split_multi(y_multi):
+    # Test for https://github.com/librosa/librosa/issues/1489
+    y, sr = y_multi
+
+    librosa.effects.split(y=y)
+
+
 @pytest.fixture(
     scope="module",
     params=[0, 1, 2, 3],


### PR DESCRIPTION
#### Reference Issue
Fixes #1489


#### What does this implement/fix? Explain your changes.

This PR adds a squeeze to the non-silence detection helper function in the effects module.  This ensures that the output here is always one-dimensional.

The squeeze operation here only applies to leading axes, and explicitly skips the trailing (frame) axis.

#### Any other comments?

I think this should be good to merge after CI passes.  Eyeballs are welcome as always.