### PR TITLE
Fixes the PR reference number in the Changelog

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,7 +19,7 @@ Documentation
     - `#1469`_ Corrected documentation for `db_to_amplitude` and `amplitude_to_db`. *i-aki-y*
     - `#1473`_ Readability improvements to package README. *Asmitha Krishnakumar*
     - `#1475`_ Expanded documentation to `librosa.sequence.viterbi_discriminative`. *Brian McFee*
-    - `#1487`_ Readability improvements to package README. *Chandrashekhar Ramaprasad*
+    - `#1479`_ Readability improvements to package README. *Chandrashekhar Ramaprasad*
     - `#1491`_ Pinned sphinx version for documentation builds. *Brian McFee*
     - `#1511`_ Expanded documentation for `find_files`. *Xiao-Ming*
     - `#1513`_ Various documentation updates and enhancements. *Brian McFee*


### PR DESCRIPTION
The PR number in the change log for my PR was the wrong one.
The earlier one was 1487 (by @LorenzNickel )

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/main/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue

<!-- Example: Fixes #123 -->


#### What does this implement/fix? Explain your changes.
This PR fixes the PR number mentioned in the changelog.
As I was reading the changelog for the [latest release](https://librosa.org/doc/0.9.2/changelog.html), I noticed that the PR reference number for my changes was the wrong one, and directed to a different PR.

This PR fixes that minor error, although it could be present in other releases too.

#### Any other comments?
This issue could be present in other releases/PR's listed too
