### PR TITLE
pinning sphinx version for doc environment until we fix jquery issue

### DIFF
--- a/.github/environment-docs.yml
+++ b/.github/environment-docs.yml
@@ -20,7 +20,7 @@ dependencies:
   - pooch>=1.0.0
   - packaging>=20.0
   - matplotlib>=3.5
-  - sphinx>=5.1.0
+  - sphinx>=5.1.0,<6
   - msgpack-python>=1.0
   - sphinx-gallery>=0.10.1
   - sphinx_rtd_theme>=1.0.0

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,7 +7,7 @@ v0.10
 
 v0.10.0
 -------
-*rc0: 2023-02-07*
+2023-02-20
 
 New features
     - `#1485`_ Added support for `"h"` (hours) and `"m"` (minutes) in `librosa.display.TimeFormatter`.  *Vincent Lostanlen*

--- a/librosa/version.py
+++ b/librosa/version.py
@@ -6,7 +6,7 @@ import sys
 import importlib
 
 short_version = "0.10"
-version = "0.10.0rc1"
+version = "0.10.0"
 
 
 def __get_mod_version(modname):

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,7 @@ librosa =
 [options.extras_require]
 docs =
     numpydoc
-    sphinx != 1.3.1
+    sphinx != 1.3.1,<6
     sphinx_rtd_theme==1.*
     numba >= 0.51
     matplotlib >= 3.3.0


### PR DESCRIPTION
#### Reference Issue

This PR does two things:

1. Bumps the librosa.version.version field to 0.10.0
2. caps the sphinx version used in the docs CI environment.


#### What does this implement/fix? Explain your changes.

(2) is necessary due to sphinx 6.0 deprecating jquery.  It's fixable, but we might need to wait a bit to let the dust settle and all the intermediate packages (themes etc) catch up.

For now, the easiest fix is to cap the version to 5.

#### Any other comments?

I'll plan to release 0.10.0 final on Monday, 2023-02-20.