### PR TITLE
redoing 0.10.0.post1 release

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,14 @@ Changelog
 v0.10
 =====
 
+v0.10.0.post1
+-------------
+2023-03-16
+
+This maintenance release updates the dependency specifications to avoid an incompatibility with
+numpy versions 1.22.0, 1.22.1, and 1.22.2.  Functionality is otherwise identical to librosa version
+0.10.0.
+
 v0.10.0
 -------
 2023-02-20

--- a/librosa/version.py
+++ b/librosa/version.py
@@ -6,7 +6,7 @@ import sys
 import importlib
 
 short_version = "0.10"
-version = "0.10.0"
+version = "0.10.0.post1"
 
 
 def __get_mod_version(modname):

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ packages = find:
 include_package_data = True
 install_requires =
     audioread >= 2.1.9
-    numpy >= 1.20.3
+    numpy >= 1.20.3, != 1.22.0, != 1.22.1, != 1.22.2
     scipy >= 1.2.0
     scikit-learn >= 0.20.0
     joblib >= 0.14


### PR DESCRIPTION
#### Reference Issue
Fixes #1681 #1675 


#### What does this implement/fix? Explain your changes.

This PR adds a version exclusion for a few incompatible numpies.  No other functionality changes.



