### PR TITLE
Rainbowgram

### DIFF
--- a/docs/examples/plot_rainbowgram.py
+++ b/docs/examples/plot_rainbowgram.py
@@ -3,9 +3,11 @@
 ================
 Rainbowgrams
 ================
+
 This notebook demonstrates how to use "Rainbowgrams" to simultaneously 
 visualize amplitude and (unwrapped) phase (differential) as demonstrated in the
-`NSynth paper <https://proceedings.mlr.press/v70/engel17a/engel17a.pdf>`
+`NSynth paper <https://proceedings.mlr.press/v70/engel17a/engel17a.pdf>`_.
+
 """
 # Code source: Brian McFee
 # License: ISC

--- a/docs/examples/plot_rainbowgram.py
+++ b/docs/examples/plot_rainbowgram.py
@@ -43,7 +43,6 @@ img = librosa.display.specshow(np.diff(np.unwrap(np.angle(phase)-phase_exp, axis
                          y_axis='log', 
                          x_axis='time')
 ax.set_facecolor('#000')
-fig.colorbar(img, ax=ax)
 cbar = fig.colorbar(img, ticks=[-np.pi, -np.pi/2, 0, np.pi/2, np.pi])
 cbar.ax.set(yticklabels=['-π', '-π/2', "0", 'π/2', 'π']);
 plt.show()

--- a/docs/examples/plot_rainbowgram.py
+++ b/docs/examples/plot_rainbowgram.py
@@ -39,7 +39,7 @@ phase_exp = 2*np.pi*np.multiply.outer(freqs,times)
 plt.close('all')
 fig, ax = plt.subplots()
 
-img = librosa.display.specshow(np.diff(np.unwrap(np.angle(phase), axis=1), axis=1, prepend=0),
+img = librosa.display.specshow(np.diff(np.unwrap(np.angle(phase)-phase_exp, axis=1), axis=1, prepend=0),
                          cmap='hsv', 
                          alpha=librosa.amplitude_to_db(mag, ref=np.max)/80 + 1,
                          ax=ax,
@@ -55,7 +55,7 @@ cbar.ax.set(yticklabels=['-π', '-π/2', 0, 'π/2', 'π']);
 # can also work here, with the caveat that it uses black to code the extremes of the map (ie 0). 
 # We can sidestep this by using a neutral axis facecolor:
 fig, ax = plt.subplots()
-img = librosa.display.specshow(np.diff(np.unwrap(np.angle(phase), axis=1), axis=1, prepend=0),
+img = librosa.display.specshow(np.diff(np.unwrap(np.angle(phase)-phase_exp, axis=1), axis=1, prepend=0),
                          cmap='twilight', 
                          alpha=librosa.amplitude_to_db(mag, ref=np.max)/80 + 1,
                          ax=ax,

--- a/docs/examples/plot_rainbowgram.py
+++ b/docs/examples/plot_rainbowgram.py
@@ -4,9 +4,10 @@
 Rainbowgrams
 ================
 This notebook demonstrates how to use "Rainbowgrams" to simultaneously 
-visualize amplitude and (unwrapped) phase (differential).
-Our working example will be the problem of silence/non-silence detection.
+visualize amplitude and (unwrapped) phase (differential) as demonstrated in the
+`NSynth paper<https://proceedings.mlr.press/v70/engel17a/engel17a.pdf>`
 """
+# %%
 # Code source: Brian McFee
 # License: ISC
 
@@ -19,14 +20,17 @@ import librosa
 import librosa.display
 
 ############################################# 
-# Construsct a sine-sweep signal.
+# %%
+# We implemented a stft method to visualize the rainbowgram and demonstrated the result with a chirp signal.
+# A chirp signal starts at a low frequency and gradually increases in frequency over time. We then separated the magnitude and phase components of the signal
 sr = 22050
 y = librosa.chirp(fmin=32, fmax=32 * 2**5, sr=sr, duration=10, linear=True)
 D = librosa.stft(y)
 mag, phase = librosa.magphase(D)
 
 ###########################################
-# we should be visualizing the demodulated phase differential derived by subtracting 2π*f*t 
+# %%
+# We should be visualizing the demodulated phase differential derived by subtracting 2π*f*t 
 # from each phase estimate prior to unwrapping, where f and t are the frequency and time.
 freqs = librosa.fft_frequencies()
 times = librosa.times_like(D)
@@ -34,7 +38,8 @@ times = librosa.times_like(D)
 phase_exp = 2*np.pi*np.multiply.outer(freqs,times)
 
 ####################
-# Plot the spectrum
+# %%
+# Plot the spectrum.
 plt.close('all')
 fig, ax = plt.subplots()
 
@@ -50,6 +55,7 @@ cbar = fig.colorbar(img, ticks=[-np.pi, -np.pi/2, 0, np.pi/2, np.pi])
 cbar.ax.set(yticklabels=['-π', '-π/2', 0, 'π/2', 'π']);
 
 ################################
+# %%
 # The above uses HSV colormap for phase fading to a black background. The twilight colormap 
 # can also work here, with the caveat that it uses black to code the extremes of the map (ie 0). 
 # We can sidestep this by using a neutral axis facecolor:

--- a/docs/examples/plot_rainbowgram.py
+++ b/docs/examples/plot_rainbowgram.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+"""
+================
+Rainbowgrams
+================
+This notebook demonstrates how to use "Rainbowgrams" to simultaneously 
+visualize amplitude and (unwrapped) phase (differential).
+Our working example will be the problem of silence/non-silence detection.
+"""
+
+# Code source: Brian McFee
+# License: ISC
+
+##################
+# Standard imports
+import numpy as np
+import matplotlib.pyplot as plt
+import librosa
+
+import librosa.display
+
+#############################################
+sr = 22050
+y = librosa.chirp(fmin=32, fmax=32 * 2**5, sr=sr, duration=10, linear=True)
+D = librosa.stft(y)
+mag, phase = librosa.magphase(D)
+
+plt.close('all')
+fig, ax = plt.subplots()
+
+img = librosa.display.specshow(np.diff(np.unwrap(np.angle(phase), axis=1), axis=1, prepend=0),
+                         cmap='hsv', 
+                         alpha=librosa.amplitude_to_db(mag, ref=np.max)/80 + 1,
+                         ax=ax,
+                         y_axis='log', 
+                         x_axis='time')
+ax.set_facecolor('#000')
+
+cbar = fig.colorbar(img, ticks=[-np.pi, -np.pi/2, 0, np.pi/2, np.pi])
+cbar.ax.set(yticklabels=['-π', '-π/2', 0, 'π/2', 'π']);
+
+
+img = librosa.display.specshow(np.diff(np.unwrap(np.angle(phase), axis=1), axis=1, prepend=0),
+                         cmap='twilight', 
+                         alpha=librosa.amplitude_to_db(mag, ref=np.max)/80 + 1,
+                         ax=ax,
+                         y_axis='log', 
+                         x_axis='time')
+ax.set_facecolor('#888')

--- a/docs/examples/plot_rainbowgram.py
+++ b/docs/examples/plot_rainbowgram.py
@@ -5,7 +5,7 @@ Rainbowgrams
 ================
 This notebook demonstrates how to use "Rainbowgrams" to simultaneously 
 visualize amplitude and (unwrapped) phase (differential) as demonstrated in the
-`NSynth paper<https://proceedings.mlr.press/v70/engel17a/engel17a.pdf>`
+`NSynth paper <https://proceedings.mlr.press/v70/engel17a/engel17a.pdf>`
 """
 # Code source: Brian McFee
 # License: ISC
@@ -33,12 +33,9 @@ freqs = librosa.fft_frequencies()
 times = librosa.times_like(D)
 
 phase_exp = 2*np.pi*np.multiply.outer(freqs,times)
-
 ####################
 # Plot the spectrum.
-plt.close('all')
 fig, ax = plt.subplots()
-
 img = librosa.display.specshow(np.diff(np.unwrap(np.angle(phase)-phase_exp, axis=1), axis=1, prepend=0),
                          cmap='hsv', 
                          alpha=librosa.amplitude_to_db(mag, ref=np.max)/80 + 1,
@@ -46,9 +43,10 @@ img = librosa.display.specshow(np.diff(np.unwrap(np.angle(phase)-phase_exp, axis
                          y_axis='log', 
                          x_axis='time')
 ax.set_facecolor('#000')
-
+fig.colorbar(img, ax=ax)
 cbar = fig.colorbar(img, ticks=[-np.pi, -np.pi/2, 0, np.pi/2, np.pi])
-cbar.ax.set(yticklabels=['-π', '-π/2', 0, 'π/2', 'π']);
+cbar.ax.set(yticklabels=['-π', '-π/2', "0", 'π/2', 'π']);
+plt.show()
 
 ################################
 # The above uses HSV colormap for phase fading to a black background. The twilight colormap 
@@ -62,4 +60,5 @@ img = librosa.display.specshow(np.diff(np.unwrap(np.angle(phase)-phase_exp, axis
                          y_axis='log', 
                          x_axis='time')
 ax.set_facecolor('#888')
-
+cbar = fig.colorbar(img, ticks=[-np.pi, -np.pi/2, 0, np.pi/2, np.pi])
+cbar.ax.set(yticklabels=['-π', '-π/2', 0, 'π/2', 'π'])

--- a/docs/examples/plot_rainbowgram.py
+++ b/docs/examples/plot_rainbowgram.py
@@ -7,9 +7,10 @@ This notebook demonstrates how to use "Rainbowgrams" to simultaneously
 visualize amplitude and (unwrapped) phase (differential).
 Our working example will be the problem of silence/non-silence detection.
 """
-# %%
 # Code source: Brian McFee
 # License: ISC
+
+#########################
 # Standard imports
 import numpy as np
 import matplotlib.pyplot as plt
@@ -17,20 +18,23 @@ import librosa
 
 import librosa.display
 
-#############################################
-# %% 
+############################################# 
 # Construsct a sine-sweep signal.
 sr = 22050
 y = librosa.chirp(fmin=32, fmax=32 * 2**5, sr=sr, duration=10, linear=True)
 D = librosa.stft(y)
 mag, phase = librosa.magphase(D)
 
+###########################################
+# we should be visualizing the demodulated phase differential derived by subtracting 2π*f*t 
+# from each phase estimate prior to unwrapping, where f and t are the frequency and time.
 freqs = librosa.fft_frequencies()
 times = librosa.times_like(D)
 
 phase_exp = 2*np.pi*np.multiply.outer(freqs,times)
 
-# %%
+####################
+# Plot the spectrum
 plt.close('all')
 fig, ax = plt.subplots()
 
@@ -45,7 +49,10 @@ ax.set_facecolor('#000')
 cbar = fig.colorbar(img, ticks=[-np.pi, -np.pi/2, 0, np.pi/2, np.pi])
 cbar.ax.set(yticklabels=['-π', '-π/2', 0, 'π/2', 'π']);
 
-# %%
+################################
+# The above uses HSV colormap for phase fading to a black background. The twilight colormap 
+# can also work here, with the caveat that it uses black to code the extremes of the map (ie 0). 
+# We can sidestep this by using a neutral axis facecolor:
 fig, ax = plt.subplots()
 img = librosa.display.specshow(np.diff(np.unwrap(np.angle(phase), axis=1), axis=1, prepend=0),
                          cmap='twilight', 

--- a/docs/examples/plot_rainbowgram.py
+++ b/docs/examples/plot_rainbowgram.py
@@ -7,11 +7,9 @@ This notebook demonstrates how to use "Rainbowgrams" to simultaneously
 visualize amplitude and (unwrapped) phase (differential).
 Our working example will be the problem of silence/non-silence detection.
 """
-
+# %%
 # Code source: Brian McFee
 # License: ISC
-
-##################
 # Standard imports
 import numpy as np
 import matplotlib.pyplot as plt
@@ -20,11 +18,19 @@ import librosa
 import librosa.display
 
 #############################################
+# %% 
+# Construsct a sine-sweep signal.
 sr = 22050
 y = librosa.chirp(fmin=32, fmax=32 * 2**5, sr=sr, duration=10, linear=True)
 D = librosa.stft(y)
 mag, phase = librosa.magphase(D)
 
+freqs = librosa.fft_frequencies()
+times = librosa.times_like(D)
+
+phase_exp = 2*np.pi*np.multiply.outer(freqs,times)
+
+# %%
 plt.close('all')
 fig, ax = plt.subplots()
 
@@ -39,7 +45,8 @@ ax.set_facecolor('#000')
 cbar = fig.colorbar(img, ticks=[-np.pi, -np.pi/2, 0, np.pi/2, np.pi])
 cbar.ax.set(yticklabels=['-π', '-π/2', 0, 'π/2', 'π']);
 
-
+# %%
+fig, ax = plt.subplots()
 img = librosa.display.specshow(np.diff(np.unwrap(np.angle(phase), axis=1), axis=1, prepend=0),
                          cmap='twilight', 
                          alpha=librosa.amplitude_to_db(mag, ref=np.max)/80 + 1,
@@ -47,3 +54,5 @@ img = librosa.display.specshow(np.diff(np.unwrap(np.angle(phase), axis=1), axis=
                          y_axis='log', 
                          x_axis='time')
 ax.set_facecolor('#888')
+
+# %%

--- a/docs/examples/plot_rainbowgram.py
+++ b/docs/examples/plot_rainbowgram.py
@@ -7,7 +7,6 @@ This notebook demonstrates how to use "Rainbowgrams" to simultaneously
 visualize amplitude and (unwrapped) phase (differential) as demonstrated in the
 `NSynth paper<https://proceedings.mlr.press/v70/engel17a/engel17a.pdf>`
 """
-# %%
 # Code source: Brian McFee
 # License: ISC
 
@@ -20,7 +19,6 @@ import librosa
 import librosa.display
 
 ############################################# 
-# %%
 # We implemented a stft method to visualize the rainbowgram and demonstrated the result with a chirp signal.
 # A chirp signal starts at a low frequency and gradually increases in frequency over time. We then separated the magnitude and phase components of the signal
 sr = 22050
@@ -29,7 +27,6 @@ D = librosa.stft(y)
 mag, phase = librosa.magphase(D)
 
 ###########################################
-# %%
 # We should be visualizing the demodulated phase differential derived by subtracting 2π*f*t 
 # from each phase estimate prior to unwrapping, where f and t are the frequency and time.
 freqs = librosa.fft_frequencies()
@@ -38,7 +35,6 @@ times = librosa.times_like(D)
 phase_exp = 2*np.pi*np.multiply.outer(freqs,times)
 
 ####################
-# %%
 # Plot the spectrum.
 plt.close('all')
 fig, ax = plt.subplots()
@@ -55,7 +51,6 @@ cbar = fig.colorbar(img, ticks=[-np.pi, -np.pi/2, 0, np.pi/2, np.pi])
 cbar.ax.set(yticklabels=['-π', '-π/2', 0, 'π/2', 'π']);
 
 ################################
-# %%
 # The above uses HSV colormap for phase fading to a black background. The twilight colormap 
 # can also work here, with the caveat that it uses black to code the extremes of the map (ie 0). 
 # We can sidestep this by using a neutral axis facecolor:
@@ -68,4 +63,3 @@ img = librosa.display.specshow(np.diff(np.unwrap(np.angle(phase), axis=1), axis=
                          x_axis='time')
 ax.set_facecolor('#888')
 
-# %%


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/main/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
Fix: #1604


#### What does this implement/fix? Explain your changes.
"Rainbowgrams" are a way to simultaneously visualize amplitude and (unwrapped) phase (differential). Add the example to the [gallery](https://librosa.org/doc/main/advanced.html).


