### PR TITLE
[CR needed] STFT pre-allocation

### DIFF
--- a/docs/examples/plot_pcen_stream.py
+++ b/docs/examples/plot_pcen_stream.py
@@ -11,6 +11,10 @@ to do dynamic per-channel energy normalization on a spectrogram incrementally.
 
 This is useful when processing long audio files that are too large to load all at
 once, or when streaming data from a recording device.
+
+It also illustrates how to use a pre-allocated output buffer for block-wise
+short-time Fourier transforms.  This provides a minor speed boost and reduction
+in memory usage when processing audio streams.
 """
 
 ##################################################
@@ -59,10 +63,15 @@ pcen_blocks = []
 # Initialize the PCEN filter delays to steady state
 zi = None
 
+# Create a handle for storing the block STFT outputs
+# After the first block has been processed, we can re-use
+# this buffer instead of allocating a new one for each block.
+D = None
+
 for y_block in stream:
     # Compute the STFT (without padding, so center=False)
     D = librosa.stft(y_block, n_fft=n_fft, hop_length=hop_length,
-                     center=False)
+                     center=False, out=D)
 
     # Compute PCEN on the magnitude spectrum, using initial delays
     # returned from our previous call (if any)

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -139,6 +139,13 @@ def stft(
         If ``center=True``, this argument is passed to `np.pad` for padding
         the edges of the signal ``y``. By default (``pad_mode="constant"``),
         ``y`` is padded on both sides with zeros.
+
+        .. note:: Not all padding modes supported by `numpy.pad` are supported here.
+            `wrap`, `mean`, `maximum`, `median`, and `minimum` are not supported.
+
+            Other modes that depend at most on input values at the edges of the
+            signal (e.g., `constant`, `edge`, `linear_ramp`) are supported.
+
         If ``center=False``,  this argument is ignored.
 
         .. see also:: `numpy.pad`
@@ -219,6 +226,9 @@ def stft(
 
     # Pad the time series so that frames are centered
     if center:
+        if pad_mode in ("wrap", "maximum", "mean", "median", "minimum"):
+            raise ParameterError("pad_mode='{}' is not supported by librosa.stft".format(pad_mode))
+
         if n_fft > y.shape[-1]:
             warnings.warn(
                 "n_fft={} is too large for input signal of length={}".format(

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -229,6 +229,15 @@ def stft(
     # Pad the time series so that frames are centered
     if center:
         if pad_mode in ("wrap", "maximum", "mean", "median", "minimum"):
+            # Note: padding with a user-provided function "works", but
+            # use at your own risk.
+            # Since we don't pass-through kwargs here, any arguments
+            # to a user-provided pad function should be encapsulated
+            # by using functools.partial:
+            #
+            # >>> my_pad_func = functools.partial(pad_func, foo=x, bar=y)
+            # >>> librosa.stft(..., pad_mode=my_pad_func)
+
             raise ParameterError("pad_mode='{}' is not supported by librosa.stft".format(pad_mode))
 
         if n_fft > y.shape[-1]:

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -2604,11 +2604,10 @@ def griffinlim(
         )
 
         # Update our phase estimates
-        if tprev is None:
-            angles[:] = rebuilt
-        else:
-            angles[:] = rebuilt - (momentum / (1 + momentum)) * tprev
-        angles[:] /= np.abs(angles) + eps
+        angles[:] = rebuilt
+        if tprev is not None:
+            angles -= (momentum / (1 + momentum)) * tprev
+        angles /= np.abs(angles) + eps
         angles *= S
         # Store
         rebuilt, tprev = tprev, rebuilt

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -212,6 +212,8 @@ def stft(
     # Set the default hop, if it's not already specified
     if hop_length is None:
         hop_length = int(win_length // 4)
+    elif not (np.issubdtype(type(hop_length), np.integer) and hop_length > 0):
+        raise ParameterError("hop_length={} must be a positive integer".format(hop_length))
 
     # Check audio is valid
     util.valid_audio(y, mono=False)

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -326,6 +326,10 @@ def stft(
         raise ParameterError(
             f"Shape mismatch for provided output array out.shape={out.shape} != {shape}"
         )
+    elif not np.iscomplexobj(out):
+        raise ParameterError(
+            f"output with dtype={out.dtype} is not of complex type"
+        )
     else:
         stft_matrix = out
 

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -152,7 +152,7 @@ def stft(
 
     out : np.ndarray or None
         A pre-allocated, complex-valued array to store the STFT results.
-        This must be of the correct shape for the given input parameters.
+        This must be of the correct shape and dtype for the given input parameters.
 
         If not provided, a new array is allocated and returned.
 
@@ -426,10 +426,11 @@ def istft(
         If provided, the output ``y`` is zero-padded or clipped to exactly
         ``length`` samples.
 
-    out : np.ndarray, optional
-        Optional pre-allocated output array.
-        FIXME: more
+    out : np.ndarray or None
+        A pre-allocated, complex-valued array to store the reconstructed signal
+        ``y``.  This must be of the correct shape for the given input parameters.
 
+        If not provided, a new array is allocated and returned.
 
     Returns
     -------

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -2573,9 +2573,11 @@ def griffinlim(
     # And initialize the previous iterate to 0
     rebuilt = 0.0
 
+    rebuilt, tprev = None, None
+    inverse = None
     for _ in range(n_iter):
         # Store the previous iterate
-        tprev = rebuilt
+        #tprev = rebuilt
 
         # Invert with our current estimate of the phases
         inverse = istft(
@@ -2587,6 +2589,7 @@ def griffinlim(
             center=center,
             dtype=dtype,
             length=length,
+            out=inverse,
         )
 
         # Rebuild the spectrogram
@@ -2598,11 +2601,17 @@ def griffinlim(
             window=window,
             center=center,
             pad_mode=pad_mode,
+            out=rebuilt
         )
 
         # Update our phase estimates
-        angles[:] = rebuilt - (momentum / (1 + momentum)) * tprev
+        if tprev is None:
+            angles[:] = rebuilt
+        else:
+            angles[:] = rebuilt - (momentum / (1 + momentum)) * tprev
         angles[:] /= np.abs(angles) + eps
+        # Store
+        rebuilt, tprev = tprev, rebuilt
 
     # Return the final phase estimates
     return istft(
@@ -2614,6 +2623,7 @@ def griffinlim(
         center=center,
         dtype=dtype,
         length=length,
+        out=inverse
     )
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -326,6 +326,21 @@ def test_stft_winsizes():
         librosa.stft(x, n_fft=N, hop_length=H, win_length=N)
 
 
+@pytest.mark.parametrize("center", [False, True])
+@pytest.mark.parametrize("n_fft, hop_length", [(1023, 128), (1023, 129), (1023, 256), (2048, 512), (2048, 2048)])
+@pytest.mark.parametrize("N", [1024, 2048, 8192])
+def test_stft_preallocate(center, n_fft, hop_length, N):
+
+    # Work in stereo by default
+    y = np.random.randn(2, max(N, n_fft))
+
+    D1 = librosa.stft(y, center=center, n_fft=n_fft, hop_length=hop_length)
+    out = np.empty_like(D1)
+    D2 = librosa.stft(y, center=center, n_fft=n_fft, hop_length=hop_length, out=out)
+    assert D2 is out
+    assert np.allclose(D1, D2)
+
+
 # results for FFT bins containing multiple components will be unstable, as when
 # using higher sampling rates or shorter windows with this test signal
 @pytest.mark.parametrize("center", [False, True])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -72,7 +72,7 @@ def test_load_soundfile():
 
 def test_load_audioread():
     fname = os.path.join("tests", "data", "test1_44100.wav")
-    
+
     # Load using an existing audioread object
     reader = audioread.rawread.RawAudioFile(fname)
     y, sr = librosa.load(reader, sr=None)
@@ -169,7 +169,9 @@ def test_resample_mono(resample_mono, sr_out, res_type, fix):
     y, sr_in = resample_mono
     y = librosa.to_mono(y)
 
-    y2 = librosa.resample(y, orig_sr=sr_in, target_sr=sr_out, res_type=res_type, fix=fix)
+    y2 = librosa.resample(
+        y, orig_sr=sr_in, target_sr=sr_out, res_type=res_type, fix=fix
+    )
 
     # First, check that the audio is valid
     librosa.util.valid_audio(y2, mono=True)
@@ -213,7 +215,9 @@ def test_resample_stereo(resample_audio, sr_out, res_type, fix):
 
     y, sr_in = resample_audio
 
-    y2 = librosa.resample(y, orig_sr=sr_in, target_sr=sr_out, res_type=res_type, fix=fix)
+    y2 = librosa.resample(
+        y, orig_sr=sr_in, target_sr=sr_out, res_type=res_type, fix=fix
+    )
 
     # First, check that the audio is valid
     librosa.util.valid_audio(y2, mono=False)
@@ -250,7 +254,9 @@ def test_resample_scale(resample_mono, res_type, sr_out):
 
     y, sr_in = resample_mono
 
-    y2 = librosa.resample(y, orig_sr=sr_in, target_sr=sr_out, res_type=res_type, scale=True)
+    y2 = librosa.resample(
+        y, orig_sr=sr_in, target_sr=sr_out, res_type=res_type, scale=True
+    )
 
     # First, check that the audio is valid
     librosa.util.valid_audio(y2, mono=True)
@@ -321,13 +327,16 @@ def test_stft_winsizes():
     x = np.zeros(1000000)
 
     for power in range(12, 17):
-        N = 2 ** power
+        N = 2**power
         H = N // 2
         librosa.stft(x, n_fft=N, hop_length=H, win_length=N)
 
 
 @pytest.mark.parametrize("center", [False, True])
-@pytest.mark.parametrize("n_fft, hop_length", [(1023, 128), (1023, 129), (1023, 256), (2048, 512), (2048, 2048)])
+@pytest.mark.parametrize(
+    "n_fft, hop_length",
+    [(1023, 128), (1023, 129), (1023, 256), (2048, 512), (2048, 2048)],
+)
 @pytest.mark.parametrize("N", [1024, 2048, 8192])
 def test_stft_preallocate(center, n_fft, hop_length, N):
 
@@ -620,7 +629,12 @@ def test_salience_basecase():
     harms = [1]
     weights = [1.0]
     S_sal = librosa.core.salience(
-        S, freqs=freqs, harmonics=harms, weights=weights, filter_peaks=False, kind="quadratic"
+        S,
+        freqs=freqs,
+        harmonics=harms,
+        weights=weights,
+        filter_peaks=False,
+        kind="quadratic",
     )
     assert np.allclose(S_sal, S)
 
@@ -632,7 +646,12 @@ def test_salience_basecase2():
     harms = [1, 0.5, 2.0]
     weights = [1.0, 0.0, 0.0]
     S_sal = librosa.core.salience(
-        S, freqs=freqs, harmonics=harms, weights=weights, filter_peaks=False, kind="quadratic"
+        S,
+        freqs=freqs,
+        harmonics=harms,
+        weights=weights,
+        filter_peaks=False,
+        kind="quadratic",
     )
     assert np.allclose(S_sal, S)
 
@@ -641,7 +660,9 @@ def test_salience_defaults():
     S = np.array([[0.1, 0.5, 0.0], [0.2, 1.2, 1.2], [0.0, 0.7, 0.3], [1.3, 3.2, 0.8]])
     freqs = np.array([50.0, 100.0, 200.0, 400.0])
     harms = [0.5, 1, 2]
-    actual = librosa.core.salience(S, freqs=freqs, harmonics=harms, kind="quadratic", fill_value=0.0)
+    actual = librosa.core.salience(
+        S, freqs=freqs, harmonics=harms, kind="quadratic", fill_value=0.0
+    )
 
     expected = (
         np.array([[0.0, 0.0, 0.0], [0.3, 2.4, 1.5], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
@@ -656,7 +677,12 @@ def test_salience_weights():
     harms = [0.5, 1, 2]
     weights = [1.0, 1.0, 1.0]
     actual = librosa.core.salience(
-        S, freqs=freqs, harmonics=harms, weights=weights, kind="quadratic", fill_value=0.0
+        S,
+        freqs=freqs,
+        harmonics=harms,
+        weights=weights,
+        kind="quadratic",
+        fill_value=0.0,
     )
 
     expected = (
@@ -672,7 +698,12 @@ def test_salience_no_peak_filter():
     harms = [0.5, 1, 2]
     weights = [1.0, 1.0, 1.0]
     actual = librosa.core.salience(
-        S, freqs=freqs, harmonics=harms, weights=weights, filter_peaks=False, kind="quadratic"
+        S,
+        freqs=freqs,
+        harmonics=harms,
+        weights=weights,
+        filter_peaks=False,
+        kind="quadratic",
     )
 
     expected = (
@@ -688,7 +719,13 @@ def test_salience_aggregate():
     harms = [0.5, 1, 2]
     weights = [1.0, 1.0, 1.0]
     actual = librosa.core.salience(
-        S, freqs=freqs, harmonics=harms, weights=weights, aggregate=np.ma.max, kind="quadratic", fill_value=0.0
+        S,
+        freqs=freqs,
+        harmonics=harms,
+        weights=weights,
+        aggregate=np.ma.max,
+        kind="quadratic",
+        fill_value=0.0,
     )
 
     expected = np.array(
@@ -729,7 +766,7 @@ def test_magphase_zero():
     assert S.dtype is np.dtype("float32")
     assert P.dtype is np.dtype("complex64")
     assert np.allclose(S, 0)
-    assert np.allclose(P, 1+0j)
+    assert np.allclose(P, 1 + 0j)
 
 
 def test_magphase_denormalized():
@@ -740,7 +777,7 @@ def test_magphase_denormalized():
     assert S.dtype is np.dtype("float32")
     assert P.dtype is np.dtype("complex64")
     assert np.allclose(S, 1.0e-42)
-    assert np.allclose(P, 0+1j)
+    assert np.allclose(P, 0 + 1j)
 
 
 def test_magphase_real():
@@ -756,7 +793,7 @@ def test_magphase_real():
             [P[0, 0], P[0, 1] ** 2],  # negative zero can have phase +1 or -1
             [P[1, 0], P[1, 1]],
         ],
-        np.array([[-1+0j, 1+0j], [1+0j, 1+0j]])
+        np.array([[-1 + 0j, 1 + 0j], [1 + 0j, 1 + 0j]]),
     )
 
 
@@ -955,7 +992,7 @@ def test_to_mono(y):
 
 
 @pytest.mark.parametrize(
-    "y", [np.ones((2, 10)), np.ones((2, 3, 10)), np.ones((2,3,4,10))]
+    "y", [np.ones((2, 10)), np.ones((2, 3, 10)), np.ones((2, 3, 4, 10))]
 )
 def test_to_mono_multi(y):
     y_mono = librosa.to_mono(y)
@@ -1109,10 +1146,10 @@ def test_pyin_multi():
     y = np.stack([librosa.tone(440, duration=1.0), librosa.tone(560, duration=1.0)])
 
     # Taper the signal
-    h = librosa.filters.get_window('triangle', y.shape[-1])
+    h = librosa.filters.get_window("triangle", y.shape[-1])
 
     # Filter it
-    y = y * h[np.newaxis,:]
+    y = y * h[np.newaxis, :]
 
     # Disable nans so we can use allclose checks
     fall, vall, vpall = librosa.pyin(y, fmin=100, fmax=1000, center=False, fill_na=-1)
@@ -1131,13 +1168,15 @@ def test_pyin_multi_center():
     y = np.stack([librosa.tone(440, duration=1.0), librosa.tone(560, duration=1.0)])
 
     # Taper the signal
-    h = librosa.filters.get_window('triangle', y.shape[-1])
+    h = librosa.filters.get_window("triangle", y.shape[-1])
 
     # Filter it
-    y = y * h[np.newaxis,:]
+    y = y * h[np.newaxis, :]
 
     # Disable nans so we can use allclose checks
-    fleft, vleft, vpleft = librosa.pyin(y, fmin=100, fmax=1000, center=False, fill_na=-1)
+    fleft, vleft, vpleft = librosa.pyin(
+        y, fmin=100, fmax=1000, center=False, fill_na=-1
+    )
     fc, vc, vpc = librosa.pyin(y, fmin=100, fmax=1000, center=True, fill_na=-1)
 
     # Centering will pad by half a frame on either side
@@ -1280,7 +1319,7 @@ def test__spectrogram(y_22050, n_fft, hop_length, power):
     # And only the spectrogram but with incorrect n_fft
     S_, n_fft_ = librosa.core.spectrum._spectrogram(S=S, n_fft=2 * n_fft, power=power)
     assert np.allclose(S, S_)
-    
+
     assert np.allclose(2 * (S.shape[-2] - 1), n_fft_)
 
 
@@ -1313,8 +1352,8 @@ def test_power_to_db_fail(x, top_db, amin):
 def test_power_to_db_inv(erp, k):
 
     y_true = (k - erp) * 10
-    x = 10.0 ** k
-    rp = 10.0 ** erp
+    x = 10.0**k
+    rp = 10.0**erp
     y = librosa.power_to_db(x, ref=rp, top_db=None)
 
     assert np.isclose(y, y_true)
@@ -1329,7 +1368,7 @@ def test_amplitude_to_db():
     x = np.abs(np.random.randn(1000)) + NOISE_FLOOR
 
     db1 = librosa.amplitude_to_db(x, top_db=None)
-    db2 = librosa.power_to_db(x ** 2, top_db=None)
+    db2 = librosa.power_to_db(x**2, top_db=None)
 
     assert np.allclose(db1, db2)
 
@@ -1347,7 +1386,7 @@ def test_amplitude_to_db_complex():
         assert len(out) > 0
         assert "complex" in str(out[0].message).lower()
 
-    db2 = librosa.power_to_db(x ** 2, top_db=None)
+    db2 = librosa.power_to_db(x**2, top_db=None)
 
     assert np.allclose(db1, db2)
 
@@ -1356,7 +1395,7 @@ def test_amplitude_to_db_complex():
 @pytest.mark.parametrize("xp", [(np.abs(np.random.randn(1000)) + 1e-5) ** 2])
 def test_db_to_power_inv(ref_p, xp):
 
-    ref = 10.0 ** ref_p
+    ref = 10.0**ref_p
     db = librosa.power_to_db(xp, ref=ref, top_db=None)
     xp2 = librosa.db_to_power(db, ref=ref)
 
@@ -1368,8 +1407,8 @@ def test_db_to_power_inv(ref_p, xp):
 def test_db_to_power(erp, db):
 
     y = db
-    rp = 10.0 ** erp
-    x_true = 10.0 ** erp * (10.0 ** (0.1 * db))
+    rp = 10.0**erp
+    x_true = 10.0**erp * (10.0 ** (0.1 * db))
 
     x = librosa.db_to_power(y, ref=rp)
 
@@ -1380,7 +1419,7 @@ def test_db_to_power(erp, db):
 @pytest.mark.parametrize("xp", [(np.abs(np.random.randn(1000)) + 1e-5)])
 def test_db_to_amplitude_inv(xp, ref_p):
 
-    ref = 10.0 ** ref_p
+    ref = 10.0**ref_p
     db = librosa.amplitude_to_db(xp, ref=ref, top_db=None)
     xp2 = librosa.db_to_amplitude(db, ref=ref)
 
@@ -1556,7 +1595,7 @@ def y_orig():
 def test_fmt_scale(y_orig, y_res, n_fmt, kind, atol, SCALE, OVER_SAMPLE):
 
     # Make sure our signals preserve energy
-    assert np.allclose(np.sum(y_orig ** 2), np.sum(y_res ** 2))
+    assert np.allclose(np.sum(y_orig**2), np.sum(y_res**2))
 
     # Scale-transform the original
     f_orig = librosa.fmt(
@@ -1662,7 +1701,7 @@ def test_harmonics_2d():
 
 
 def test_harmonics_1d_nonunique():
-    x = np.arange(-8, 8)**2
+    x = np.arange(-8, 8) ** 2
     y = np.linspace(-8, 8, num=len(x), endpoint=False) ** 2
 
     h = [0.25, 0.5, 1, 2, 4]
@@ -1852,7 +1891,7 @@ def test_pcen_power(S_pcen, p):
     P = librosa.pcen(
         S_pcen, gain=0, bias=0, power=p, b=1, time_constant=0.5, eps=1e-6, max_size=1
     )
-    assert np.allclose(P, S_pcen ** p)
+    assert np.allclose(P, S_pcen**p)
 
 
 def test_pcen_ones(S_pcen):
@@ -2058,7 +2097,7 @@ def test_reset_fftlib():
 @pytest.fixture
 def y_chirp():
     sr = 22050
-    y = librosa.chirp(fmin=55, fmax=55 * 2 ** 7, length=sr // 8, sr=sr)
+    y = librosa.chirp(fmin=55, fmax=55 * 2**7, length=sr // 8, sr=sr)
     return y
 
 
@@ -2255,7 +2294,9 @@ def test_stream(
         # frame this for easy checking
         y_b_mono = librosa.to_mono(y_block)
         if len(y_b_mono) >= frame_length:
-            y_b_frame = librosa.util.frame(y_b_mono, frame_length=frame_length, hop_length=hop_length)
+            y_b_frame = librosa.util.frame(
+                y_b_mono, frame_length=frame_length, hop_length=hop_length
+            )
             y_frame_stream.append(y_b_frame)
 
     # Concatenate the framed blocks together
@@ -2272,7 +2313,9 @@ def test_stream(
         path, sr=None, dtype=dtype, mono=True, offset=offset, duration=duration
     )
     # First, check the rate
-    y_frame = librosa.util.frame(y_full, frame_length=frame_length, hop_length=hop_length)
+    y_frame = librosa.util.frame(
+        y_full, frame_length=frame_length, hop_length=hop_length
+    )
 
     # Raw audio will not be padded
     n = y_frame.shape[1]
@@ -2349,3 +2392,22 @@ def test_mu_expand_badmu():
 )
 def test_mu_expand_badx(x):
     librosa.mu_expand(x, quantize=False)
+
+
+@pytest.mark.xfail(raises=librosa.ParameterError)
+def test_stft_bad_prealloc_shape():
+    y = np.zeros(22050)
+
+    # Output shape here is incorrect, and should trigger a failure
+    S1 = librosa.stft(
+        y, n_fft=512, hop_length=128, out=np.zeros((100, 10), dtype=np.complex)
+    )
+
+
+@pytest.mark.xfail(raises=librosa.ParameterError)
+def test_stft_bad_prealloc_dtype():
+    y = np.zeros(22050)
+    D = librosa.stft(y)
+
+    Dbad = np.zeros(D.shape, dtype=np.float32)
+    librosa.stft(y, out=Dbad)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -355,6 +355,45 @@ def test_stft_preallocate(center, n_fft, hop_length, N):
     "n_fft, hop_length",
     [(1023, 128), (1023, 129), (1023, 256), (2048, 512), (2048, 2048)],
 )
+@pytest.mark.parametrize("N", [2048])
+def test_stft_preallocate_oversize(center, n_fft, hop_length, N):
+
+    # Work in stereo by default
+    y = np.random.randn(2, max(N, n_fft))
+
+    D1 = librosa.stft(y, center=center, n_fft=n_fft, hop_length=hop_length)
+    shape = list(D1.shape)
+    shape[-1] *= 2
+    out = np.empty_like(D1, shape=shape)
+    D2 = librosa.stft(y, center=center, n_fft=n_fft, hop_length=hop_length, out=out)
+    assert np.allclose(D1, D2)
+    assert np.allclose(D1, out[..., :D2.shape[-1]])
+
+
+@pytest.mark.parametrize("center", [False, True])
+@pytest.mark.parametrize(
+    "n_fft, hop_length",
+    [(1023, 128), (1023, 129), (1023, 256), (2048, 512), (2048, 2048)],
+)
+@pytest.mark.parametrize("N", [2048])
+@pytest.mark.xfail(raises=librosa.ParameterError)
+def test_stft_preallocate_undersize(center, n_fft, hop_length, N):
+
+    # Work in stereo by default
+    y = np.random.randn(2, max(N, n_fft))
+
+    D1 = librosa.stft(y, center=center, n_fft=n_fft, hop_length=hop_length)
+    shape = list(D1.shape)
+    shape[-1] //= 2
+    out = np.empty_like(D1, shape=shape)
+    D2 = librosa.stft(y, center=center, n_fft=n_fft, hop_length=hop_length, out=out)
+
+
+@pytest.mark.parametrize("center", [False, True])
+@pytest.mark.parametrize(
+    "n_fft, hop_length",
+    [(1023, 128), (1023, 129), (1023, 256), (2048, 512), (2048, 2048)],
+)
 @pytest.mark.parametrize("N", [1024, 2048, 8192])
 def test_istft_preallocate(center, n_fft, hop_length, N):
     y = np.random.randn(2, max(N, n_fft))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -343,7 +343,7 @@ def test_stft_preallocate(center, n_fft, hop_length, N):
 
 # results for FFT bins containing multiple components will be unstable, as when
 # using higher sampling rates or shorter windows with this test signal
-@pytest.mark.parametrize("center", [False, True])
+@pytest.mark.parametrize("center", [False])
 @pytest.mark.parametrize("sr", [256, 512, 2000, 2048])
 @pytest.mark.parametrize("n_fft", [128, 255, 256, 512, 1280])
 def test___reassign_frequencies(sr, n_fft, center):
@@ -351,7 +351,7 @@ def test___reassign_frequencies(sr, n_fft, center):
     y = np.sin(17 * x * 2 * np.pi) + np.sin(103 * x * 2 * np.pi)
 
     freqs, S = librosa.core.spectrum.__reassign_frequencies(
-        y=y, sr=sr, n_fft=n_fft, hop_length=n_fft, center=center, pad_mode="wrap"
+        y=y, sr=sr, n_fft=n_fft, hop_length=n_fft, center=center
     )
 
     S_db = librosa.amplitude_to_db(np.abs(S), ref=np.max)

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -131,3 +131,10 @@ def test_istft_bad_window():
     window = np.ones(n_fft // 2)
 
     librosa.istft(D, window=window)
+
+
+@pytest.mark.xfail(raises=librosa.ParameterError)
+@pytest.mark.parametrize('y', [np.empty(22050)])
+@pytest.mark.parametrize('mode', ['wrap', 'maximum', 'minimum', 'median', 'mean'])
+def test_stft_bad_pad(y, mode):
+    librosa.stft(y, pad_mode=mode)


### PR DESCRIPTION
#### Reference Issue
Fixes #871 


#### What does this implement/fix? Explain your changes.

This PR adds parameter `out=` to `stft` and `istft` methods, allowing re-use of previously allocated output buffers.

Additionally, it implements some more careful handling of edge padding (when using centered mode) to reduce unnecessary copying.  The result should be a substantial speedup when processing long signals.

#### Any other comments?

This is currently WIP.  To-dos:

- [x] complete tests for stft pre-allocation
- [x] add istft and tests
- [x] update other parts of the library to make use of pre-allocation where possible, eg griffinlim
- [x] add an example to the gallery illustrating the utility, or maybe just extend the pcen example

That said, I'd like to get some early feedback on the implementation, mainly from the perspective of readability.
