### PR TITLE
removing typehints from doc build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,7 +35,7 @@ removals = [_ for _ in sys.modules if 'librosa' in _]
 for _ in removals:
     del sys.modules[_]
 
-# -- General configuration -----------------------------------------------------
+# -- General configuration ----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
 if sphinx.__version__ < "2.0":
@@ -378,6 +378,7 @@ texinfo_documents = [
 # texinfo_show_urls = 'footnote'
 
 autodoc_member_order = "bysource"
+autodoc_typehints = "none"
 
 smv_branch_whitelist = r"^main$"  # build main branch, and anything relating to documentation
 smv_tag_whitelist = r"^((0\.8\.1)|(0\.[9]\.\d+))$"  # use this for final builds


### PR DESCRIPTION
#### Reference Issue
Fixes #1629 


#### What does this implement/fix? Explain your changes.
This PR removes type annotations from the documentation website.  It's purely cosmetic, but it should make things readable again.

#### Any other comments?

No code changes here.