### PR TITLE
updated CI environments, fixes #1589

### DIFF
--- a/.github/environment-ci.yml
+++ b/.github/environment-ci.yml
@@ -16,6 +16,7 @@ dependencies:
   - pooch>=1.0
   - packaging>=20.0
   - soxr-python>=0.3.2
+  - lazy_loader>=0.1
 
   # optional, but required for testing
   - matplotlib>=3.3.0

--- a/.github/environment-docs.yml
+++ b/.github/environment-docs.yml
@@ -23,6 +23,7 @@ dependencies:
   - sphinx>=5.1.0
   - sphinx-gallery>=0.10.1
   - sphinx_rtd_theme>=1.0.0
+  - lazy_loader>=0.1
   - ffmpeg
   - pip:
     - sphinx-multiversion==0.2.4

--- a/.github/environment-minimal.yml
+++ b/.github/environment-minimal.yml
@@ -16,6 +16,7 @@ dependencies:
   - pooch==1.0.0
   - packaging==20.0
   - soxr-python==0.3.2
+  - lazy_loader==0.1
 
   # optional, but required for testing
   - matplotlib==3.3.0


### PR DESCRIPTION
#### Reference Issue
Fixes #1589 


#### What does this implement/fix? Explain your changes.

This PR modifies the CI environments to install `lazy_loader` from conda-forge instead of indirectly via pypi.

#### Any other comments?

No changes to the code - should be good to merge once CI passes.