### PR TITLE
f0 harmonic interpolation

### DIFF
--- a/docs/examples/plot_spectral_harmonics.py
+++ b/docs/examples/plot_spectral_harmonics.py
@@ -7,8 +7,8 @@ Spectral harmonics
 This notebook demonstrates how to extract spectral harmonics from an audio signal.
 The basic idea is to estimate the fundamental frequency (f0) at each time step,
 and extract the energy at integer multiples of f0 (*harmonics*).
-This representation can be used to compactly encode timbral content, either for resynthesis [1]_ or
-downstream analysis [2]_.
+This representation can be used to compactly encode timbral content, either for
+resynthesis [1]_ or downstream analysis [2]_.
 
 .. [1] Bonada, Jordi, X. Serra, X. Amatriain, and A. Loscos.
     "Spectral processing."

--- a/docs/examples/plot_spectral_harmonics.py
+++ b/docs/examples/plot_spectral_harmonics.py
@@ -1,0 +1,166 @@
+# coding: utf-8
+"""
+==================
+Spectral harmonics
+==================
+
+This notebook demonstrates how to extract spectral harmonics from an audio signal.
+The basic idea is to estimate the fundamental frequency (f0) at each time step,
+and extract the energy at integer multiples of f0 (*harmonics*).
+This representation can be used to compactly encode timbral content, either for resynthesis [1]_ or
+downstream analysis [2]_.
+
+.. [1] Bonada, Jordi, X. Serra, X. Amatriain, and A. Loscos.
+    "Spectral processing."
+    DAFX Digital Audio Effects (2011): 393-444.
+
+.. [2] Rafii, Zafar.
+    "The Constant-Q Harmonic Coefficients: A timbre feature designed for music signals [Lecture Notes]."
+    IEEE Signal Processing Magazine 39, no. 3 (2022): 90-96.
+"""
+
+# Code source: Brian McFee
+# License: ISC
+
+# %%
+# We'll need numpy and matplotlib as usual
+import numpy as np
+import matplotlib.pyplot as plt
+
+# For synthesis, we'll use mir_eval's sonify module
+import mir_eval.sonify
+
+# For audio playback, we'll use IPython.display's Audio widget
+from IPython.display import Audio
+
+import librosa
+
+
+####################################################
+# We'll start by loading a speech example to analyze
+y, sr = librosa.load(librosa.ex('libri2'), duration=5)
+
+Audio(data=y, rate=sr)
+
+#####################################################
+# Next, we'll estimate the fundamental frequency (f0)
+# of the voice using `librosa.pyin`.
+#
+# We'll constrain `f0` to lie within the range 50 Hz
+# to 300 Hz.
+
+f0, voicing, voicing_probability = librosa.pyin(y=y, sr=sr, fmin=50, fmax=300)
+
+####################################################################
+# We can visualize the f0 contour on top of a spectrogram as follows
+
+S = np.abs(librosa.stft(y))
+
+times = librosa.times_like(S, sr=sr)
+
+fig, ax = plt.subplots()
+librosa.display.specshow(librosa.amplitude_to_db(S, ref=np.max),
+                         y_axis='log', x_axis='time', ax=ax)
+ax.plot(times, f0, linewidth=2, color='white', label='f0')
+ax.legend()
+
+##########################################################
+# The figure above illustrates how the f0 contour tends to
+# follow the lowest frequency with the most energy, which
+# are indicated by bright colors toward the bottom of the
+# image.  The patterns replicate at higher frequencies
+# corresponding to harmonics of the fundamental, which are
+# identified by `2*f0`, `3*f0`, `4*f0`, etc.
+#
+# We can use `librosa.f0_harmonics` to extract the energy
+# from a specified set of harmonics relative to the f0.
+
+# Let's use the first 30 harmonics: 1, 2, 3, ..., 30
+harmonics = np.arange(1, 31)
+
+# And standard Fourier transform frequencies
+frequencies = librosa.fft_frequencies(sr=sr)
+
+harmonic_energy = librosa.f0_harmonics(S, f0=f0, harmonics=harmonics, freqs=frequencies)
+
+#############################################################
+# We can visualize the result `harmonic_energy` alongside the
+# full spectrogram `S` to see how they compare to each other.
+
+# sphinx_gallery_thumbnail_number = 2
+
+fig, ax = plt.subplots(nrows=2, sharex=True)
+
+librosa.display.specshow(librosa.amplitude_to_db(S, ref=np.max),
+                         y_axis='log', x_axis='time', ax=ax[0])
+librosa.display.specshow(librosa.amplitude_to_db(harmonic_energy, ref=np.max),
+                         x_axis='time', ax=ax[1])
+ax[0].label_outer()
+ax[1].set(ylabel='Harmonics')
+
+#########################################################
+# In the above figure, we can observe the same general
+# patterns of spectral energy as in the full spectrogram,
+# but notice that the shapes no longer move up and down
+# with the f0 contour.  The resulting `harmonic_energy`
+# has been normalized with regard to the fundamental.
+#
+
+##############################################################
+# From the f0 contour and the harmonic energy measurements,
+# we can reconstruct an approximation to the original signal
+# by sinusoidal modeling.  This really just means adding up
+# sine waves at the chosen set of frequencies and scaled
+# appropriately by the amount of energy at that frequency
+# over time.
+#
+# Since the f0 contour is a time-varying frequency measurement,
+# the synthesis will need to support variable frequencies.
+# Luckily, the `mir_eval.sonify` module does exactly this.
+# We'll generate a separate signal for each harmonic separately,
+# and add them into a mixture to better approximate the original
+# signal.
+
+# f0 takes value np.nan for unvoiced regions, but this isn't
+# helpful for synthesis.  We'll use `np.nan_to_num` to replace
+# nans with a frequency of 0.
+f0_synth = np.nan_to_num(f0)
+
+yout = np.zeros_like(y)
+
+for i, (factor, energy) in enumerate(zip(harmonics, harmonic_energy)):
+    # Mix in a synthesized pitch contour
+    yout = yout + mir_eval.sonify.pitch_contour(times, f0_synth * factor,
+                                                amplitudes=energy,
+                                                fs=sr,
+                                                length=len(y))
+
+Audio(data=yout, rate=sr)
+
+
+###################################################
+# The synthesized audio is by no means a perfect
+# reconstruction of the input signal.  Notably,
+# it is derived from a sparse sinusoidal modeling
+# assumption, and will therefore not do well at
+# representing transients.  The result is still
+# largely intelligible, however, and the decoupling
+# of f0 from harmonic energy allows us to modify
+# the synthesized signal in various ways.
+#
+# For example, we can synthesize the same utterance
+# with a constant f0 to produce a monotone effect.
+
+# Make a fake f0 contour
+f_mono = 110 * np.ones_like(f0)
+
+ymono = np.zeros_like(y)
+
+for i, (factor, energy) in enumerate(zip(harmonics, harmonic_energy)):
+    # Use f_mono here instead of f0
+    ymono = ymono + mir_eval.sonify.pitch_contour(times, f_mono * factor,
+                                                amplitudes=energy,
+                                                fs=sr,
+                                                length=len(y))
+
+Audio(data=ymono, rate=sr)

--- a/librosa/__init__.py
+++ b/librosa/__init__.py
@@ -78,6 +78,7 @@ Harmonics
 
     interp_harmonics
     salience
+    f0_harmonics
 
     phase_vocoder
 

--- a/librosa/__init__.pyi
+++ b/librosa/__init__.pyi
@@ -104,6 +104,7 @@ from .core import (
     vqt as vqt,
     salience as salience,
     interp_harmonics as interp_harmonics,
+    f0_harmonics as f0_harmonics,
     get_fftlib as get_fftlib,
     set_fftlib as set_fftlib,
     key_to_degrees as key_to_degrees,

--- a/librosa/beat.py
+++ b/librosa/beat.py
@@ -8,7 +8,6 @@ Beat and tempo
 
    beat_track
    plp
-   tempo
 """
 
 import numpy as np

--- a/librosa/beat.py
+++ b/librosa/beat.py
@@ -20,11 +20,17 @@ from . import core
 from . import onset
 from . import util
 from .feature import tempogram, fourier_tempogram
+from .feature import tempo as _tempo
 from .util.exceptions import ParameterError
+from .util.decorators import moved
 from typing import Any, Callable, Optional, Tuple
 
 __all__ = ["beat_track", "tempo", "plp"]
 
+
+tempo = moved(moved_from="librosa.beat.tempo",
+              version="0.10.0",
+              version_removed="1.0")(_tempo)
 
 def beat_track(
     *,
@@ -168,7 +174,7 @@ def beat_track(
 
     # Estimate BPM if one was not provided
     if bpm is None:
-        bpm = tempo(
+        bpm = _tempo(
             onset_envelope=onset_envelope,
             sr=sr,
             hop_length=hop_length,
@@ -187,172 +193,6 @@ def beat_track(
         return (bpm, core.frames_to_time(beats, hop_length=hop_length, sr=sr))
     else:
         raise ParameterError("Invalid unit type: {}".format(units))
-
-
-@cache(level=30)
-def tempo(
-    *,
-    y: Optional[np.ndarray] = None,
-    sr: float = 22050,
-    onset_envelope: Optional[np.ndarray] = None,
-    hop_length: int = 512,
-    start_bpm: float = 120,
-    std_bpm: float = 1.0,
-    ac_size: float = 8.0,
-    max_tempo: Optional[float] = 320.0,
-    aggregate: Optional[Callable[..., Any]] = np.mean,
-    prior: Optional[scipy.stats.rv_continuous] = None,
-) -> np.ndarray:
-    """Estimate the tempo (beats per minute)
-
-    Parameters
-    ----------
-    y : np.ndarray [shape=(..., n)] or None
-        audio time series. Multi-channel is supported.
-    sr : number > 0 [scalar]
-        sampling rate of the time series
-    onset_envelope : np.ndarray [shape=(..., n)]
-        pre-computed onset strength envelope
-    hop_length : int > 0 [scalar]
-        hop length of the time series
-    start_bpm : float [scalar]
-        initial guess of the BPM
-    std_bpm : float > 0 [scalar]
-        standard deviation of tempo distribution
-    ac_size : float > 0 [scalar]
-        length (in seconds) of the auto-correlation window
-    max_tempo : float > 0 [scalar, optional]
-        If provided, only estimate tempo below this threshold
-    aggregate : callable [optional]
-        Aggregation function for estimating global tempo.
-        If `None`, then tempo is estimated independently for each frame.
-    prior : scipy.stats.rv_continuous [optional]
-        A prior distribution over tempo (in beats per minute).
-        By default, a pseudo-log-normal prior is used.
-        If given, ``start_bpm`` and ``std_bpm`` will be ignored.
-
-    Returns
-    -------
-    tempo : np.ndarray
-        estimated tempo (beats per minute).
-        If input is multi-channel, one tempo estimate per channel is provided.
-
-    See Also
-    --------
-    librosa.onset.onset_strength
-    librosa.feature.tempogram
-
-    Notes
-    -----
-    This function caches at level 30.
-
-    Examples
-    --------
-    >>> # Estimate a static tempo
-    >>> y, sr = librosa.load(librosa.ex('nutcracker'), duration=30)
-    >>> onset_env = librosa.onset.onset_strength(y=y, sr=sr)
-    >>> tempo = librosa.beat.tempo(onset_envelope=onset_env, sr=sr)
-    >>> tempo
-    array([143.555])
-
-    >>> # Or a static tempo with a uniform prior instead
-    >>> import scipy.stats
-    >>> prior = scipy.stats.uniform(30, 300)  # uniform over 30-300 BPM
-    >>> utempo = librosa.beat.tempo(onset_envelope=onset_env, sr=sr, prior=prior)
-    >>> utempo
-    array([161.499])
-
-    >>> # Or a dynamic tempo
-    >>> dtempo = librosa.beat.tempo(onset_envelope=onset_env, sr=sr,
-    ...                             aggregate=None)
-    >>> dtempo
-    array([ 89.103,  89.103,  89.103, ..., 123.047, 123.047, 123.047])
-
-    >>> # Dynamic tempo with a proper log-normal prior
-    >>> prior_lognorm = scipy.stats.lognorm(loc=np.log(120), scale=120, s=1)
-    >>> dtempo_lognorm = librosa.beat.tempo(onset_envelope=onset_env, sr=sr,
-    ...                                     aggregate=None,
-    ...                                     prior=prior_lognorm)
-    >>> dtempo_lognorm
-    array([ 89.103,  89.103,  89.103, ..., 123.047, 123.047, 123.047])
-
-    Plot the estimated tempo against the onset autocorrelation
-
-    >>> import matplotlib.pyplot as plt
-    >>> # Convert to scalar
-    >>> tempo = tempo.item()
-    >>> utempo = utempo.item()
-    >>> # Compute 2-second windowed autocorrelation
-    >>> hop_length = 512
-    >>> ac = librosa.autocorrelate(onset_env, max_size=2 * sr // hop_length)
-    >>> freqs = librosa.tempo_frequencies(len(ac), sr=sr,
-    ...                                   hop_length=hop_length)
-    >>> # Plot on a BPM axis.  We skip the first (0-lag) bin.
-    >>> fig, ax = plt.subplots()
-    >>> ax.semilogx(freqs[1:], librosa.util.normalize(ac)[1:],
-    ...              label='Onset autocorrelation', base=2)
-    >>> ax.axvline(tempo, 0, 1, alpha=0.75, linestyle='--', color='r',
-    ...             label='Tempo (default prior): {:.2f} BPM'.format(tempo))
-    >>> ax.axvline(utempo, 0, 1, alpha=0.75, linestyle=':', color='g',
-    ...             label='Tempo (uniform prior): {:.2f} BPM'.format(utempo))
-    >>> ax.set(xlabel='Tempo (BPM)', title='Static tempo estimation')
-    >>> ax.grid(True)
-    >>> ax.legend()
-
-    Plot dynamic tempo estimates over a tempogram
-
-    >>> fig, ax = plt.subplots()
-    >>> tg = librosa.feature.tempogram(onset_envelope=onset_env, sr=sr,
-    ...                                hop_length=hop_length)
-    >>> librosa.display.specshow(tg, x_axis='time', y_axis='tempo', cmap='magma', ax=ax)
-    >>> ax.plot(librosa.times_like(dtempo), dtempo,
-    ...          color='c', linewidth=1.5, label='Tempo estimate (default prior)')
-    >>> ax.plot(librosa.times_like(dtempo_lognorm), dtempo_lognorm,
-    ...          color='c', linewidth=1.5, linestyle='--',
-    ...          label='Tempo estimate (lognorm prior)')
-    >>> ax.set(title='Dynamic tempo estimation')
-    >>> ax.legend()
-    """
-
-    if start_bpm <= 0:
-        raise ParameterError("start_bpm must be strictly positive")
-
-    win_length = core.time_to_frames(ac_size, sr=sr, hop_length=hop_length).item()
-
-    tg = tempogram(
-        y=y,
-        sr=sr,
-        onset_envelope=onset_envelope,
-        hop_length=hop_length,
-        win_length=win_length,
-    )
-
-    # Eventually, we want this to work for time-varying tempo
-    if aggregate is not None:
-        tg = aggregate(tg, axis=-1, keepdims=True)
-
-    # Get the BPM values for each bin, skipping the 0-lag bin
-    bpms = core.tempo_frequencies(tg.shape[-2], hop_length=hop_length, sr=sr)
-
-    # Weight the autocorrelation by a log-normal distribution
-    if prior is None:
-        logprior = -0.5 * ((np.log2(bpms) - np.log2(start_bpm)) / std_bpm) ** 2
-    else:
-        logprior = prior.logpdf(bpms)
-
-    # Kill everything above the max tempo
-    if max_tempo is not None:
-        max_idx = int(np.argmax(bpms < max_tempo))
-        logprior[:max_idx] = -np.inf
-    # explicit axis expansion
-    logprior = util.expand_to(logprior, ndim=tg.ndim, axes=-2)
-
-    # Get the maximum, weighted by the prior
-    # Using log1p here for numerical stability
-    best_period = np.argmax(np.log1p(1e6 * tg) + logprior, axis=-2)
-
-    tempo_est: np.ndarray = np.take(bpms, best_period)
-    return tempo_est
 
 
 def plp(

--- a/librosa/core/__init__.pyi
+++ b/librosa/core/__init__.pyi
@@ -97,6 +97,7 @@ from .constantq import (
 from .harmonic import (
     salience as salience,
     interp_harmonics as interp_harmonics,
+    f0_harmonics as f0_harmonics,
 )
 
 from .fft import (

--- a/librosa/core/harmonic.py
+++ b/librosa/core/harmonic.py
@@ -343,6 +343,7 @@ def f0_harmonics(
 
     """
 
+    result: np.ndarray
     if freqs.ndim == 1 and len(freqs) == x.shape[axis]:
         if not is_unique(freqs, axis=0):
             warnings.warn(
@@ -367,7 +368,7 @@ def f0_harmonics(
             return interp(f)
 
         xfunc = np.vectorize(_f_interps, signature="(f),(h)->(h)")
-        return xfunc(  # type: ignore
+        result = xfunc(
             x.swapaxes(axis, -1), np.multiply.outer(f0, harmonics)
         ).swapaxes(axis, -1)
 
@@ -393,7 +394,7 @@ def f0_harmonics(
             return interp(f)
 
         xfunc = np.vectorize(_f_interpd, signature="(f),(f),(h)->(h)")
-        return xfunc(  # type: ignore
+        result = xfunc(
             x.swapaxes(axis, -1),
             freqs.swapaxes(axis, -1),
             np.multiply.outer(f0, harmonics),
@@ -403,3 +404,5 @@ def f0_harmonics(
         raise ParameterError(
             f"freqs.shape={freqs.shape} is incompatible with input shape={x.shape}"
         )
+
+    return np.nan_to_num(result, copy=False, nan=fill_value)

--- a/librosa/core/harmonic.py
+++ b/librosa/core/harmonic.py
@@ -311,7 +311,7 @@ def f0_harmonics(
     fill_value: float = 0,
     axis: int = -2,
 ) -> np.ndarray:
-    """Compute the energy at selected harmonics of a time-varying 
+    """Compute the energy at selected harmonics of a time-varying
     fundamental frequency.
 
     This function can be used to reduce a `frequency * time` representation

--- a/librosa/core/harmonic.py
+++ b/librosa/core/harmonic.py
@@ -353,7 +353,7 @@ def f0_harmonics(
         # We have a fixed frequency grid
         idx = np.isfinite(freqs)
 
-        def _f_interp(data, f):
+        def _f_interps(data, f):
             interp = scipy.interpolate.interp1d(
                 freqs[idx],
                 data[idx],
@@ -366,9 +366,13 @@ def f0_harmonics(
             )
             return interp(f)
 
-        xfunc = np.vectorize(_f_interp, signature="(f),(h)->(h)")
-        return xfunc(x.swapaxes(axis, -1), np.multiply.outer(f0, harmonics)).swapaxes(
-            axis, -1
+        xfunc = np.vectorize(_f_interps, signature="(f),(h)->(h)")
+        return (  # type: ignore
+            xfunc(x.swapaxes(axis, -1), np.multiply.outer(f0, harmonics))
+            .swapaxes(
+                axis,
+                -1
+            )
         )
 
     elif freqs.shape == x.shape:
@@ -378,7 +382,7 @@ def f0_harmonics(
                 stacklevel=2,
             )
         # We have a dynamic frequency grid, not so bad
-        def _f_interp(data, frequencies, f):
+        def _f_interpd(data, frequencies, f):
             idx = np.isfinite(frequencies)
             interp = scipy.interpolate.interp1d(
                 frequencies[idx],
@@ -392,12 +396,15 @@ def f0_harmonics(
             )
             return interp(f)
 
-        xfunc = np.vectorize(_f_interp, signature="(f),(f),(h)->(h)")
-        return xfunc(
-            x.swapaxes(axis, -1),
-            freqs.swapaxes(axis, -1),
-            np.multiply.outer(f0, harmonics),
-        ).swapaxes(axis, -1)
+        xfunc = np.vectorize(_f_interpd, signature="(f),(f),(h)->(h)")
+        return (  # type: ignore
+            xfunc(
+                x.swapaxes(axis, -1),
+                freqs.swapaxes(axis, -1),
+                np.multiply.outer(f0, harmonics),
+            )
+            .swapaxes(axis, -1)
+        )
 
     else:
         raise ParameterError(

--- a/librosa/core/harmonic.py
+++ b/librosa/core/harmonic.py
@@ -367,13 +367,9 @@ def f0_harmonics(
             return interp(f)
 
         xfunc = np.vectorize(_f_interps, signature="(f),(h)->(h)")
-        return (  # type: ignore
-            xfunc(x.swapaxes(axis, -1), np.multiply.outer(f0, harmonics))
-            .swapaxes(
-                axis,
-                -1
-            )
-        )
+        return xfunc(  # type: ignore
+            x.swapaxes(axis, -1), np.multiply.outer(f0, harmonics)
+        ).swapaxes(axis, -1)
 
     elif freqs.shape == x.shape:
         if not np.all(is_unique(freqs, axis=axis)):
@@ -397,14 +393,11 @@ def f0_harmonics(
             return interp(f)
 
         xfunc = np.vectorize(_f_interpd, signature="(f),(f),(h)->(h)")
-        return (  # type: ignore
-            xfunc(
-                x.swapaxes(axis, -1),
-                freqs.swapaxes(axis, -1),
-                np.multiply.outer(f0, harmonics),
-            )
-            .swapaxes(axis, -1)
-        )
+        return xfunc(  # type: ignore
+            x.swapaxes(axis, -1),
+            freqs.swapaxes(axis, -1),
+            np.multiply.outer(f0, harmonics),
+        ).swapaxes(axis, -1)
 
     else:
         raise ParameterError(

--- a/librosa/core/harmonic.py
+++ b/librosa/core/harmonic.py
@@ -10,7 +10,7 @@ import scipy.signal
 from ..util.exceptions import ParameterError
 from ..util import is_unique
 from numpy.typing import ArrayLike
-from typing import Callable, Optional, Sequence, Union
+from typing import Callable, Optional, Sequence
 
 __all__ = ["salience", "interp_harmonics", "f0_harmonics"]
 

--- a/librosa/feature/__init__.py
+++ b/librosa/feature/__init__.py
@@ -31,6 +31,7 @@ Rhythm features
 .. autosummary::
     :toctree: generated/
 
+    tempo
     tempogram
     fourier_tempogram
 

--- a/librosa/feature/__init__.py
+++ b/librosa/feature/__init__.py
@@ -34,6 +34,7 @@ Rhythm features
     tempo
     tempogram
     fourier_tempogram
+    tempogram_ratio
 
 Feature manipulation
 --------------------

--- a/librosa/feature/__init__.pyi
+++ b/librosa/feature/__init__.pyi
@@ -22,6 +22,7 @@ from .spectral import (
 from .rhythm import (
     tempogram as tempogram,
     fourier_tempogram as fourier_tempogram,
+    tempo as tempo,
 )
 
 from . import (

--- a/librosa/feature/__init__.pyi
+++ b/librosa/feature/__init__.pyi
@@ -23,6 +23,7 @@ from .rhythm import (
     tempogram as tempogram,
     fourier_tempogram as fourier_tempogram,
     tempo as tempo,
+    tempogram_ratio as tempogram_ratio,
 )
 
 from . import (

--- a/librosa/feature/rhythm.py
+++ b/librosa/feature/rhythm.py
@@ -488,10 +488,8 @@ def tempogram_ratio(
     and triplet ratios.
 
     By default, the multiplicative factors used here are as specified by
-    [2]_.
-    If the estimated tempo corresponds to a quarter note, these factors
+    [2]_.  If the estimated tempo corresponds to a quarter note, these factors
     will measure relative energy at the following metrical subdivisions:
-
 
     +-------+--------+------------------+
     | Index | Factor | Description      |

--- a/librosa/feature/rhythm.py
+++ b/librosa/feature/rhythm.py
@@ -488,26 +488,40 @@ def tempogram_ratio(
     and triplet ratios.
 
     By default, the multiplicative factors used here are as specified by
-    [2]_::
+    [2]_.
+    If the estimated tempo corresponds to a quarter note, these factors
+    will measure relative energy at the following metrical subdivisions:
 
-        [4, 8/3, 3, 2, 4/3, 3/2, 1, 2/3, 3/4, 1/2, 1/3, 3/8, 1/4]
 
-    If the estimated tempo corresponds to a quarter note (𝅘𝅥 ), these factors
-    will measure relative energy at the following metrical subdivisions::
-
-    - Sixteenth note: 𝅘𝅥𝅯 
-    - Dotted sixteenth: 𝅘𝅥𝅯 .
-    - Eighth triplet: 𝅘𝅥𝅮 ₃
-    - Eighth: 𝅘𝅥𝅮 
-    - Dotted 8th: 𝅘𝅥𝅮 .
-    - Quarter-note triplet: 𝅘𝅥 ₃
-    - Quarter note: 𝅘𝅥 
-    - Dotted quarter note: 𝅘𝅥 .
-    - Half-note triplet: 𝅗𝅥 ₃
-    - Half note: 𝅗𝅥 
-    - Dotted half note: 𝅗𝅥 .
-    - Whole-note triplet: 𝅝 ₃
-    - Whole note: 𝅝 
+    +-------+--------+------------------+
+    | Index | Factor | Description      |
+    +=======+========+==================+
+    |     0 |    4   | Sixteenth note   |
+    +-------+--------+------------------+
+    |     1 |    8/3 | Dotted sixteenth |
+    +-------+--------+------------------+
+    |     2 |    3   | Eighth triplet   |
+    +-------+--------+------------------+
+    |     3 |    2   | Eighth note      |
+    +-------+--------+------------------+
+    |     4 |    4/3 | Dotted eighth    |
+    +-------+--------+------------------+
+    |     5 |    3/2 | Quarter triplet  |
+    +-------+--------+------------------+
+    |     6 |    1   | Quarter note     |
+    +-------+--------+------------------+
+    |     7 |    2/3 | Dotted quarter   |
+    +-------+--------+------------------+
+    |     8 |    3/4 | Half triplet     |
+    +-------+--------+------------------+
+    |     9 |    1/2 | Half note        |
+    +-------+--------+------------------+
+    |    10 |    1/3 | Dotted half note |
+    +-------+--------+------------------+
+    |    11 |    3/8 | Whole triplet    |
+    +-------+--------+------------------+
+    |    12 |    1/4 | Whole note       |
+    +-------+--------+------------------+
 
     .. [1] Peeters, Geoffroy.
         "Rhythm Classification Using Spectral Rhythm Patterns."
@@ -635,11 +649,7 @@ def tempogram_ratio(
 
     if factors is None:
         # metric multiples from Prockup'15
-        factors = np.array([4, 8/3, 3, 2, 4/3, 3/2, 1, 2/3, 3/4, 1/2, 1/3,
-            3/8, 1/4])
-        # metric multiples from Peeters'05
-        #factors = np.array([1/4, 1/3, 1/2, 2/3, 3/4, 1, 1.25, 1.5, 1.75, 2,
-        #                    2.25, 2.5, 2.75, 3, 3.25, 3.5, 3.75, 4])
+        factors = np.array([4, 8/3, 3, 2, 4/3, 3/2, 1, 2/3, 3/4, 1/2, 1/3, 3/8, 1/4])
 
     tgr = f0_harmonics(tg, freqs=freqs, f0=bpm, harmonics=factors,
                        kind=kind, fill_value=fill_value)

--- a/librosa/feature/rhythm.py
+++ b/librosa/feature/rhythm.py
@@ -3,17 +3,20 @@
 """Rhythmic feature extraction"""
 
 import numpy as np
+import scipy
 
 from .. import util
 
+from .._cache import cache
 from ..core.audio import autocorrelate
 from ..core.spectrum import stft
+from ..core.convert import tempo_frequencies, time_to_frames
 from ..util.exceptions import ParameterError
 from ..filters import get_window
-from typing import Optional
+from typing import Optional, Callable, Any
 from .._typing import _WindowSpec
 
-__all__ = ["tempogram", "fourier_tempogram"]
+__all__ = ["tempogram", "fourier_tempogram", "tempo"]
 
 
 # -- Rhythmic features -- #
@@ -100,8 +103,8 @@ def tempogram(
     >>> ac_global = librosa.autocorrelate(oenv, max_size=tempogram.shape[0])
     >>> ac_global = librosa.util.normalize(ac_global)
     >>> # Estimate the global tempo for display purposes
-    >>> tempo = librosa.beat.tempo(onset_envelope=oenv, sr=sr,
-    ...                            hop_length=hop_length)[0]
+    >>> tempo = librosa.feature.tempo(onset_envelope=oenv, sr=sr,
+    ...                               hop_length=hop_length)[0]
 
     >>> import matplotlib.pyplot as plt
     >>> fig, ax = plt.subplots(nrows=4, figsize=(10, 10))
@@ -273,3 +276,169 @@ def fourier_tempogram(
     return stft(
         onset_envelope, n_fft=win_length, hop_length=1, center=center, window=window
     )
+
+
+@cache(level=30)
+def tempo(
+    *,
+    y: Optional[np.ndarray] = None,
+    sr: float = 22050,
+    onset_envelope: Optional[np.ndarray] = None,
+    hop_length: int = 512,
+    start_bpm: float = 120,
+    std_bpm: float = 1.0,
+    ac_size: float = 8.0,
+    max_tempo: Optional[float] = 320.0,
+    aggregate: Optional[Callable[..., Any]] = np.mean,
+    prior: Optional[scipy.stats.rv_continuous] = None,
+) -> np.ndarray:
+    """Estimate the tempo (beats per minute)
+
+    Parameters
+    ----------
+    y : np.ndarray [shape=(..., n)] or None
+        audio time series. Multi-channel is supported.
+    sr : number > 0 [scalar]
+        sampling rate of the time series
+    onset_envelope : np.ndarray [shape=(..., n)]
+        pre-computed onset strength envelope
+    hop_length : int > 0 [scalar]
+        hop length of the time series
+    start_bpm : float [scalar]
+        initial guess of the BPM
+    std_bpm : float > 0 [scalar]
+        standard deviation of tempo distribution
+    ac_size : float > 0 [scalar]
+        length (in seconds) of the auto-correlation window
+    max_tempo : float > 0 [scalar, optional]
+        If provided, only estimate tempo below this threshold
+    aggregate : callable [optional]
+        Aggregation function for estimating global tempo.
+        If `None`, then tempo is estimated independently for each frame.
+    prior : scipy.stats.rv_continuous [optional]
+        A prior distribution over tempo (in beats per minute).
+        By default, a pseudo-log-normal prior is used.
+        If given, ``start_bpm`` and ``std_bpm`` will be ignored.
+
+    Returns
+    -------
+    tempo : np.ndarray
+        estimated tempo (beats per minute).
+        If input is multi-channel, one tempo estimate per channel is provided.
+
+    See Also
+    --------
+    librosa.onset.onset_strength
+    librosa.feature.tempogram
+
+    Notes
+    -----
+    This function caches at level 30.
+
+    Examples
+    --------
+    >>> # Estimate a static tempo
+    >>> y, sr = librosa.load(librosa.ex('nutcracker'), duration=30)
+    >>> onset_env = librosa.onset.onset_strength(y=y, sr=sr)
+    >>> tempo = librosa.feature.tempo(onset_envelope=onset_env, sr=sr)
+    >>> tempo
+    array([143.555])
+
+    >>> # Or a static tempo with a uniform prior instead
+    >>> import scipy.stats
+    >>> prior = scipy.stats.uniform(30, 300)  # uniform over 30-300 BPM
+    >>> utempo = librosa.feature.tempo(onset_envelope=onset_env, sr=sr, prior=prior)
+    >>> utempo
+    array([161.499])
+
+    >>> # Or a dynamic tempo
+    >>> dtempo = librosa.feature.tempo(onset_envelope=onset_env, sr=sr,
+    ...                                aggregate=None)
+    >>> dtempo
+    array([ 89.103,  89.103,  89.103, ..., 123.047, 123.047, 123.047])
+
+    >>> # Dynamic tempo with a proper log-normal prior
+    >>> prior_lognorm = scipy.stats.lognorm(loc=np.log(120), scale=120, s=1)
+    >>> dtempo_lognorm = librosa.feature.tempo(onset_envelope=onset_env, sr=sr,
+    ...                                        aggregate=None,
+    ...                                        prior=prior_lognorm)
+    >>> dtempo_lognorm
+    array([ 89.103,  89.103,  89.103, ..., 123.047, 123.047, 123.047])
+
+    Plot the estimated tempo against the onset autocorrelation
+
+    >>> import matplotlib.pyplot as plt
+    >>> # Convert to scalar
+    >>> tempo = tempo.item()
+    >>> utempo = utempo.item()
+    >>> # Compute 2-second windowed autocorrelation
+    >>> hop_length = 512
+    >>> ac = librosa.autocorrelate(onset_env, max_size=2 * sr // hop_length)
+    >>> freqs = librosa.tempo_frequencies(len(ac), sr=sr,
+    ...                                   hop_length=hop_length)
+    >>> # Plot on a BPM axis.  We skip the first (0-lag) bin.
+    >>> fig, ax = plt.subplots()
+    >>> ax.semilogx(freqs[1:], librosa.util.normalize(ac)[1:],
+    ...              label='Onset autocorrelation', base=2)
+    >>> ax.axvline(tempo, 0, 1, alpha=0.75, linestyle='--', color='r',
+    ...             label='Tempo (default prior): {:.2f} BPM'.format(tempo))
+    >>> ax.axvline(utempo, 0, 1, alpha=0.75, linestyle=':', color='g',
+    ...             label='Tempo (uniform prior): {:.2f} BPM'.format(utempo))
+    >>> ax.set(xlabel='Tempo (BPM)', title='Static tempo estimation')
+    >>> ax.grid(True)
+    >>> ax.legend()
+
+    Plot dynamic tempo estimates over a tempogram
+
+    >>> fig, ax = plt.subplots()
+    >>> tg = librosa.feature.tempogram(onset_envelope=onset_env, sr=sr,
+    ...                                hop_length=hop_length)
+    >>> librosa.display.specshow(tg, x_axis='time', y_axis='tempo', cmap='magma', ax=ax)
+    >>> ax.plot(librosa.times_like(dtempo), dtempo,
+    ...          color='c', linewidth=1.5, label='Tempo estimate (default prior)')
+    >>> ax.plot(librosa.times_like(dtempo_lognorm), dtempo_lognorm,
+    ...          color='c', linewidth=1.5, linestyle='--',
+    ...          label='Tempo estimate (lognorm prior)')
+    >>> ax.set(title='Dynamic tempo estimation')
+    >>> ax.legend()
+    """
+
+    if start_bpm <= 0:
+        raise ParameterError("start_bpm must be strictly positive")
+
+    win_length = time_to_frames(ac_size, sr=sr, hop_length=hop_length).item()
+
+    tg = tempogram(
+        y=y,
+        sr=sr,
+        onset_envelope=onset_envelope,
+        hop_length=hop_length,
+        win_length=win_length,
+    )
+
+    # Eventually, we want this to work for time-varying tempo
+    if aggregate is not None:
+        tg = aggregate(tg, axis=-1, keepdims=True)
+
+    # Get the BPM values for each bin, skipping the 0-lag bin
+    bpms = tempo_frequencies(tg.shape[-2], hop_length=hop_length, sr=sr)
+
+    # Weight the autocorrelation by a log-normal distribution
+    if prior is None:
+        logprior = -0.5 * ((np.log2(bpms) - np.log2(start_bpm)) / std_bpm) ** 2
+    else:
+        logprior = prior.logpdf(bpms)
+
+    # Kill everything above the max tempo
+    if max_tempo is not None:
+        max_idx = int(np.argmax(bpms < max_tempo))
+        logprior[:max_idx] = -np.inf
+    # explicit axis expansion
+    logprior = util.expand_to(logprior, ndim=tg.ndim, axes=-2)
+
+    # Get the maximum, weighted by the prior
+    # Using log1p here for numerical stability
+    best_period = np.argmax(np.log1p(1e6 * tg) + logprior, axis=-2)
+
+    tempo_est: np.ndarray = np.take(bpms, best_period)
+    return tempo_est

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -59,7 +59,7 @@ def test_tempo(tempo, sr, hop_length, ac_size, aggregate, prior):
     delay = librosa.time_to_samples(60.0 / tempo, sr=sr).item()
     y[::delay] = 1
 
-    tempo_est = librosa.beat.tempo(
+    tempo_est = librosa.feature.tempo(
         y=y,
         sr=sr,
         hop_length=hop_length,
@@ -105,7 +105,7 @@ def test_beat_no_onsets():
 @pytest.mark.parametrize("hop_length", [512])
 def test_tempo_no_onsets(start_bpm, aggregate, onsets, sr, hop_length):
 
-    tempo = librosa.beat.tempo(
+    tempo = librosa.feature.tempo(
         onset_envelope=onsets,
         sr=sr,
         hop_length=hop_length,

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -283,3 +283,17 @@ def deprecated_test_beat(infile):
 
     beat_times = librosa.frames_to_time(beats, sr=8000, hop_length=32)
     assert np.allclose(beat_times, DATA["beats"])
+
+
+def test_tempo_tgin(ysr):
+    # Test that tempo estimation tempogram input matches without
+    y, sr = ysr
+    # Use a non-standard win length
+    ac_size = 5
+    t1 = librosa.feature.tempo(y=y, sr=sr, ac_size=ac_size, aggregate=None)
+
+    win_length = librosa.time_to_frames(ac_size, sr=sr).item()
+    tg = librosa.feature.tempogram(y=y, sr=sr, win_length=win_length)
+    t2 = librosa.feature.tempo(tg=tg, sr=sr, aggregate=None)
+
+    assert np.allclose(t1, t2)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2599,13 +2599,13 @@ def test_f0_harmonics_dynamic():
 
 
 def test_f0_harmonics_1d_nonunique():
-    freqs = np.arange(-8, 8) **2
+    freqs = np.arange(-8, 8)**2
     data = np.multiply.outer(freqs, np.arange(5))
 
     h = [1, 2, 3]
     f0 = np.ones(data.shape[-1])
     with pytest.warns(UserWarning):
-        yh = librosa.f0_harmonics(data, freqs=freqs, harmonics=h, f0=f0)
+        librosa.f0_harmonics(data, freqs=freqs, harmonics=h, f0=f0)
 
 
 def test_f0_harmonics_2d_nonunique():
@@ -2616,5 +2616,5 @@ def test_f0_harmonics_2d_nonunique():
     h = [1, 2, 3]
     f0 = np.ones(data.shape[-1])
     with pytest.warns(UserWarning):
-        yh = librosa.f0_harmonics(data, freqs=freqs, harmonics=h, f0=f0)
+        librosa.f0_harmonics(data, freqs=freqs, harmonics=h, f0=f0)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2618,3 +2618,14 @@ def test_f0_harmonics_2d_nonunique():
     with pytest.warns(UserWarning):
         librosa.f0_harmonics(data, freqs=freqs, harmonics=h, f0=f0)
 
+
+@pytest.mark.xfail(raises=librosa.ParameterError)
+def test_f0_harmonics_incompat():
+
+    # Freq axis does not match data shape
+    freqs = np.arange(5)
+    data = np.zeros((6, 7))
+    f0 = np.arange(7)
+    harmonics = np.arange(1, 3)
+
+    librosa.f0_harmonics(data, freqs=freqs, harmonics=harmonics, f0=f0)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2519,3 +2519,102 @@ def test_get_samplerate_audioread():
     assert sr == 8000
 
 
+def test_f0_harmonics_static():
+
+    freqs = np.arange(8)
+
+    data = np.multiply.outer(freqs, np.arange(2, 5))
+    # array([[ 0,  0,  0],
+    #        [ 2,  3,  4],
+    #        [ 4,  6,  8],
+    #        [ 6,  9, 12],
+    #        [ 8, 12, 16],
+    #        [10, 15, 20],
+    #        [12, 18, 24],
+    #        [14, 21, 28]])
+
+    f0 = np.array([1, 2, 0])
+    harmonics = [0.5, 1, 3]
+
+    yh = librosa.f0_harmonics(data, f0=f0, freqs=freqs, harmonics=harmonics)
+
+    assert yh.shape[0] == len(harmonics)
+    assert yh.shape[1:] == data.shape[1:]
+
+    # The 1 here comes from linear interpolation of the 0.5 subharmonic
+    # All else are data[1,2,3]
+    assert np.allclose(yh[:, 0], [1, 2, 6])
+    # Values here come from f0 = 2
+    assert np.allclose(yh[:, 1], [3, 6, 18])
+    # Last frame has f0 = 0, so all harmonics will evaluate to 0
+    assert np.allclose(yh[:, 2], [0, 0, 0])
+
+
+def test_f0_harmonics_dynamic():
+
+    # Cook up a dynamic frequency grid
+    freqs = np.add.outer(np.arange(8), np.arange(3))
+    # array([[0, 1, 2],
+    #        [1, 2, 3],
+    #        [2, 3, 4],
+    #        [3, 4, 5],
+    #        [4, 5, 6],
+    #        [5, 6, 7],
+    #        [6, 7, 8],
+    #        [7, 8, 9]])
+
+    # Broadcast multiply to make some measurements
+    data = freqs * np.arange(2, 5)
+    # array([[ 0,  3,  8],
+    #        [ 2,  6, 12],
+    #        [ 4,  9, 16],
+    #        [ 6, 12, 20],
+    #        [ 8, 15, 24],
+    #        [10, 18, 28],
+    #        [12, 21, 32],
+    #        [14, 24, 36]])
+
+    # f0 at each frame
+    f0 = [2, 4, 5]
+
+    # Harmonics
+    harmonics = [0.5, 1, 2]
+
+    # Interpolate
+    yh = librosa.f0_harmonics(data, f0=f0, freqs=freqs, harmonics=harmonics)
+
+    assert yh.shape[0] == len(harmonics)
+    assert yh.shape[1:] == data.shape[1:]
+
+    # f0 in frame 0 = 2, f0 * h => [1, 2, 4]
+    # data[f0 * h] = [2, 4, 8]
+    assert np.allclose(yh[:, 0], [2, 4, 8])
+    # f0 in frame 1 = 4, f0 * h => [2, 4, 8]
+    # data[f0 * h] = [6, 12, 24]
+    assert np.allclose(yh[:, 1], [6, 12, 24])
+    # f0 in frame 2 = 5, f0 * h = [2.5, 5, 10]
+    # interpolation happens here
+    # last frequency falls off the edge of the frequency grid, filled as 0
+    assert np.allclose(yh[:, 2], [10, 20, 0])
+
+
+def test_f0_harmonics_1d_nonunique():
+    freqs = np.arange(-8, 8) **2
+    data = np.multiply.outer(freqs, np.arange(5))
+
+    h = [1, 2, 3]
+    f0 = np.ones(data.shape[-1])
+    with pytest.warns(UserWarning):
+        yh = librosa.f0_harmonics(data, freqs=freqs, harmonics=h, f0=f0)
+
+
+def test_f0_harmonics_2d_nonunique():
+    freqs = np.add.outer(np.arange(-8, 8)**2, np.arange(5))
+
+    data = freqs * np.arange(5)
+
+    h = [1, 2, 3]
+    f0 = np.ones(data.shape[-1])
+    with pytest.warns(UserWarning):
+        yh = librosa.f0_harmonics(data, freqs=freqs, harmonics=h, f0=f0)
+

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2575,7 +2575,7 @@ def test_f0_harmonics_dynamic():
     #        [14, 24, 36]])
 
     # f0 at each frame
-    f0 = [2, 4, 5]
+    f0 = np.array([2, 4, 5])
 
     # Harmonics
     harmonics = [0.5, 1, 2]

--- a/tests/test_multichannel.py
+++ b/tests/test_multichannel.py
@@ -1037,3 +1037,27 @@ def test_resample_highdim_axis(x, axis, res_type):
     # Verify that the target axis is the correct shape
     assert y.shape[axis] == 11025
     assert y.ndim == x.ndim
+
+
+@pytest.mark.parametrize('dynamic', [False, True])
+def test_f0_harmonics(y_multi, dynamic):
+
+    y, sr = y_multi
+    Df, _, S = librosa.reassigned_spectrogram(y, sr=sr, fill_nan=True)
+    freqs = librosa.fft_frequencies(sr=sr)
+
+    harmonics = np.array([1, 2, 3])
+
+    f0 = 100 + 30 * np.random.random_sample(size=(S.shape[0], S.shape[-1]))
+
+    if dynamic:
+        out = librosa.f0_harmonics(S, freqs=Df, f0=f0, harmonics=harmonics)
+        out0 = librosa.f0_harmonics(S[0], freqs=Df[0], f0=f0[0], harmonics=harmonics)
+        out1 = librosa.f0_harmonics(S[1], freqs=Df[1], f0=f0[1], harmonics=harmonics)
+    else:
+        out = librosa.f0_harmonics(S, freqs=freqs, f0=f0, harmonics=harmonics)
+        out0 = librosa.f0_harmonics(S[0], freqs=freqs, f0=f0[0], harmonics=harmonics)
+        out1 = librosa.f0_harmonics(S[1], freqs=freqs, f0=f0[1], harmonics=harmonics)
+
+    assert np.allclose(out[0], out0)
+    assert np.allclose(out[1], out1)

--- a/tests/test_multichannel.py
+++ b/tests/test_multichannel.py
@@ -171,7 +171,7 @@ def test_tempo_multi(y_multi):
     y[0,::delay[0]] = 1
     y[1,::delay[1]] = 1
 
-    t = librosa.beat.tempo(
+    t = librosa.feature.tempo(
         y=y,
         sr=sr,
         hop_length=512,
@@ -180,7 +180,7 @@ def test_tempo_multi(y_multi):
         prior=None
     )
 
-    t0 = librosa.beat.tempo(
+    t0 = librosa.feature.tempo(
         y=y[0],
         sr=sr,
         hop_length=512,
@@ -189,7 +189,7 @@ def test_tempo_multi(y_multi):
         prior=None
     )
 
-    t1 = librosa.beat.tempo(
+    t1 = librosa.feature.tempo(
         y=y[1],
         sr=sr,
         hop_length=512,


### PR DESCRIPTION
#### Reference Issue
Fixes #1500 


#### What does this implement/fix? Explain your changes.

This PR adds the f0 harmonic interpolation method described in #1500.

It's a work in progress, but the core functionality is there.  I've informally tested the following cases:

- single channel, static frequency grid (`librosa.fft_frequencies()`)
- single channel, dynamic frequency grid (`librosa.reassigned_spectrogram`)
- multi-channel, static frequency grid
- multi-channel, dynamic frequency grid

It all seems to work to spec, though I still need to work up some unit tests.  I'm opening the PR now just to get some early feedback on the API and maybe some eyeballs on the implementation.  It's possible that we could simplify the code a bit by factoring out the interpolation helper and just changing how it gets vectorized, but I'm not expert enough with `np.vectorize` to see how to do that immediately.

Once the core is stable, I'll cook up a rhythm descriptor feature following Peeters'05.  We can also add in the implementation of Rafii'21's timbre descriptor, though I think this might work better as an advanced example.  (This is because there are some finnicky details in f0 estimation that make me hesitant to wire in as a library function.)

#### Any other comments?

TODO:

- ~~[ ] support for scalar (static) f0 (useful in tempogram ratios)~~
- [x] unit tests
- [x] multichannel integration tests
- [x] docstring examples
- [x] tempogram ratio feature extractor
- [x] timbre extractor demo
- [x] tempogram ratio tests