### PR TITLE
use rfft when appropriate in autocorrelate, fixes #1526

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -966,7 +966,7 @@ def test_get_duration_fail():
 
 @pytest.mark.parametrize(
     "y",
-    [np.random.randn(256, 256), np.exp(1.0j * np.random.randn(256, 256))],
+    [np.random.randn(256, 384), np.exp(1.0j * np.random.randn(256, 384))],
     ids=["real", "complex"],
 )
 @pytest.mark.parametrize("axis", [0, 1, -1])


### PR DESCRIPTION
#### Reference Issue
Fixes #1526 


#### What does this implement/fix? Explain your changes.

This PR rewrites autocorrelate to use (i)rfft when provided with real-valued inputs.  This should cut the memory usage approximately in half.

#### Any other comments?

This PR is definitely an improvement, but I'm not 100% satisfied yet as noted in the discussion thread of #1526.  We still are computing a full inverse DFT and then cropping the result, rather than only computing what is actually needed.  Perhaps this is the best we can do, given how the fft API is defined.