### PR TITLE
Localmax and localmin vectorization

### DIFF
--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -963,13 +963,13 @@ def normalize(S, *, norm=np.inf, axis=0, threshold=None, fill=None):
 
 
 @numba.stencil
-def _localmax_sten(x):
+def _localmax_sten(x):  # pragma: no cover
     '''Numba stencil for local maxima computation'''
     return (x[0] > x[-1]) & (x[0] >= x[1])
 
 
 @numba.stencil
-def _localmin_sten(x):
+def _localmin_sten(x):  # pragma: no cover
     '''Numba stencil for local minima computation'''
     return (x[0] < x[-1]) & (x[0] <= x[1])
 
@@ -980,7 +980,7 @@ def _localmin_sten(x):
                     'void(float32[:], bool_[:])',
                     'void(float64[:], bool_[:])'], '(n)->(n)',
                    cache=True, nopython=True)
-def _localmax(x, y):
+def _localmax(x, y):  # pragma: no cover
     '''Vectorized wrapper for the localmax stencil'''
     y[:] = _localmax_sten(x)
 
@@ -991,7 +991,7 @@ def _localmax(x, y):
                     'void(float32[:], bool_[:])',
                     'void(float64[:], bool_[:])'], '(n)->(n)',
                    cache=True, nopython=True)
-def _localmin(x, y):
+def _localmin(x, y):  # pragma: no cover
     '''Vectorized wrapper for the localmin stencil'''
     y[:] = _localmin_sten(x)
 


### PR DESCRIPTION
#### Reference Issue

Fixes #1199 

#### What does this implement/fix? Explain your changes.

This PR rewrites localmax and localmin operations using vectorized numba stencils.  This avoids expensive edge padding and memory copies, and should reduce our memory footprint significantly.

#### Any other comments?

No other API or documentation changes here - if this passes CI it should be good to merge.