### PR TITLE
Changing default resampler

### DIFF
--- a/.github/environment-ci.yml
+++ b/.github/environment-ci.yml
@@ -16,6 +16,7 @@ dependencies:
   - pysoundfile>=0.10.2
   - pooch>=1.0
   - packaging>=20.0
+  - soxr-python>=0.3.0
 
   # optional, but required for testing
   - matplotlib>=3.3.0
@@ -26,5 +27,4 @@ dependencies:
   - coverage
   - ffmpeg
   - pip:
-    - soxr
     - samplerate

--- a/.github/environment-docs.yml
+++ b/.github/environment-docs.yml
@@ -12,6 +12,7 @@ dependencies:
   - joblib>=0.14.0
   - decorator>=4.0.10
   - resampy>=0.2.2
+  - soxr-python>=0.3.0
   - numba<0.50
   - numpydoc>=1.1.0
   - ipython>=7.0

--- a/.github/environment-minimal.yml
+++ b/.github/environment-minimal.yml
@@ -11,11 +11,11 @@ dependencies:
   - scikit-learn==0.19.1
   - joblib==0.14.0
   - decorator==4.0.10
-  - resampy==0.2.2
   - numba==0.45.1
   - pysoundfile==0.10.2
   - pooch==1.0.0
   - packaging==20.0
+  - soxr-python==0.3.2b1
 
   # optional, but required for testing
   - matplotlib==3.3.0
@@ -26,9 +26,9 @@ dependencies:
   - coverage
   - ffmpeg
   - tomli<2.0
+  - resampy==0.2.2
 
   # For python 3.6 we limit this dependency
   - typing-extensions<4.2
   - pip:
-    - soxr
     - samplerate

--- a/.github/environment-minimal.yml
+++ b/.github/environment-minimal.yml
@@ -15,7 +15,6 @@ dependencies:
   - pysoundfile==0.10.2
   - pooch==1.0.0
   - packaging==20.0
-  - soxr-python==0.3.2b1
 
   # optional, but required for testing
   - matplotlib==3.3.0
@@ -31,4 +30,5 @@ dependencies:
   # For python 3.6 we limit this dependency
   - typing-extensions<4.2
   - pip:
+    - soxr>=0.3.0
     - samplerate

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -950,7 +950,9 @@ def vqt(
 
     if res_type is None:
         warnings.warn("Support for VQT with res_type=None is deprecated in librosa 0.10\n"
-                      "and will be removed in version 1.0.")
+                      "and will be removed in version 1.0.",
+                      category=DeprecationWarning,
+                      stacklevel=2)
         res_type = "soxr_hq"
 
     y, sr, hop_length = __early_downsample(

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -36,7 +36,7 @@ def cqt(
     window="hann",
     scale=True,
     pad_mode="constant",
-    res_type=None,
+    res_type="soxr_hq",
     dtype=None,
 ):
     """Compute the constant-Q transform of an audio signal.
@@ -209,7 +209,7 @@ def hybrid_cqt(
     window="hann",
     scale=True,
     pad_mode="constant",
-    res_type=None,
+    res_type="soxr_hq",
     dtype=None,
 ):
     """Compute the hybrid constant-Q transform of an audio signal.
@@ -547,7 +547,7 @@ def icqt(
     window="hann",
     scale=True,
     length=None,
-    res_type="fft",
+    res_type="soxr_hq",
     dtype=None,
 ):
     """Compute the inverse constant-Q transform.
@@ -608,8 +608,7 @@ def icqt(
         ``length`` samples.
 
     res_type : string
-        Resampling mode.  By default, this uses ``'fft'`` mode for high-quality
-        reconstruction, but this may be slow depending on your signal duration.
+        Resampling mode.
         See `librosa.resample` for supported modes.
 
     dtype : numeric type
@@ -773,7 +772,7 @@ def vqt(
     window="hann",
     scale=True,
     pad_mode="constant",
-    res_type=None,
+    res_type="soxr_hq",
     dtype=None,
 ):
     """Compute the variable-Q transform of an audio signal.
@@ -870,14 +869,6 @@ def vqt(
     res_type : string [optional]
         The resampling mode for recursive downsampling.
 
-        By default, `vqt` will adaptively select a resampling mode
-        which trades off accuracy at high frequencies for efficiency at low frequencies.
-
-        You can override this by specifying a resampling mode as supported by
-        `librosa.resample`.  For example, ``res_type='fft'`` will use a high-quality,
-        but potentially slow FFT-based down-sampling, while ``res_type='polyphase'`` will
-        use a fast, but potentially inaccurate down-sampling.
-
     dtype : np.dtype
         The dtype of the output array.  By default, this is inferred to match the
         numerical precision of the input signal.
@@ -957,13 +948,10 @@ def vqt(
             "Try reducing the number of frequency bins."
         )
 
-    auto_resample = False
-    if not res_type:
-        auto_resample = True
-        if filter_cutoff < audio.BW_FASTEST * nyquist:
-            res_type = "kaiser_fast"
-        else:
-            res_type = "kaiser_best"
+    if res_type is None:
+        warnings.warn("Support for VQT with res_type=None is deprecated in librosa 0.10\n"
+                      "and will be removed in version 1.0.")
+        res_type = "soxr_hq"
 
     y, sr, hop_length = __early_downsample(
         y, sr, hop_length, res_type, n_octaves, nyquist, filter_cutoff, scale
@@ -971,38 +959,10 @@ def vqt(
 
     vqt_resp = []
 
-    # Skip this block for now
-    oct_start = 0
-    if auto_resample and res_type != "kaiser_fast":
-
-        # Do the top octave before resampling to allow for fast resampling
-        freqs_top = freqs[-n_filters:]
-
-        fft_basis, n_fft, _ = __vqt_filter_fft(
-            sr,
-            freqs_top,
-            filter_scale,
-            norm,
-            sparsity,
-            window=window,
-            gamma=gamma,
-            dtype=dtype,
-            alpha=alpha,
-        )
-
-        # Compute the VQT filter response and append it to the stack
-        vqt_resp.append(
-            __cqt_response(y, n_fft, hop_length, fft_basis, pad_mode, dtype=dtype)
-        )
-
-        oct_start = 1
-
-        res_type = "kaiser_fast"
-
     # Iterate down the octaves
     my_y, my_sr, my_hop = y, sr, hop_length
 
-    for i in range(oct_start, n_octaves):
+    for i in range(n_octaves):
 
         # Slice out the current octave of filters
         if i == 0:
@@ -1167,7 +1127,7 @@ def __early_downsample_count(nyquist, filter_cutoff, hop_length, n_octaves):
     """Compute the number of early downsampling operations"""
 
     downsample_count1 = max(
-        0, int(np.ceil(np.log2(audio.BW_FASTEST * nyquist / filter_cutoff)) - 1) - 1
+        0, int(np.ceil(np.log2(0.95 * nyquist / filter_cutoff)) - 1) - 1
     )
 
     num_twos = __num_two_factors(hop_length)
@@ -1185,7 +1145,7 @@ def __early_downsample(
         nyquist, filter_cutoff, hop_length, n_octaves
     )
 
-    if downsample_count > 0 and res_type == "kaiser_fast":
+    if downsample_count > 0 and res_type != 'polyphase':
         downsample_factor = 2 ** (downsample_count)
 
         hop_length //= downsample_factor
@@ -1242,7 +1202,7 @@ def griffinlim_cqt(
     window="hann",
     scale=True,
     pad_mode="constant",
-    res_type="kaiser_fast",
+    res_type="soxr_hq",
     dtype=None,
     length=None,
     momentum=0.99,

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -106,16 +106,8 @@ def cqt(
 
         See also: `librosa.stft` and `numpy.pad`.
 
-    res_type : string [optional]
+    res_type : string
         The resampling mode for recursive downsampling.
-
-        By default, `cqt` will adaptively select a resampling mode
-        which trades off accuracy at high frequencies for efficiency at low frequencies.
-
-        You can override this by specifying a resampling mode as supported by
-        `librosa.resample`.  For example, ``res_type='fft'`` will use a high-quality,
-        but potentially slow FFT-based down-sampling, while ``res_type='polyphase'`` will
-        use a fast, but potentially inaccurate down-sampling.
 
     dtype : np.dtype
         The (complex) data type of the output array.  By default, this is inferred to match
@@ -866,7 +858,7 @@ def vqt(
 
         See also: `librosa.stft` and `numpy.pad`.
 
-    res_type : string [optional]
+    res_type : string
         The resampling mode for recursive downsampling.
 
     dtype : np.dtype
@@ -1129,7 +1121,7 @@ def __early_downsample_count(nyquist, filter_cutoff, hop_length, n_octaves):
     """Compute the number of early downsampling operations"""
 
     downsample_count1 = max(
-        0, int(np.ceil(np.log2(0.95 * nyquist / filter_cutoff)) - 1) - 1
+        0, int(np.ceil(np.log2(nyquist / filter_cutoff)) - 1) - 1
     )
 
     num_twos = __num_two_factors(hop_length)
@@ -1147,7 +1139,7 @@ def __early_downsample(
         nyquist, filter_cutoff, hop_length, n_octaves
     )
 
-    if downsample_count > 0 and res_type != 'polyphase':
+    if downsample_count > 0:
         downsample_factor = 2 ** (downsample_count)
 
         hop_length //= downsample_factor
@@ -1160,7 +1152,7 @@ def __early_downsample(
 
         new_sr = sr / float(downsample_factor)
         y = audio.resample(
-            y, orig_sr=sr, target_sr=new_sr, res_type=res_type, scale=True
+            y, orig_sr=downsample_factor, target_sr=1, res_type=res_type, scale=True
         )
 
         # If we're not going to length-scale after CQT, we
@@ -1287,12 +1279,6 @@ def griffinlim_cqt(
 
     res_type : string
         The resampling mode for recursive downsampling.
-
-        By default, CQT uses an adaptive mode selection to
-        trade accuracy at high frequencies for efficiency at low
-        frequencies.
-
-        Griffin-Lim uses the efficient (fast) resampling mode by default.
 
         See ``librosa.resample`` for a list of available options.
 

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1467,7 +1467,7 @@ def iirt(
     tuning=0.0,
     pad_mode="constant",
     flayout="sos",
-    res_type="kaiser_best",
+    res_type="soxr_hq",
     **kwargs,
 ):
     r"""Time-frequency representation using IIR filters

--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -256,7 +256,7 @@ def time_stretch(y, *, rate, **kwargs):
 
 
 def pitch_shift(
-    y, *, sr, n_steps, bins_per_octave=12, res_type="kaiser_best", **kwargs
+    y, *, sr, n_steps, bins_per_octave=12, res_type="soxr_hq", **kwargs
 ):
     """Shift the pitch of a waveform by ``n_steps`` steps.
 
@@ -277,7 +277,7 @@ def pitch_shift(
         how many steps per octave
 
     res_type : string
-        Resample type. By default, 'kaiser_best' is used.
+        Resample type. By default, 'soxr_hq' is used.
 
         See `librosa.resample` for more information.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,11 +49,11 @@ install_requires =
     scikit-learn >= 0.19.1
     joblib >= 0.14
     decorator >= 4.0.10
-    resampy >= 0.2.2
     numba >= 0.45.1
     soundfile >= 0.10.2
     pooch >= 1.0
     packaging >= 20.0
+    soxr >= 0.3.0
 python_requires = >=3.6
 
 [options.package_data]
@@ -79,6 +79,6 @@ tests =
     pytest
     contextlib2
     samplerate
-    soxr
+    resampy >= 0.2.2
 display =
     matplotlib >= 3.3.0

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -524,7 +524,7 @@ def y_icqt(sr_icqt):
 @pytest.mark.parametrize("scale", [False, True])
 @pytest.mark.parametrize("hop_length", [384, 512])
 @pytest.mark.parametrize("length", [None, True])
-@pytest.mark.parametrize("res_type", ["scipy", "kaiser_fast", "polyphase"])
+@pytest.mark.parametrize("res_type", ["soxr_hq", "polyphase"])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_icqt(y_icqt, sr_icqt, scale, hop_length, over_sample, length, res_type, dtype):
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -84,7 +84,7 @@ def test_load_audioread():
     assert np.isclose(sr, sr2)
 
 
-@pytest.mark.parametrize("res_type", ["kaiser_fast", "kaiser_best", "scipy"])
+@pytest.mark.parametrize("res_type", ["soxr_qq", "soxr_hq", "scipy"])
 def test_load_resample(res_type):
 
     sr_target = 16000


### PR DESCRIPTION
#### Reference Issue
Fixes #1556
Fixes #1558 


#### What does this implement/fix? Explain your changes.

This PR changes the default resampling engine throughout the package to use `soxr_hq` rather than resampy.

Accordingly, resampy has been relegated to an optional dependency, and soxr has been promoted to a core dependency.  Package requirements and testing environments have been updated accordingly.



#### Any other comments?

The adaptive resampling behavior of VQT has also been "simplified", though I'm not yet sure how we should proceed here.

The code has been simplified by removing the special case code block for the top octave filter.  We now only do a single early downsampling operation before processing, and handle all octaves with the same code.  This simplifies the implementation a bit.  

For reference, "early downsampling" here is the idea of an up-front downsampling operation so that Nyquist is within an octave of the highest frequency.  This is essentially an efficiency hack to avoid wasting computation.

The tricky part here is that early downsampling was only ever active when the resampling mode was `kaiser_fast`.  In principle, this logic could be applied to any resampler that supports fractional rates (ie, anything but polyphase).

Alternatively, we could simply remove the early downsampling logic entirely.  There are cases where it's essentially a no-op (eg when hop-length is odd), and eliminating it entirely would get us out of having a magic number for the roll-off of the resampling filter.

---

One last comment: this PR will deprecate the option of supplying `res_type=None` to select adaptive resampling mode.  We'll remove this shim in the 1.0 series.