### PR TITLE
Square plots when different axis types are compatible

### DIFF
--- a/librosa/display.py
+++ b/librosa/display.py
@@ -618,16 +618,20 @@ def __envelope(x, hop):
     return x_frame.max(axis=1)
 
 
-_categorical_axis_types = ['chroma', 'chroma_h', 'tonnetz', 'frames']
-_time_axis_types = ['linear', 'fft', 'hz', 'log,' 'fft_note', 'fft_svara', 'mel', 'cqt_hz', 'cqt_note', 'cqt_svara']
-_freq_axis_types = ['time', 's', 'ms', 'lag', 'lag_s', 'lag_ms']
-_tempo_axis_types = ['tempo', 'fourier_tempo']
+_chroma_ax_types = ('chroma', 'chroma_h', 'chroma_c',)
+_cqt_ax_types = ('cqt_hz', 'cqt_note', 'cqt_svara',)
+_freq_ax_types = ('linear', 'fft', 'hz', 'fft_note', 'fft_svara',)
+_time_ax_types = ('time', 's', 'ms',)
+_lag_ax_types = ('lag', 'lag_s', 'lag_ms',)
+_misc_ax_types = ('tempo', 'fourier_tempo', 'mel', 'log', 'tonnetz', 'frames',)
 
 _AXIS_COMPAT = set(
-    [(t, t) for t in _categorical_axis_types] +
-    [t for t in product(_time_axis_types, _time_axis_types)] +
-    [t for t in product(_freq_axis_types, _freq_axis_types)] +
-    [t for t in product(_tempo_axis_types, _tempo_axis_types)]
+    [(t, t) for t in _misc_ax_types] +
+    [t for t in product(_chroma_ax_types, _chroma_ax_types)] +
+    [t for t in product(_cqt_ax_types, _cqt_ax_types)] +
+    [t for t in product(_freq_ax_types, _freq_ax_types)] +
+    [t for t in product(_time_ax_types, _time_ax_types)] +
+    [t for t in product(_lag_ax_types, _lag_ax_types)]
 )
 
 

--- a/librosa/display.py
+++ b/librosa/display.py
@@ -35,6 +35,7 @@ Miscellaneous
 
 """
 
+from itertools import product
 import warnings
 
 import numpy as np
@@ -615,6 +616,19 @@ def __envelope(x, hop):
     """
     x_frame = np.abs(util.frame(x, frame_length=hop, hop_length=hop))
     return x_frame.max(axis=1)
+
+
+_categorical_axis_types = ['chroma', 'chroma_h', 'tonnetz', 'frames']
+_time_axis_types = ['linear', 'fft', 'hz', 'log,' 'fft_note', 'fft_svara', 'mel', 'cqt_hz', 'cqt_note', 'cqt_svara']
+_freq_axis_types = ['time', 's', 'ms', 'lag', 'lag_s', 'lag_ms']
+_tempo_axis_types = ['tempo', 'fourier_tempo']
+
+_AXIS_COMPAT = set(
+    [(t, t) for t in _categorical_axis_types] +
+    [t for t in product(_time_axis_types, _time_axis_types)] +
+    [t for t in product(_freq_axis_types, _freq_axis_types)] +
+    [t for t in product(_tempo_axis_types, _tempo_axis_types)]
+)
 
 
 @deprecate_positional_args
@@ -1276,10 +1290,10 @@ def __coord_time(n, sr=22050, hop_length=512, **_kwargs):
 
 
 def __same_axes(x_axis, y_axis, xlim, ylim):
-    """Check if two axes are the same, used to determine squared plots"""
-    axes_same_and_not_none = (x_axis == y_axis) and (x_axis is not None)
+    """Check if two axes are similar, used to determine squared plots"""
+    axes_compatible_and_not_none = (x_axis, y_axis) in _AXIS_COMPAT
     axes_same_lim = xlim == ylim
-    return axes_same_and_not_none and axes_same_lim
+    return axes_compatible_and_not_none and axes_same_lim
 
 
 @deprecate_positional_args

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -833,6 +833,7 @@ def test_display_fourier_tempo_odd():
         ("time", "linear", (0.0, 1.0), (0.0, 1.0), False),
         ("time", "time", (0.0, 1.0), (0.0, 2.0), False),
         ("chroma", "chroma", (0.0, 1.0), (0.0, 1.0), True),
+        ("s", "ms", (0.0, 1.0), (0.0, 1.0), True),
     ],
 )
 def test_same_axes(x_axis, y_axis, xlim, ylim, out):
@@ -841,7 +842,7 @@ def test_same_axes(x_axis, y_axis, xlim, ylim, out):
 
 def test_auto_aspect():
 
-    fig, ax = plt.subplots(nrows=4)
+    fig, ax = plt.subplots(nrows=5)
 
     # Ensure auto aspect by default
     for axi in ax:
@@ -849,7 +850,7 @@ def test_auto_aspect():
 
     X = np.zeros((12, 12))
 
-    # Different axes should retain auto scaling
+    # Different axes with incompatible types should retain auto scaling
     librosa.display.specshow(X, x_axis="chroma", y_axis="time", ax=ax[0])
     assert ax[0].get_aspect() == "auto"
 
@@ -868,6 +869,10 @@ def test_auto_aspect():
         X[:2, :], x_axis="chroma", y_axis="chroma", auto_aspect=True, ax=ax[3]
     )
     assert ax[3].get_aspect() == "auto"
+
+    # different axes with compatible types and auto_aspect=True should force equal scaling
+    librosa.display.specshow(X, x_axis="time", y_axis="ms", ax=ax[4])
+    assert ax[4].get_aspect() == 1.0
 
 
 @pytest.mark.mpl_image_compare(


### PR DESCRIPTION
#### Reference Issue
Fixes #1499 


#### What does this implement/fix? Explain your changes.
This PR softens the comparison logic to determine whether plots could be squared. In addition to having exact axis types, different types in the same category, such as 'time' and 'ms', are also considered compatible and can have equal-scaling.

#### Any other comments?
I'm not sure if every two types in the same category are compatible, e.g., `linear` and `cqt_note`.