### PR TITLE
Adds `CITATION.cff` file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,84 @@
+# Referenced from https://zenodo.org/record/6759664#.Y43yzhRBz30
+
+cff-version: 1.2.0
+title: librosa
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+license: "ISC"
+version: 0.9.2
+date-released: 2022-06-27
+authors:
+  - given-names: Brian
+    family-names: McFee
+    affiliation: New York University
+  - given-names: Alexandros
+    family-names: Metsai
+  - given-names: Matt
+    family-names: McVicar
+  - given-names: Stefan
+    family-names: Balke
+  - given-names: Carl
+    family-names: Thomé
+    affiliation: '@xlnaudio'
+  - given-names: Colin
+    family-names: Raffel
+    affiliation: UNC and Hugging Face
+  - given-names: Frank
+    family-names: Zalkow
+  - given-names: Ayoub
+    family-names: Malek
+    affiliation: '@yoummday'
+  - given-names: Dana
+    affiliation: Ableton
+  - given-names: Kyungyun
+    family-names: Lee
+    affiliation: Gaudio Lab
+  - given-names: Oriol
+    family-names: Nieto
+    affiliation: Adobe Research
+  - given-names: Dan
+    family-names: Ellis
+    affiliation: Google
+  - given-names: Jack
+    family-names: Mason
+  - given-names: Eric
+    family-names: Battenberg
+    affiliation: Google
+  - given-names: Scott
+    family-names: Seyfarth
+  - given-names: Ryuichi
+    family-names: Yamamoto
+    affiliation: '@line'
+  - given-names: viktorandreevichmorozov
+  - given-names: Keunwoo
+    family-names: Choi
+    affiliation: '@bytedance'
+  - given-names: Josh
+    family-names: Moore
+    affiliation: '@openmicroscopy'
+  - given-names: Rachel
+    family-names: Bittner
+  - given-names: Shunsuke Hidaka
+    affiliation: 'Kyushu University, Graduate School of Design'
+  - given-names: Ziyao
+    family-names: Wei
+  - given-names: nullmightybofo
+  - given-names: Adam
+    family-names: Weiss
+  - given-names: Darío
+    family-names: Hereñú
+  - given-names: Fabian-Robert
+    family-names: Stöter
+    affiliation: Audioshake
+  - given-names: Lorenz
+    family-names: Nickel
+  - given-names: Pius
+    family-names: Friesch
+    affiliation: KTH Royal Institute of Technology
+  - given-names: Matt
+    family-names: Vollrath
+    affiliation: '@EndPointCorp'
+  - given-names: Taewoon
+    family-names: Kim


### PR DESCRIPTION
Used for easily citing the software elsewhere

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/main/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
No Issues to reference


#### What does this implement/fix? Explain your changes.
This PR implements the addition of a **`CITATION.cff`** file, which is used for easily citing the software directly from [GitHub](https://github.com/librosa/librosa) without leaving the page.
I have referenced the author list provided from [Zenodo](https://zenodo.org/record/6759664#.Y432DRRBz30).

<img src="https://user-images.githubusercontent.com/73425927/205654343-6b838cd9-e6c6-4c7d-b31b-fd6be6c3783a.png" width="40%">


More Info:
- [What is a `CITATION.cff` file?](https://citation-file-format.github.io/)
- [About CITATION files - GitHub Docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files)
- [citation-file-format/citation-file-format](https://github.com/citation-file-format/citation-file-format) - GitHub Repo

#### Any other comments?

You can have a preview of it in my [forked repo](https://github.com/cr2007/librosa), where you can directly cite the repository from there.

Feel free to add any other edits that you see fit.

<img width="40%" src="https://user-images.githubusercontent.com/73425927/205655224-5e1096d0-1120-455d-b3b5-c9544f9c999d.png">

