### PR TITLE
removed hanning from tests, fixes #1547

### DIFF
--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -226,7 +226,6 @@ def test_chroma_issue1295(freq):
         "flattop",
         "hamming",
         "hann",
-        "hanning",
         "nuttall",
         "parzen",
         "triang",


### PR DESCRIPTION
#### Reference Issue
Fixes #1547 


#### What does this implement/fix? Explain your changes.

This PR just removes `hanning` from the filter test suite to keep things passing on scipy 1.9.0.  Support is retained in the library for now.


