### PR TITLE
Parabolic interpolation speedup for yin

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,6 +8,9 @@ omit =
 exclude_lines =
     @numba.jit
     @jit
+    @numba.stencil
+    @numba.guvectorize
+    @numba.vectorize
     pragma: no cover
     if TYPE_CHECKING:
     @overload

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -465,6 +465,7 @@ def _parabolic_interpolation(x: np.ndarray, *, axis: int=-2) -> np.ndarray:
 
     axis : int
         axis along which to interpolate
+
     Returns
     -------
     parabolic_shifts : np.ndarray [shape=x.shape]

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -462,7 +462,6 @@ def _parabolic_interpolation(x: np.ndarray, *, axis: int=-2) -> np.ndarray:
     ----------
     x : np.ndarray
         array to interpolate
-
     axis : int
         axis along which to interpolate
 

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -452,7 +452,7 @@ def _pi_stencil(x: np.ndarray) -> np.ndarray:
 @numba.guvectorize(['void(float32[:], float32[:])',
                     'void(float64[:], float64[:])'], '(n)->(n)',
                    cache=True, nopython=True)
-def _pi_wrapper(x: np.ndarray, y: np.ndarray) -> np.ndarray:  # pragma: no cover
+def _pi_wrapper(x: np.ndarray, y: np.ndarray) -> None:  # pragma: no cover
     '''Vectorized wrapper for the parabolic interpolation stencil'''
     y[:] = _pi_stencil(x)
 

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -438,6 +438,8 @@ def _cumulative_mean_normalized_difference(
 def _pi_stencil(x: np.ndarray) -> np.ndarray:
     '''Stencil to compute local parabolic interpolation'''
 
+    # Divided differences 
+    # (x[1] - x[0]) - (x[0] - x[-1])
     a = x[1] + x[-1] - 2 * x[0]
     b = (x[1] - x[-1]) / 2
 
@@ -469,6 +471,9 @@ def _parabolic_interpolation(x: np.ndarray, *, axis: int=-2) -> np.ndarray:
     -------
     parabolic_shifts : np.ndarray [shape=x.shape]
         position of the parabola optima (relative to bin indices)
+
+        Note: the shift at bin `n` is determined as 0 if the estimated
+        optimum is outside the range `[n-1, n+1]`.
     """
     # Rotate the target axis to the end
     xi = x.swapaxes(-1, axis)

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -474,17 +474,17 @@ def _parabolic_interpolation(x: np.ndarray, *, axis: int=-2) -> np.ndarray:
     xi = x.swapaxes(-1, axis)
 
     # Allocate the output array and rotate target axis
-    lp = np.empty_like(x)
-    lpi = lp.swapaxes(-1, axis)
+    shifts = np.empty_like(x)
+    shiftsi = shifts.swapaxes(-1, axis)
 
     # Call the vectorized stencil
-    _pi_wrapper(xi, lpi)
+    _pi_wrapper(xi, shiftsi)
 
     # Handle the edge condition not covered by the stencil
-    lpi[..., -1] = 0
-    lpi[..., 0] = 0
+    shiftsi[..., -1] = 0
+    shiftsi[..., 0] = 0
 
-    return lp
+    return shifts
 
 
 def yin(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1156,7 +1156,7 @@ def test_piptrack_errors():
     pitches, mags = librosa.piptrack(
         y=None,
         sr=22050,
-        S=np.asarray([[1, 0, 0]]).T,
+        S=np.asarray([[1.0, 0.0, 0.0]]).T,
         n_fft=4096,
         hop_length=None,
         fmin=150,


### PR DESCRIPTION
#### Reference Issue

Fixes #1608 


#### What does this implement/fix? Explain your changes.

This PR replaces our parabolic interpolation helper with a faster implementation using numba stencils. There are some very minor changes to numerical behavior, but overall users should see no practical difference.  Speedup on this operation is about 80-90% in my (not very rigorous) benchmarks.

#### Any other comments?

If this passes CI, we should be fine to merge.