### PR TITLE
Zero crossings rewrite

### DIFF
--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -1181,7 +1181,7 @@ def _zc_wrapper(
 def zero_crossings(
     y: np.ndarray,
     *,
-    threshold: Optional[float] = 1e-10,
+    threshold: float = 1e-10,
     ref_magnitude: Optional[Union[float, Callable]] = None,
     pad: bool = True,
     zero_pos: bool = True,
@@ -1198,8 +1198,8 @@ def zero_crossings(
     y : np.ndarray
         The input array
 
-    threshold : float > 0 or None
-        If specified, values where ``-threshold <= y <= threshold`` are
+    threshold : float >= 0
+        If non-zero, values where ``-threshold <= y <= threshold`` are
         clipped to 0.
 
     ref_magnitude : float > 0 or callable
@@ -1273,18 +1273,11 @@ def zero_crossings(
     (array([ 0,  3,  5,  8, 10, 12, 15, 17, 19]),)
     """
 
-    # TODO: drop support for None thresholds, just use 0
-    # Clip within the threshold
-    if threshold is None:
-        threshold = 0.0
-
     if callable(ref_magnitude):
         threshold = threshold * ref_magnitude(np.abs(y))
 
     elif ref_magnitude is not None:
         threshold = threshold * ref_magnitude
-
-    assert threshold is not None  # because mypy can't infer we're float now
 
     yi = y.swapaxes(-1, axis)
     z = np.empty_like(y, dtype=bool)

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -1082,7 +1082,7 @@ def zero_crossing_rate(
         This is similar to the padding in `librosa.stft`,
         but uses edge-value copies instead of zero-padding.
     **kwargs : additional keyword arguments to pass to `librosa.zero_crossings`
-    threshold : float > 0 or None
+    threshold : float >= 0
         If specified, values where ``-threshold <= y <= threshold`` are
         clipped to 0.
     ref_magnitude : float > 0 or callable

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1064,7 +1064,7 @@ def test_to_mono_multi(y):
 
 
 @pytest.mark.parametrize("data", [np.random.randn(32)])
-@pytest.mark.parametrize("threshold", [None, 0, 1e-10])
+@pytest.mark.parametrize("threshold", [0, 1e-10])
 @pytest.mark.parametrize("ref_magnitude", [None, 0.1, np.max])
 @pytest.mark.parametrize("pad", [False, True])
 @pytest.mark.parametrize("zp", [False, True])


### PR DESCRIPTION
#### Reference Issue
Fixes #1635 


#### What does this implement/fix? Explain your changes.

This PR removes support for `threshold=None` in zero crossings, since the behavior was equivalent to `threshold=0`

#### Any other comments?

The zero crossings function has been rewritten to use a numba stencil.  The result is numerically equivalent to the old implementation, but avoids extraneous copying and slicing.

I think this should be ready to merge as long as CI passes.  Some CR would be nice, but not strictly necessary IMO.