### PR TITLE
Require matplotlib 3.3+

### DIFF
--- a/.github/requirements-lint.txt
+++ b/.github/requirements-lint.txt
@@ -1,8 +1,0 @@
-bandit
-codespell
-flake8
-velin
-types-decorator
-mypy
-pytest
-numpy

--- a/librosa/display.py
+++ b/librosa/display.py
@@ -41,7 +41,6 @@ from itertools import product
 import warnings
 
 import numpy as np
-from packaging.version import parse as version_parse
 import lazy_loader as lazy
 
 from . import core
@@ -1331,28 +1330,14 @@ def __scale_axes(axes, ax_type, which):
     """Set the axis scaling"""
 
     kwargs = dict()
-    if which == "x":
-        if version_parse(matplotlib.__version__) < version_parse("3.3.0"):
-            thresh = "linthreshx"
-            base = "basex"
-            scale = "linscalex"
-        else:
-            thresh = "linthresh"
-            base = "base"
-            scale = "linscale"
+    thresh = "linthresh"
+    base = "base"
+    scale = "linscale"
 
+    if which == "x":
         scaler = axes.set_xscale
         limit = axes.set_xlim
     else:
-        if version_parse(matplotlib.__version__) < version_parse("3.3.0"):
-            thresh = "linthreshy"
-            base = "basey"
-            scale = "linscaley"
-        else:
-            thresh = "linthresh"
-            base = "base"
-            scale = "linscale"
-
         scaler = axes.set_yscale
         limit = axes.set_ylim
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,6 @@ install_requires =
     numba >= 0.51.0
     soundfile >= 0.11.0
     pooch >= 1.0
-    packaging >= 20.0
     soxr >= 0.3.2
     typing_extensions >= 4.0.0
     lazy_loader >= 0.1
@@ -82,6 +81,7 @@ docs =
     presets
 tests =
     matplotlib >= 3.3.0
+    packaging >= 20.0
     pytest-mpl
     pytest-cov
     pytest


### PR DESCRIPTION
#### Reference Issue
Fixes #1636 

#### What does this implement/fix? Explain your changes.
This PR removes support for matplotlib 3.2 and below.

#### Any other comments?
This also removes packaging as a runtime dependency.  Packaging is still required for tests though.

As long as this passes CI, we should be ready to merge.