### PR TITLE
allow dtype specification in abs2, rms

### DIFF
--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -17,6 +17,7 @@ from ..core.spectrum import power_to_db, _spectrogram
 from ..core.constantq import cqt, hybrid_cqt, vqt
 from ..core.pitch import estimate_tuning
 from typing import Any, Optional, Union, Collection
+from numpy.typing import DTypeLike
 from .._typing import _FloatLike_co, _WindowSpec, _PadMode, _PadModeSTFT
 
 
@@ -807,6 +808,7 @@ def rms(
     hop_length: int = 512,
     center: bool = True,
     pad_mode: _PadMode = "constant",
+    dtype: DTypeLike = np.float32,
 ) -> np.ndarray:
     """Compute root-mean-square (RMS) value for each frame, either from the
     audio samples ``y`` or from a spectrogram ``S``.
@@ -834,6 +836,8 @@ def rms(
     pad_mode : str
         Padding mode for centered analysis.  See `numpy.pad` for valid
         values.
+    dtype : np.dtype, optional
+        Data type of the output array.  Defaults to float32.
 
     Returns
     -------
@@ -880,7 +884,7 @@ def rms(
         x = util.frame(y, frame_length=frame_length, hop_length=hop_length)
 
         # Calculate power
-        power = np.mean(util.abs2(x), axis=-2, keepdims=True)
+        power = np.mean(util.abs2(x, dtype=dtype), axis=-2, keepdims=True)
     elif S is not None:
         # Check the frame length
         if S.shape[-2] != frame_length // 2 + 1:
@@ -893,7 +897,7 @@ def rms(
             )
 
         # power spectrogram
-        x = np.abs(S) ** 2
+        x = util.abs2(S, dtype=dtype)
 
         # Adjust the DC and sr/2 component
         x[..., 0, :] *= 0.5

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -2491,7 +2491,6 @@ def abs2(x: _NumberOrArray, dtype: Optional[DTypeLike] = None) -> _NumberOrArray
     ----------
     x : np.ndarray or scalar, real or complex typed
         The input data, either real (float32, float64) or complex (complex64, complex128) typed
-
     dtype : np.dtype, optional
         The data type of the output array.
         If not provided, it will be inferred from `x`

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -2481,7 +2481,7 @@ _Number = Union[complex, "np.number[Any]"]
 _NumberOrArray = TypeVar("_NumberOrArray", bound=Union[_Number, np.ndarray])
 
 
-def abs2(x: _NumberOrArray) -> _NumberOrArray:
+def abs2(x: _NumberOrArray, dtype: Optional[DTypeLike] = None) -> _NumberOrArray:
     """Compute the squared magnitude of a real or complex array.
 
     This function is equivalent to calling `np.abs(x)**2` but it
@@ -2491,6 +2491,10 @@ def abs2(x: _NumberOrArray) -> _NumberOrArray:
     ----------
     x : np.ndarray or scalar, real or complex typed
         The input data, either real (float32, float64) or complex (complex64, complex128) typed
+
+    dtype : np.dtype, optional
+        The data type of the output array.
+        If not provided, it will be inferred from `x`
 
     Returns
     -------
@@ -2508,10 +2512,14 @@ def abs2(x: _NumberOrArray) -> _NumberOrArray:
     """
     if np.iscomplexobj(x):
         # suppress type check, mypy doesn't like vectorization
-        return _cabs2(x)  # type: ignore
+        y = _cabs2(x)
+        if dtype is None:
+            return y  # type: ignore
+        else:
+            return y.astype(dtype)  # type: ignore
     else:
         # suppress type check, mypy doesn't know this is real
-        return x**2  # type: ignore
+        return np.power(x, 2, dtype=dtype)  # type: ignore
 
 
 @numba.vectorize(

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1367,6 +1367,26 @@ def test_abs2_complex(x, dtype):
     assert p.dtype == librosa.util.dtype_c2r(x_cast.dtype)
 
 
+def test_abs2_int_dtype():
+    x = np.arange(5, dtype=np.int16)
+    y = librosa.util.abs2(x, dtype=None)
+    assert x.dtype == y.dtype
+
+    z = librosa.util.abs2(x, dtype=np.float32)
+    assert z.dtype == np.float32
+
+
+def test_abs2_complex_dtype():
+    x = np.arange(5, dtype=np.complex64)
+    y = librosa.util.abs2(x, dtype=None)
+    assert np.isrealobj(y)
+    # complex64 -> float32 by default
+    assert y.dtype == np.float32
+
+    z = librosa.util.abs2(x, dtype=np.float64)
+    # force it to float64
+    assert z.dtype == np.float64
+
 
 @pytest.mark.parametrize('dtype', [np.float32, np.float64])
 @pytest.mark.parametrize('angles', [np.pi/2, [np.pi/2, -np.pi/3]])


### PR DESCRIPTION
#### Reference Issue
 fixes #1656


#### What does this implement/fix? Explain your changes.
This PR allows a user to specify a target dtype in abs2 and rms calculations.

This resolves the issue with rms calculation on integer inputs noted in #1656 .  For example, if dtype is not specified, we get overflow:

```python
In [14]: x = np.arange(1, 32768, dtype=np.int16)

In [15]: librosa.util.abs2(x)
Out[15]: array([1, 4, 9, ..., 9, 4, 1], dtype=int16)
```

If dtype is specified, we get proper outputs:

```python
In [16]: librosa.util.abs2(x, dtype=np.float32)
Out[16]: 
array([1.00000000e+00, 4.00000000e+00, 9.00000000e+00, ...,
       1.07354522e+09, 1.07361075e+09, 1.07367629e+09], dtype=float32)
```

Float32 is the default for rms now, as the result will be averaged and then sqrt'ed anyway.

#### Any other comments?

I've also snuck in a replacement of `np.abs(S)**2` by `util.abs2(S)` in the rms calculation.  Not sure how we missed that one before, but it's fixed now.
