### PR TITLE
forced floating point sampling rates in multirate filterbank

### DIFF
--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -1357,15 +1357,15 @@ def mr_frequencies(tuning):
     sample_rates = np.asarray(
         len(np.arange(0, 36))
         * [
-            882,
+            882.0,
         ]
         + len(np.arange(36, 70))
         * [
-            4410,
+            4410.0,
         ]
         + len(np.arange(70, 85))
         * [
-            22050,
+            22050.0,
         ]
     )
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1865,15 +1865,15 @@ def test_iirt_peaks():
     sample_rates = np.asarray(
         len(np.arange(40, 46))
         * [
-            1000,
+            1000.0,
         ]
         + len(np.arange(46, 80))
         * [
-            1750,
+            1750.0,
         ]
         + len(np.arange(80, 95))
         * [
-            4000,
+            4000.0,
         ]
     )
 


### PR DESCRIPTION
#### Reference Issue
Fixes #1569 


#### What does this implement/fix? Explain your changes.
This PR ensures that sampling rates used in IIRT are floating point-valued, rather than integer valued.  This should avoid the numerical overflow bug that popped up on windows.

#### Any other comments?

A related PR is ongoing for resampy https://github.com/bmcfee/resampy/pull/115 and the 0.4.2 release there will be quasi-redundant to this PR.