### PR TITLE
updated tests for numpy 1.23 compatibility

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2122,6 +2122,8 @@ def test_pcen_stream_multi(axis):
     slice2 = [slice(None)] * x.ndim
     slice2[axis] = slice(10, None)
 
+    slice1 = tuple(slice1)
+    slice2 = tuple(slice2)
     # Compute pcen piecewise
     p1, zf1 = librosa.pcen(x[slice1], return_zf=True, axis=axis)
     p2, zf2 = librosa.pcen(x[slice2], zi=zf1, return_zf=True, axis=axis)

--- a/tests/test_multichannel.py
+++ b/tests/test_multichannel.py
@@ -65,13 +65,13 @@ def test_sync_multi(aggregate, ndim, axis):
     idx = [slice(None)] * ndim
     idx[axis] = 0
     if aggregate is np.sum:
-        assert np.allclose(dsync[idx], 2)
+        assert np.allclose(dsync[tuple(idx)], 2)
     else:
-        assert np.allclose(dsync[idx], 1)
+        assert np.allclose(dsync[tuple(idx)], 1)
 
     # The second slice will sum to 1 and have mean 1
     idx[axis] = 1
-    assert np.allclose(dsync[idx], 1)
+    assert np.allclose(dsync[tuple(idx)], 1)
 
 
 def test_stft_multi(y_multi):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -877,13 +877,13 @@ def test_sync(aggregate, ndim, axis):
     idx = [slice(None)] * ndim
     idx[axis] = 0
     if aggregate is np.sum:
-        assert np.allclose(dsync[idx], 2)
+        assert np.allclose(dsync[tuple(idx)], 2)
     else:
-        assert np.allclose(dsync[idx], 1)
+        assert np.allclose(dsync[tuple(idx)], 1)
 
     # The second slice will sum to 1 and have mean 1
     idx[axis] = 1
-    assert np.allclose(dsync[idx], 1)
+    assert np.allclose(dsync[tuple(idx)], 1)
 
 
 @pytest.mark.parametrize("aggregate", [np.mean, np.max])


### PR DESCRIPTION
#### Reference Issue
Fixes #1580 


#### What does this implement/fix? Explain your changes.
This PR updates a few of our tests for compatibility with numpy 1.23.

#### Any other comments?

Our CI is not yet running on numpy 1.23, but I have tested this on a local environment and everything now passes.  I'm happy to merge this PR for now and revisit when our CI environments update.