### PR TITLE
reverting mpl version change for doc build

### DIFF
--- a/.github/environment-docs.yml
+++ b/.github/environment-docs.yml
@@ -19,7 +19,7 @@ dependencies:
   - pysoundfile>=0.11.0
   - pooch>=1.0.0
   - packaging>=20.0
-  - matplotlib>=3.3,<3.5
+  - matplotlib>=3.5
   - sphinx>=5.1.0
   - msgpack-python>=1.0
   - sphinx-gallery>=0.10.1


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Latest doc environment patch broke one of our examples (rainbowgram), so I'm reverting that change.

