### PR TITLE
Drop use of contextlib2

### DIFF
--- a/.github/environment-ci.yml
+++ b/.github/environment-ci.yml
@@ -22,7 +22,6 @@ dependencies:
   - pytest-mpl
   - pytest-cov
   - pytest
-  - contextlib2
   - coverage
   - ffmpeg
   - pip:

--- a/.github/environment-minimal.yml
+++ b/.github/environment-minimal.yml
@@ -22,7 +22,6 @@ dependencies:
   - pytest-mpl
   - pytest-cov
   - pytest
-  - contextlib2
   - coverage
   - ffmpeg
   - tomli<2.0

--- a/librosa/version.py
+++ b/librosa/version.py
@@ -57,7 +57,6 @@ def show_versions():
         "matplotlib",
         "samplerate",
         "soxr",
-        "contextlib2",
         "presets",
     ]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,7 +77,6 @@ tests =
     pytest-mpl
     pytest-cov
     pytest
-    contextlib2
     samplerate
     soxr
 display =

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -2,8 +2,6 @@
 # CREATED:2013-03-11 18:14:30 by Brian McFee <brm2132@columbia.edu>
 #  unit tests for librosa.beat
 
-from __future__ import print_function
-
 # Disable cache
 import os
 
@@ -13,7 +11,7 @@ except:
     pass
 
 import pytest
-from contextlib2 import nullcontext as dnr
+from contextlib import nullcontext as dnr
 
 import numpy as np
 import scipy.stats

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -11,7 +11,7 @@ try:
 except KeyError:
     pass
 
-from contextlib2 import nullcontext as dnr
+from contextlib import nullcontext as dnr
 import numpy as np
 import pytest
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -19,7 +19,7 @@ try:
 except KeyError:
     pass
 
-from contextlib2 import nullcontext as dnr
+from contextlib import nullcontext as dnr
 import glob
 import numpy as np
 import scipy.io

--- a/tests/test_multichannel.py
+++ b/tests/test_multichannel.py
@@ -3,8 +3,6 @@
 #  unit tests for multi-channel functionality
 #
 
-from __future__ import print_function
-
 # Disable cache
 import os
 
@@ -21,7 +19,7 @@ import pytest
 import warnings
 from unittest import mock
 
-from contextlib2 import nullcontext as dnr
+from contextlib import nullcontext as dnr
 from test_core import srand
 
 

--- a/tests/test_onset.py
+++ b/tests/test_onset.py
@@ -2,9 +2,8 @@
 # CREATED:2013-03-11 18:14:30 by Brian McFee <brm2132@columbia.edu>
 #  unit tests for librosa.onset
 
-from __future__ import print_function
 import pytest
-from contextlib2 import nullcontext as dnr
+from contextlib import nullcontext as dnr
 
 # Disable cache
 import os


### PR DESCRIPTION
As of Python 3.7, contextlib in the standard library now supports all
functionality that this library requires. As a consequence, remove the
external requirement, and switch to it. Drive by removing some now
unneeded __future__ imports.

Please note: This may fail CI for Python 3.6, but 3.6 has been EOL now for eight months.