### PR TITLE
Fixes docstring for 'note_to_midi' function in librosa/core/convert.py

### DIFF
--- a/librosa/core/convert.py
+++ b/librosa/core/convert.py
@@ -475,8 +475,8 @@ def note_to_midi(note, *, round_midi=True):
     note : str or iterable of str
         One or more note names.
     round_midi : bool
-        - If ``True``, allow for fractional midi notes
-        - Otherwise, round cent deviations to the nearest note
+        - If ``True``, midi numbers are rounded to the nearest integer.
+        - IF ``False``, allow fractional midi numbers.
 
     Returns
     -------

--- a/librosa/core/convert.py
+++ b/librosa/core/convert.py
@@ -476,7 +476,7 @@ def note_to_midi(note, *, round_midi=True):
         One or more note names.
     round_midi : bool
         - If ``True``, midi numbers are rounded to the nearest integer.
-        - IF ``False``, allow fractional midi numbers.
+        - If ``False``, allow fractional midi numbers.
 
     Returns
     -------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/main/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
<!-- Example: Fixes #123 -->
Fixes #1544

#### What does this implement/fix? Explain your changes.
Changes the docstring for the `note_to_midi` function in core/convert.py

