### PR TITLE
Doc build corrections

### DIFF
--- a/.github/environment-docs.yml
+++ b/.github/environment-docs.yml
@@ -19,7 +19,7 @@ dependencies:
   - pysoundfile>=0.11.0
   - pooch>=1.0.0
   - packaging>=20.0
-  - matplotlib>=3.5
+  - matplotlib>=3.3,<3.5
   - sphinx>=5.1.0
   - msgpack-python>=1.0
   - sphinx-gallery>=0.10.1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,7 +69,7 @@ jobs:
             sphinx-multiversion docs/ build/html
             touch build/html/.nojekyll
             cp docs/docsite-index-redirect.html build/html/index.html
-            ln -srf build/html/$(git tag -l --sort=creatordate |tail -1) build/html/latest  # auto-link the latest tag
+            ln -srf build/html/$(git tag -l --sort=creatordate |grep -v rc |tail -1) build/html/latest  # auto-link the latest tag
 
         - name: Push to web
           uses: tagus/git-deploy@v0.4.1

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -383,7 +383,7 @@ smv_branch_whitelist = (
     r"^main$"  # build main branch, and anything relating to documentation
 )
 smv_tag_whitelist = (
-    r"^((0\.8\.1)|(0\.[9]\.2))|(0\.10\.\d+)$"  # use this for final builds
+    r"^((0\.8\.1)|(0\.9\.2)|(0\.10\.\d+))$"  # use this for final builds
 )
 smv_released_pattern = r".*tags.*"
 smv_remote_whitelist = r"^origin$"


### PR DESCRIPTION
#### Reference Issue

Fixes #1660 

#### What does this implement/fix? Explain your changes.

This PR pins the matplotlib version for the doc environment to the 3.3/3.4 range, and prevents release candidates from being selected as the `latest` build for documentation.

#### Any other comments?

No code changes here, should merge immediately.
