### PR TITLE
harmonic interpolation for scipy 1.9.3

### DIFF
--- a/tests/test_multichannel.py
+++ b/tests/test_multichannel.py
@@ -756,10 +756,9 @@ def test_interp_harmonics_multi_static(s_multi):
 def test_interp_harmonics_multi_vary(tfr_multi):
     times, freqs, mags = tfr_multi
 
-    # Force slinear mode here to deal with non-unique frequencies
-    Hall = librosa.interp_harmonics(mags, freqs=freqs, harmonics=[0.5, 1, 2], kind="slinear")
-    H0 = librosa.interp_harmonics(mags[0], freqs=freqs[0], harmonics=[0.5, 1, 2], kind="slinear")
-    H1 = librosa.interp_harmonics(mags[1], freqs=freqs[1], harmonics=[0.5, 1, 2], kind="slinear")
+    Hall = librosa.interp_harmonics(mags, freqs=freqs, harmonics=[0.5, 1, 2], kind="nearest")
+    H0 = librosa.interp_harmonics(mags[0], freqs=freqs[0], harmonics=[0.5, 1, 2], kind="nearest")
+    H1 = librosa.interp_harmonics(mags[1], freqs=freqs[1], harmonics=[0.5, 1, 2], kind="nearest")
 
     assert np.allclose(Hall[0], H0)
     assert np.allclose(Hall[1], H1)
@@ -811,7 +810,7 @@ def test_salience_multi_dynamic(tfr_multi, filter_peaks):
         S,
         freqs=freqs,
         harmonics=[0.5, 1, 2, 3],
-        kind="slinear",
+        kind="nearest",
         filter_peaks=filter_peaks,
         fill_value=0,
     )
@@ -819,7 +818,7 @@ def test_salience_multi_dynamic(tfr_multi, filter_peaks):
         S[0],
         freqs=freqs[0],
         harmonics=[0.5, 1, 2, 3],
-        kind="slinear",
+        kind="nearest",
         filter_peaks=filter_peaks,
         fill_value=0,
     )
@@ -827,7 +826,7 @@ def test_salience_multi_dynamic(tfr_multi, filter_peaks):
         S[1],
         freqs=freqs[1],
         harmonics=[0.5, 1, 2, 3],
-        kind="slinear",
+        kind="nearest",
         filter_peaks=filter_peaks,
         fill_value=0,
     )
@@ -897,7 +896,6 @@ def test_click_multi():
 
     yout = librosa.clicks(times=[0, 1, 2], sr=1000, click=click)
 
-    print(yout.shape)
     assert yout.shape[0] == click.shape[0]
 
     assert np.allclose(yout[..., :100], click)
@@ -915,7 +913,6 @@ def test_nnls_multi(s_multi):
     # multichannel  
     mel_basis = librosa.filters.mel(sr=sr, n_fft=2*S.shape[-2]-1, n_mels=256)
     M = np.einsum('...ft,mf->...mt', S, mel_basis)
-    print(M.shape, mel_basis.shape)
     S_recover = librosa.util.nnls(mel_basis, M)
 
     # channel 0


### PR DESCRIPTION
#### Reference Issue
Fixes #1595 


#### What does this implement/fix? Explain your changes.
This PR "fixes" the tests on dynamic multichannel harmonic interpolation that began failing with the release of scipy 1.9.3.

Scare-quotes here are because I've swapped out the interpolation mode from "slinear" to "nearest".  This is okay here because the tests are really just verifying that operating on multiple channels simultaneously provides equivalent output to individual channel processing.

#### Any other comments?

The tests began failing here because spline mode interpolation (eg "slinear") no longer supports repeated values in the domain.  This can happen when reassigned frequencies are not unique within a frame.

Swapping out to "linear" mode fixes that problem, but introduces a new problem wherein the result can be `nan` and this breaks the allclose check.  Rather than hack the allclose check to only verify the finite values, I've swapped over to a nearest-neighbor interpolator here.

I'm okay with this fix for now, but it may be worth thinking carefully about whether we want to build a bit more safety into the frequency reassignment method.

As there are no changes to the code in this PR, I'm okay with merging when CI passes.