### PR TITLE
Doc build headaches continued

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
                 include:
                     - os: ubuntu-latest
                       python-version: "3.8"
-                      channel-priority: "strict"
+                      channel-priority: "flexible"
                       envfile: ".github/environment-docs.yml"
         steps:
         - uses: actions/checkout@v3


### PR DESCRIPTION
#### Reference Issue
#1649 still


#### What does this implement/fix? Explain your changes.
Still working on the documentation environment

#### Any other comments?

Bumping to sklearn 1.2 requires bumping to python 3.8.  This is causing problems with strict conda solve, so maybe a flexible solve will sort us out.