### PR TITLE
Refactor AdaptiveWaveplot, disconnection support

### DIFF
--- a/librosa/display.py
+++ b/librosa/display.py
@@ -531,7 +531,6 @@ class AdaptiveWaveplot:
         See Also
         --------
         disconnect
-        matplotlib.axes.callbacks.connect
         """
         # Disconnect any existing callback first
         self.disconnect()

--- a/librosa/display.py
+++ b/librosa/display.py
@@ -162,11 +162,11 @@ class TimeFormatter(Formatter):
             s = "{:d}:{:02d}".format(int(value / 60.0), int(np.mod(value, 60)))
         elif self.unit == "s":
             s = "{:.3g}".format(value)
-        elif self.unit==None and (vmax - vmin >= 1):
+        elif self.unit == None and (vmax - vmin >= 1):
             s = "{:.2g}".format(value)
         elif self.unit == "ms":
             s = "{:.3g}".format(value * 1000)
-        elif self.unit==None and (vmax - vmin < 1):
+        elif self.unit == None and (vmax - vmin < 1):
             s = "{:.3f}".format(value)
 
         return "{:s}{:s}".format(sign, s)
@@ -509,6 +509,44 @@ class AdaptiveWaveplot:
         self.envelope = envelope
         self.sr = sr
         self.max_samples = max_samples
+        self.cid = None
+        self.ax = None
+
+    def connect(self, ax, signal="xlim_changed"):
+        """Connect the adaptor to a signal on an axes object.
+
+        Note that if the adaptor has already been connected to an axes object,
+        that connect is first broken and then replaced by a new callback.
+
+        Parameters
+        ----------
+        ax : matplotlib.axes.Axes
+            The axes to connect this adaptor to
+
+        signal : string, {'xlim_changed', 'ylim_changed'}
+            The signal to connect the update to
+
+        See Also
+        --------
+        disconnect
+        matplotlib.axes.callbacks.connect
+        """
+        # Disconnect any existing callback first
+        if self.ax:
+            self.ax.callbacks.disconnect(self.cid)
+
+        self.ax = ax
+        self.cid = ax.callbacks.connect(signal, self.update)
+
+    def disconnect(self):
+        """Disconnect the adaptor's update callback.
+
+        See Also
+        --------
+        connect
+        """
+        if self.ax:
+            self.ax.callbacks.disconnect(self.cid)
 
     def update(self, ax):
         """Update the matplotlib display according to the current viewport limits.
@@ -517,7 +555,7 @@ class AdaptiveWaveplot:
 
         Parameters
         ----------
-        ax : matplotlib axes object
+        ax : matplotlib.axes.Axes
             The axes object to update
         """
         lims = ax.viewLim
@@ -614,20 +652,53 @@ def __envelope(x, hop):
     return x_frame.max(axis=1)
 
 
-_chroma_ax_types = ('chroma', 'chroma_h', 'chroma_c',)
-_cqt_ax_types = ('cqt_hz', 'cqt_note', 'cqt_svara',)
-_freq_ax_types = ('linear', 'fft', 'hz', 'fft_note', 'fft_svara',)
-_time_ax_types = ('time', 'h', 'm', 's', 'ms',)
-_lag_ax_types = ('lag', 'lag_h', 'lag_m', 'lag_s', 'lag_ms',)
-_misc_ax_types = ('tempo', 'fourier_tempo', 'mel', 'log', 'tonnetz', 'frames',)
+_chroma_ax_types = (
+    "chroma",
+    "chroma_h",
+    "chroma_c",
+)
+_cqt_ax_types = (
+    "cqt_hz",
+    "cqt_note",
+    "cqt_svara",
+)
+_freq_ax_types = (
+    "linear",
+    "fft",
+    "hz",
+    "fft_note",
+    "fft_svara",
+)
+_time_ax_types = (
+    "time",
+    "h",
+    "m",
+    "s",
+    "ms",
+)
+_lag_ax_types = (
+    "lag",
+    "lag_h",
+    "lag_m",
+    "lag_s",
+    "lag_ms",
+)
+_misc_ax_types = (
+    "tempo",
+    "fourier_tempo",
+    "mel",
+    "log",
+    "tonnetz",
+    "frames",
+)
 
 _AXIS_COMPAT = set(
-    [(t, t) for t in _misc_ax_types] +
-    [t for t in product(_chroma_ax_types, _chroma_ax_types)] +
-    [t for t in product(_cqt_ax_types, _cqt_ax_types)] +
-    [t for t in product(_freq_ax_types, _freq_ax_types)] +
-    [t for t in product(_time_ax_types, _time_ax_types)] +
-    [t for t in product(_lag_ax_types, _lag_ax_types)]
+    [(t, t) for t in _misc_ax_types]
+    + [t for t in product(_chroma_ax_types, _chroma_ax_types)]
+    + [t for t in product(_cqt_ax_types, _cqt_ax_types)]
+    + [t for t in product(_freq_ax_types, _freq_ax_types)]
+    + [t for t in product(_time_ax_types, _time_ax_types)]
+    + [t for t in product(_lag_ax_types, _lag_ax_types)]
 )
 
 
@@ -1050,8 +1121,7 @@ def __decorate_axis(
     axis, ax_type, key="C:maj", Sa=None, mela=None, thaat=None, unicode=True
 ):
     """Configure axis tickers, locators, and labels"""
-    time_units = {
-        "h": "hours", "m": "minutes", "s": "seconds", "ms": "milliseconds"}
+    time_units = {"h": "hours", "m": "minutes", "s": "seconds", "ms": "milliseconds"}
 
     if ax_type == "tonnetz":
         axis.set_major_formatter(TonnetzFormatter())
@@ -1502,7 +1572,7 @@ def waveshow(
         times, y[0], steps, envelope, sr=sr, max_samples=max_points
     )
 
-    axes.callbacks.connect("xlim_changed", adaptor.update)
+    adaptor.connect(axes, signal="xlim_changed")
 
     # Force an initial update to ensure the state is consistent
     adaptor.update(axes)

--- a/librosa/display.py
+++ b/librosa/display.py
@@ -512,6 +512,9 @@ class AdaptiveWaveplot:
         self.cid = None
         self.ax = None
 
+    def __del__(self):
+        self.disconnect(strict=True)
+
     def connect(self, ax, signal="xlim_changed"):
         """Connect the adaptor to a signal on an axes object.
 
@@ -521,10 +524,9 @@ class AdaptiveWaveplot:
         Parameters
         ----------
         ax : matplotlib.axes.Axes
-            The axes to connect this adaptor to
-
-        signal : string, {'xlim_changed', 'ylim_changed'}
-            The signal to connect the update to
+            The axes to connect with this adaptor's `update`
+        signal : string, {"xlim_changed", "ylim_changed"}
+            The signal to connect
 
         See Also
         --------
@@ -532,14 +534,21 @@ class AdaptiveWaveplot:
         matplotlib.axes.callbacks.connect
         """
         # Disconnect any existing callback first
-        if self.ax:
-            self.ax.callbacks.disconnect(self.cid)
+        self.disconnect()
 
+        # Attach to axes and store the connection id
         self.ax = ax
         self.cid = ax.callbacks.connect(signal, self.update)
 
-    def disconnect(self):
+    def disconnect(self, strict=False):
         """Disconnect the adaptor's update callback.
+
+        Parameters
+        ----------
+        strict : bool
+            If `True`, remove references to the connected axes.
+
+            If `False` (default), only disconnect the callback.
 
         See Also
         --------
@@ -547,6 +556,9 @@ class AdaptiveWaveplot:
         """
         if self.ax:
             self.ax.callbacks.disconnect(self.cid)
+            self.cid = None
+            if strict:
+                self.ax = None
 
     def update(self, ax):
         """Update the matplotlib display according to the current viewport limits.

--- a/librosa/display.py
+++ b/librosa/display.py
@@ -515,7 +515,7 @@ class AdaptiveWaveplot:
     def __del__(self):
         self.disconnect(strict=True)
 
-    def connect(self, ax, signal="xlim_changed"):
+    def connect(self, ax, *, signal="xlim_changed"):
         """Connect the adaptor to a signal on an axes object.
 
         Note that if the adaptor has already been connected to an axes object,
@@ -540,7 +540,7 @@ class AdaptiveWaveplot:
         self.ax = ax
         self.cid = ax.callbacks.connect(signal, self.update)
 
-    def disconnect(self, strict=False):
+    def disconnect(self, *, strict=False):
         """Disconnect the adaptor's update callback.
 
         Parameters

--- a/librosa/display.py
+++ b/librosa/display.py
@@ -546,8 +546,10 @@ class AdaptiveWaveplot:
         ----------
         strict : bool
             If `True`, remove references to the connected axes.
-
             If `False` (default), only disconnect the callback.
+
+            This functionality is intended primarily for internal use,
+            and should have no observable effects for users.
 
         See Also
         --------

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -950,3 +950,58 @@ def test_specshow_unicode_false(C, sr):
         axi.label_outer()
 
     return fig
+
+
+def test_waveshow_disconnect(y, sr):
+    fig, ax = plt.subplots()
+    ad = librosa.display.waveshow(y=y, sr=sr, ax=ax)
+
+    # By default, envelope should be visible and steps should not
+    assert ad.envelope.get_visible() and not ad.steps.get_visible()
+
+    # Zoom in to a 0.25 second range
+    ax.set(xlim=[0, 0.25])
+
+    # Steps should be visible but not envelope
+    assert ad.steps.get_visible() and not ad.envelope.get_visible()
+
+    # Zoom back out
+    ax.set(xlim=[0, 4])
+    assert ad.envelope.get_visible() and not ad.steps.get_visible()
+
+    # Disconnect
+    ad.disconnect()
+
+    # Zoom back in to a 0.25 second range
+    ax.set(xlim=[0, 0.25])
+
+    # Envelope should now still be visible
+    assert ad.envelope.get_visible() and not ad.steps.get_visible()
+
+
+def test_waveshow_deladaptor(y, sr):
+    fig, ax = plt.subplots()
+    ad = librosa.display.waveshow(y=y, sr=sr, ax=ax)
+
+    envelope, steps = ad.envelope, ad.steps
+    # By default, envelope should be visible and steps should not
+    assert envelope.get_visible() and not steps.get_visible()
+
+    # Zoom in to a 0.25 second range
+    ax.set(xlim=[0, 0.25])
+
+    # Steps should be visible but not envelope
+    assert steps.get_visible() and not envelope.get_visible()
+
+    # Zoom back out
+    ax.set(xlim=[0, 4])
+    assert envelope.get_visible() and not steps.get_visible()
+
+    # Disconnect
+    del ad
+
+    # Zoom back in to a 0.25 second range
+    ax.set(xlim=[0, 0.25])
+
+    # Envelope should now still be visible
+    assert envelope.get_visible() and not steps.get_visible()


### PR DESCRIPTION
#### Reference Issue
Fixes #1532 


#### What does this implement/fix? Explain your changes.

This PR refactors the `AdaptiveWaveplot` object a bit to make connection and disconnection from callbacks easier.  This doesn't "automatically" resolve #1532, but it does make things a bit cleaner.

You can now do the following to disable the adaptivity:
```python
adaptor = librosa.display.waveshow(...)

adaptor.disconnect()
```

And if you want to release memory and references, you can do:
```python
adaptor = librosa.display.waveshow(...)
del adaptor
```

This also allows adaptor objects to be reconnected to different axes objects and signals.

A deconstructor method is added to facilitate clean disconnection.


#### Any other comments?

The functionality is all here now, though I'm not sure what kind of documentation would be appropriate to explain things in a way that would avoid #1532.  Any feedback from @youssefabdelm would be appreciated.