### PR TITLE
Accelerated abs2 and phasor

### DIFF
--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -845,7 +845,7 @@ def autocorrelate(y, *, max_size=None, axis=-1):
     # Compute the power spectrum along the chosen axis
     # Pad out the signal to support full-length auto-correlation.
     fft = get_fftlib()
-    powspec = np.abs(fft.fft(y, n=2 * y.shape[axis] + 1, axis=axis)) ** 2
+    powspec = util.abs2(fft.fft(y, n=2 * y.shape[axis] + 1, axis=axis))
 
     # Convert back to time domain
     autocorr = fft.ifft(powspec, axis=axis)

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -714,7 +714,7 @@ def icqt(
         inv_basis = fft_basis.H.todense()
 
         # Compute each filter's frequency-domain power
-        freq_power = 1 / np.sum(np.abs(np.asarray(inv_basis)) ** 2, axis=0)
+        freq_power = 1 / np.sum(util.abs2(np.asarray(inv_basis)), axis=0)
 
         # Compensate for length normalization in the forward transform
         freq_power *= n_fft / lengths[sl]

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -1429,7 +1429,7 @@ def griffinlim_cqt(
 
     if init == "random":
         # randomly initialize the phase
-        angles[:] = np.exp(2j * np.pi * rng.rand(*C.shape))
+        angles[:] = util.phasor(2 * np.pi * rng.rand(*C.shape))
     elif init is None:
         # Initialize an all ones complex matrix
         angles[:] = 1.0

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1438,7 +1438,7 @@ def phase_vocoder(D, *, rate, hop_length=None, n_fft=None):
         mag = (1.0 - alpha) * np.abs(columns[..., 0]) + alpha * np.abs(columns[..., 1])
 
         # Store to output array
-        d_stretch[..., t] = mag * np.exp(1.0j * phase_acc)
+        d_stretch[..., t] = util.phasor(phase_acc, mag=mag)
 
         # Compute phase advance
         dphase = np.angle(columns[..., 1]) - np.angle(columns[..., 0]) - phi_advance
@@ -2581,7 +2581,7 @@ def griffinlim(
 
     if init == "random":
         # randomly initialize the phase
-        angles[:] = np.exp(2j * np.pi * rng.rand(*S.shape))
+        angles[:] = util.phasor((2 * np.pi * rng.rand(*S.shape)))
     elif init is None:
         # Initialize an all ones complex matrix
         angles[:] = 1.0

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -945,7 +945,7 @@ def rms(
         x = util.frame(y, frame_length=frame_length, hop_length=hop_length)
 
         # Calculate power
-        power = np.mean(np.abs(x) ** 2, axis=-2, keepdims=True)
+        power = np.mean(util.abs2(x), axis=-2, keepdims=True)
     elif S is not None:
         # Check the frame length
         if S.shape[-2] != frame_length // 2 + 1:

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -569,8 +569,8 @@ def constant_q(
     filters = []
     for ilen, freq in zip(lengths, freqs):
         # Build the filter: note, length will be ceil(ilen)
-        sig = np.exp(
-            np.arange(-ilen // 2, ilen // 2, dtype=float) * 1j * 2 * np.pi * freq / sr
+        sig = util.phasor(
+            np.arange(-ilen // 2, ilen // 2, dtype=float) * 2 * np.pi * freq / sr
         )
 
         # Apply the windowing function
@@ -927,8 +927,8 @@ def wavelet(
     filters = []
     for ilen, freq in zip(lengths, freqs):
         # Build the filter: note, length will be ceil(ilen)
-        sig = np.exp(
-            np.arange(-ilen // 2, ilen // 2, dtype=float) * 1j * 2 * np.pi * freq / sr
+        sig = util.phasor(
+            np.arange(-ilen // 2, ilen // 2, dtype=float) * 2 * np.pi * freq / sr
         )
 
         # Apply the windowing function

--- a/librosa/util/__init__.py
+++ b/librosa/util/__init__.py
@@ -49,6 +49,7 @@ Miscellaneous
     dtype_r2c
     count_unique
     is_unique
+    abs2
 
 
 Input validation

--- a/librosa/util/__init__.py
+++ b/librosa/util/__init__.py
@@ -50,6 +50,7 @@ Miscellaneous
     count_unique
     is_unique
     abs2
+    phasor
 
 
 Input validation

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -14,7 +14,7 @@ from .exceptions import ParameterError
 from .deprecation import Deprecated
 
 # Constrain STFT block sizes to 256 KB
-MAX_MEM_BLOCK = 2 ** 8 * 2 ** 10
+MAX_MEM_BLOCK = 2**8 * 2**10
 
 __all__ = [
     "MAX_MEM_BLOCK",
@@ -46,7 +46,7 @@ __all__ = [
     "count_unique",
     "is_unique",
     "abs2",
-    "phasor"
+    "phasor",
 ]
 
 
@@ -924,7 +924,7 @@ def normalize(S, *, norm=np.inf, axis=0, threshold=None, fill=None):
         length = np.sum(mag > 0, axis=axis, keepdims=True, dtype=mag.dtype)
 
     elif np.issubdtype(type(norm), np.number) and norm > 0:
-        length = np.sum(mag ** norm, axis=axis, keepdims=True) ** (1.0 / norm)
+        length = np.sum(mag**norm, axis=axis, keepdims=True) ** (1.0 / norm)
 
         if axis is None:
             fill_norm = mag.size ** (-1.0 / norm)
@@ -2279,14 +2279,16 @@ def is_unique(data, *, axis=-1):
     return np.apply_along_axis(__is_unique, axis, data)
 
 
-@numba.vectorize(['float32(complex64)', 'float64(complex128)'], nopython=True, cache=True, identity=0)
-def _cabs2(x):
-    '''Helper function for efficiently computing abs2 on complex inputs'''
+@numba.vectorize(
+    ["float32(complex64)", "float64(complex128)"], nopython=True, cache=True, identity=0
+)
+def _cabs2(x):  # pragma: no cover
+    """Helper function for efficiently computing abs2 on complex inputs"""
     return x.real**2 + x.imag**2
 
 
 def abs2(x):
-    '''Compute the squared magnitude of a real or complex array.
+    """Compute the squared magnitude of a real or complex array.
 
     This function is equivalent to calling `np.abs(x)**2` but slightly
     more efficient.
@@ -2308,20 +2310,22 @@ def abs2(x):
     >>> librosa.util.abs2((0.5j)**np.arange(8))
     array([1.000e+00, 2.500e-01, 6.250e-02, 1.562e-02, 3.906e-03, 9.766e-04,
        2.441e-04, 6.104e-05])
-    '''
+    """
     if np.iscomplexobj(x):
         return _cabs2(x)
     else:
         return x**2
 
 
-@numba.vectorize(['complex64(float32)', 'complex128(float64)'], nopython=True, cache=True, identity=1)
-def _phasor_angles(x):
+@numba.vectorize(
+    ["complex64(float32)", "complex128(float64)"], nopython=True, cache=True, identity=1
+)
+def _phasor_angles(x):  # pragma: no cover
     return np.cos(x) + 1j * np.sin(x)
 
 
 def phasor(angles, *, mag=None):
-    '''Construct a complex phasor representation from angles.
+    """Construct a complex phasor representation from angles.
 
     When `mag` is not provided, this is equivalent to:
 
@@ -2373,7 +2377,7 @@ def phasor(angles, *, mag=None):
 
     >>> librosa.util.phasor(np.array([0, np.pi/2]), mag=np.array([0.5, 1.5]))
     array([5.000e-01+0.j , 9.185e-17+1.5j])
-    '''
+    """
     z = _phasor_angles(angles)
 
     if mag is not None:

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -45,6 +45,7 @@ __all__ = [
     "dtype_c2r",
     "count_unique",
     "is_unique",
+    "abs2",
 ]
 
 
@@ -2275,3 +2276,38 @@ def is_unique(data, *, axis=-1):
     """
 
     return np.apply_along_axis(__is_unique, axis, data)
+
+
+@numba.vectorize(['float32(complex64)', 'float64(complex128)'], nopython=True, cache=True, identity=0)
+def _cabs2(x):
+    '''Helper function for efficiently computing abs2 on complex inputs'''
+    return x.real**2 + x.imag**2
+
+
+def abs2(x):
+    '''Compute the squared magnitude of a real or complex array:
+
+        p = |x|**2
+
+    Parameters
+    ----------
+    x : np.ndarray or scalar, real or complex typed
+        The input data, either real (float32, float64) or complex (complex64, complex128) typed
+
+    Returns
+    -------
+    p : real-valued squared magnitude of `x`
+
+    Examples
+    --------
+    >>> librosa.util.abs2(3 + 4j)
+    25.0
+
+    >>> librosa.util.abs2((0.5j)**np.arange(8))
+    array([1.000e+00, 2.500e-01, 6.250e-02, 1.562e-02, 3.906e-03, 9.766e-04,
+       2.441e-04, 6.104e-05])
+    '''
+    if np.iscomplexobj(x):
+        return _cabs2(x)
+    else:
+        return x**2

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -2290,8 +2290,8 @@ def _cabs2(x):  # pragma: no cover
 def abs2(x):
     """Compute the squared magnitude of a real or complex array.
 
-    This function is equivalent to calling `np.abs(x)**2` but slightly
-    more efficient.
+    This function is equivalent to calling `np.abs(x)**2` but it
+    is slightly more efficient.
 
     Parameters
     ----------
@@ -2300,7 +2300,8 @@ def abs2(x):
 
     Returns
     -------
-    p : real-valued squared magnitude of `x`
+    p : np.ndarray or scale, real
+        squared magnitude of `x`
 
     Examples
     --------

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -2358,16 +2358,19 @@ def phasor(angles, *, mag=None):
 
     Examples
     --------
-    Construct unit phasors at angles 0, pi/2, and pi
+    Construct unit phasors at angles 0, pi/2, and pi:
+
     >>> librosa.util.phasor([0, np.pi/2, np.pi])
     array([ 1.000e+00+0.000e+00j,  6.123e-17+1.000e+00j,
            -1.000e+00+1.225e-16j])
 
-    Construct a phasor with magnitude 1/2
+    Construct a phasor with magnitude 1/2:
+
     >>> librosa.util.phasor(np.pi/2, mag=0.5)
     (3.061616997868383e-17+0.5j)
 
-    Or arrays of angles and magnitudes
+    Or arrays of angles and magnitudes:
+
     >>> librosa.util.phasor(np.array([0, np.pi/2]), mag=np.array([0.5, 1.5]))
     array([5.000e-01+0.j , 9.185e-17+1.5j])
     '''

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -46,6 +46,7 @@ __all__ = [
     "count_unique",
     "is_unique",
     "abs2",
+    "phasor"
 ]
 
 
@@ -2285,9 +2286,10 @@ def _cabs2(x):
 
 
 def abs2(x):
-    '''Compute the squared magnitude of a real or complex array:
+    '''Compute the squared magnitude of a real or complex array.
 
-        p = |x|**2
+    This function is equivalent to calling `np.abs(x)**2` but slightly
+    more efficient.
 
     Parameters
     ----------
@@ -2311,3 +2313,67 @@ def abs2(x):
         return _cabs2(x)
     else:
         return x**2
+
+
+@numba.vectorize(['complex64(float32)', 'complex128(float64)'], nopython=True, cache=True, identity=1)
+def _phasor_angles(x):
+    return np.cos(x) + 1j * np.sin(x)
+
+
+def phasor(angles, *, mag=None):
+    '''Construct a complex phasor representation from angles.
+
+    When `mag` is not provided, this is equivalent to:
+
+        z = np.cos(angles) + 1j * np.sin(angles)
+
+    or by Euler's formula:
+
+        z = np.exp(1j * angles)
+
+    When `mag` is provided, this is equivalent to:
+
+        z = mag * np.exp(1j * angles)
+
+    This function should be more efficient (in time and memory) than the equivalent'
+    formulations above, but produce numerically identical results.
+
+    Parameters
+    ----------
+    angles : np.ndarray or scalar, real-valued
+        Angle(s), measured in radians
+
+    mag : np.ndarray or scalar, optional
+        If provided, phasor(s) will be scaled by `mag`.
+
+        If not provided (default), phasors will have unit magnitude.
+
+        `mag` must be of compatible shape to multiply with `angles`.
+
+    Returns
+    -------
+    z : np.ndarray or scalar, complex-valued
+        Complex number(s) z corresponding to the given angle(s)
+        and optional magnitude(s).
+
+    Examples
+    --------
+    Construct unit phasors at angles 0, pi/2, and pi
+    >>> librosa.util.phasor([0, np.pi/2, np.pi])
+    array([ 1.000e+00+0.000e+00j,  6.123e-17+1.000e+00j,
+           -1.000e+00+1.225e-16j])
+
+    Construct a phasor with magnitude 1/2
+    >>> librosa.util.phasor(np.pi/2, mag=0.5)
+    (3.061616997868383e-17+0.5j)
+
+    Or arrays of angles and magnitudes
+    >>> librosa.util.phasor(np.array([0, np.pi/2]), mag=np.array([0.5, 1.5]))
+    array([5.000e-01+0.j , 9.185e-17+1.5j])
+    '''
+    z = _phasor_angles(angles)
+
+    if mag is not None:
+        z *= mag
+
+    return z

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1346,3 +1346,21 @@ def test_abs2_complex(x, dtype):
     p = librosa.util.abs2(x)
     assert np.allclose(p, np.abs(x)**2)
     assert p.dtype == librosa.util.dtype_c2r(x.dtype)
+
+
+
+@pytest.mark.parametrize('dtype', [np.float32, np.float64])
+@pytest.mark.parametrize('angles', [np.pi/2, [np.pi/2, -np.pi/3]])
+@pytest.mark.parametrize('mag', [None, 2])
+def test_phasor(dtype, angles, mag):
+
+    angles = dtype(angles)
+    z = np.exp(1j * angles)
+    if mag is not None:
+        mag = dtype(mag)
+        z *= mag
+
+    z2 = librosa.util.phasor(angles, mag=mag)
+
+    assert np.allclose(z, z2)
+    assert z2.dtype == librosa.util.dtype_r2c(dtype)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1329,3 +1329,20 @@ def test_is_unique():
 
     assert np.allclose(x0, [True, True, True, True, False])
     assert np.allclose(x1, [False, False, True, True, True])
+
+
+@pytest.mark.parametrize('x', [-2, 3, np.arange(-3, 3)])
+@pytest.mark.parametrize('dtype', [np.float32, np.float64])
+def test_abs2_real(x, dtype):
+    x = dtype(x)
+    p = librosa.util.abs2(x)
+    assert np.allclose(p, x**2)
+
+
+@pytest.mark.parametrize('x', [(2 -2j), (3 +0j), (0.5j)**np.arange(6)])
+@pytest.mark.parametrize('dtype', [np.complex64, np.complex128])
+def test_abs2_complex(x, dtype):
+    x = dtype(x)
+    p = librosa.util.abs2(x)
+    assert np.allclose(p, np.abs(x)**2)
+    assert p.dtype == librosa.util.dtype_c2r(x.dtype)


### PR DESCRIPTION
#### Reference Issue
Fixes #745 

#### What does this implement/fix? Explain your changes.
This PR implements numba-accelerated utility functions for squared absolute value (abs2) and (unit) phasor construction.

#### Any other comments?

The following functions have been updated to use the new accelerated utilities:

- `core.autocorrelate`
- `core.phase_vocoder`
- `core.griffinlim`
- `core.griffinlim_cqt`
- `core.icqt`
- `feature.rms`
- `filters.wavelet`
- `filters.constantq`

Results appear to be numerically identical in all cases.

As long as the documentation and tests seem clear enough, I think this should be good to merge.  Doing so will unblock #1526.