### PR TITLE
Speed up `magphase`

### DIFF
--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1168,8 +1168,17 @@ def magphase(D, *, power=1):
     """
 
     mag = np.abs(D)
+
+    # Prevent NaNs and return magnitude 0, phase 1+0j for zero
+    zeros_to_ones = mag == 0
+    mag_nonzero = mag + zeros_to_ones
+    # Compute real and imaginary separately, because complex division can
+    # produce NaNs when denormalized numbers are involved (< ~2e-39 for
+    # complex64, ~5e-309 for complex128)
+    phase = D.imag / mag_nonzero * 1.0j
+    phase += D.real / mag_nonzero + zeros_to_ones
+
     mag **= power
-    phase = np.exp(1.0j * np.angle(D))
 
     return mag, phase
 

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1169,14 +1169,18 @@ def magphase(D, *, power=1):
 
     mag = np.abs(D)
 
+    if not np.iscomplexobj(D):
+        return mag, np.sign(D, dtype=util.dtype_r2c(D.dtype)) + (D == 0)
+
     # Prevent NaNs and return magnitude 0, phase 1+0j for zero
     zeros_to_ones = mag == 0
     mag_nonzero = mag + zeros_to_ones
     # Compute real and imaginary separately, because complex division can
     # produce NaNs when denormalized numbers are involved (< ~2e-39 for
     # complex64, ~5e-309 for complex128)
-    phase = D.imag / mag_nonzero * 1.0j
-    phase += D.real / mag_nonzero + zeros_to_ones
+    phase = np.empty_like(D)
+    phase.real = D.real / mag_nonzero + zeros_to_ones
+    phase.imag = D.imag / mag_nonzero
 
     mag **= power
 

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1169,16 +1169,13 @@ def magphase(D, *, power=1):
 
     mag = np.abs(D)
 
-    if not np.iscomplexobj(D):
-        return mag, np.sign(D, dtype=util.dtype_r2c(D.dtype)) + (D == 0)
-
     # Prevent NaNs and return magnitude 0, phase 1+0j for zero
     zeros_to_ones = mag == 0
     mag_nonzero = mag + zeros_to_ones
     # Compute real and imaginary separately, because complex division can
     # produce NaNs when denormalized numbers are involved (< ~2e-39 for
     # complex64, ~5e-309 for complex128)
-    phase = np.empty_like(D)
+    phase = np.empty_like(D, dtype=util.dtype_r2c(D.dtype))
     phase.real = D.real / mag_nonzero + zeros_to_ones
     phase.imag = D.imag / mag_nonzero
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -700,7 +700,32 @@ def test_magphase(y_22050):
 
     S, P = librosa.magphase(D)
 
+    assert S.dtype is y_22050.dtype  # float
+    assert P.dtype is D.dtype  # complex
+    assert np.allclose(np.abs(P), 1.0)
     assert np.allclose(S * P, D)
+
+
+def test_magphase_zero():
+
+    D = np.zeros((128, 128), dtype=np.complex64)
+    S, P = librosa.magphase(D)
+
+    assert S.dtype is np.dtype("float32")
+    assert P.dtype is np.dtype("complex64")
+    assert np.allclose(S, 0)
+    assert np.allclose(P, 1+0j)
+
+
+def test_magphase_denormalized():
+
+    D = 1.0e-42j * np.ones((128, 128), dtype=np.complex64)
+    S, P = librosa.magphase(D)
+
+    assert S.dtype is np.dtype("float32")
+    assert P.dtype is np.dtype("complex64")
+    assert np.allclose(S, 1.0e-42)
+    assert np.allclose(P, 0+1j)
 
 
 @pytest.fixture(scope="module", params=[22050, 44100])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -728,6 +728,23 @@ def test_magphase_denormalized():
     assert np.allclose(P, 0+1j)
 
 
+def test_magphase_real():
+
+    D = np.array([[-1.0, -0.0], [0.0, 1.0]], dtype=np.float64)
+    S, P = librosa.magphase(D)
+
+    assert S.dtype is np.dtype("float64")
+    assert P.dtype is np.dtype("complex128")
+    assert np.allclose(S, np.array([[1.0, 0.0], [0.0, 1.0]]))
+    assert np.allclose(
+        [
+            [P[0, 0], P[0, 1] ** 2],  # negative zero can have phase +1 or -1
+            [P[1, 0], P[1, 1]],
+        ],
+        np.array([[-1+0j, 1+0j], [1+0j, 1+0j]])
+    )
+
+
 @pytest.fixture(scope="module", params=[22050, 44100])
 def y_chirp_istft(request):
     sr = request.param


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Dividing the spectrum by the magnitude is equivalent to `exp(1j * angle(D))`, but about 4x faster:

```
$ python -m timeit -s 'import librosa; y, sr = librosa.load(librosa.ex("trumpet")); D = librosa.stft(y)' 'librosa.magphase_old(D)'
100 loops, best of 3: 13.5 msec per loop
$ python -m timeit -s 'import librosa; y, sr = librosa.load(librosa.ex("trumpet")); D = librosa.stft(y)' 'librosa.magphase_new(D)'
100 loops, best of 3: 3.58 msec per loop
```

[More thorough benchmark here.](https://github.com/futurulus/librosa/blob/faster-magphase-notebook/docs/magphase.ipynb) The proposed calculation is slightly slower for very small arrays, but is faster already on a 100-element array, and continues to be ~3x faster up through at least 10M elements. 

#### Any other comments?

Some potential speedup (and simplicity) is sacrificed to prevent the new implementation from producing NaNs where the old one didn't. The new implementation is also ~5x closer to a perfect reconstruction of the original complex spectrum when the magnitude and phase are multiplied back together, but the original was already accurate enough that I'm not sure this will matter in practice.

This idea was prompted by the result of profiling `librosa.decompose.hpss`; the current implementation spends about 10% of its time in `magphase`.