### PR TITLE
off-by-one error in STFT frame padding

### DIFF
--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -277,7 +277,7 @@ def stft(
             padding[-1] = (n_fft // 2, 0)
 
             y_pre = np.pad(
-                y[..., : (start_k - 1) * hop_length - n_fft // 2 + n_fft],
+                y[..., : (start_k - 1) * hop_length - n_fft // 2 + n_fft + 1],
                 padding,
                 mode=pad_mode,
             )

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -282,6 +282,8 @@ def stft(
                 mode=pad_mode,
             )
             y_frames_pre = util.frame(y_pre, frame_length=n_fft, hop_length=hop_length)
+            # Trim this down to the exact number of frames we should have
+            y_frames_pre = y_frames_pre[..., :start_k]
 
             # How many extra frames do we have from the head?
             extra = y_frames_pre.shape[-1]

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -276,6 +276,8 @@ def stft(
             start = start_k * hop_length - n_fft // 2
             padding[-1] = (n_fft // 2, 0)
 
+            # +1 here is to ensure enough samples to fill the window
+            # fixes bug #1567
             y_pre = np.pad(
                 y[..., : (start_k - 1) * hop_length - n_fft // 2 + n_fft + 1],
                 padding,


### PR DESCRIPTION
#### Reference Issue
fixes #1567 


#### What does this implement/fix? Explain your changes.

This PR fixes a subtle off-by-one error in the head slice of the new STFT framing implemented in #1514.  This bug would only affect people using A) strictly positive windows, and B) non-zero padding (eg reflection).

#### Any other comments?

STFT results are now confirmed to be numerically identical to the 0.9.2 series.