### PR TITLE
Replace numpy deprecated types with python types.

### DIFF
--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -2214,7 +2214,7 @@ def dtype_c2r(d, *, default=np.float32):
     mapping = {
         np.dtype(np.complex64): np.float32,
         np.dtype(np.complex128): np.float64,
-        np.dtype(complex): np.dtype(np.float).type,
+        complex: float,
     }
 
     # If we're given a real type already, return it

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -2214,7 +2214,7 @@ def dtype_c2r(d, *, default=np.float32):
     mapping = {
         np.dtype(np.complex64): np.float32,
         np.dtype(np.complex128): np.float64,
-        complex: float,
+        np.dtype(complex): np.dtype(float).type,
     }
 
     # If we're given a real type already, return it

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1258,6 +1258,7 @@ def test_dtype_r2c(dtype, target):
         (np.complex64, np.float32),
         (np.int32, np.float32),
         (np.complex128, np.float64),
+        (complex, float)
     ],
 )
 def test_dtype_c2r(dtype, target):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1258,7 +1258,8 @@ def test_dtype_r2c(dtype, target):
         (np.complex64, np.float32),
         (np.int32, np.float32),
         (np.complex128, np.float64),
-        (complex, float)
+        (complex, float),
+        (np.dtype(complex), np.float64)
     ],
 )
 def test_dtype_c2r(dtype, target):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/main/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
Complete fixing of issue #1350


#### What does this implement/fix? Explain your changes.
Replaces deprecated np types complex and float with the equivalent Python types

#### Any other comments?

