### PR TITLE
Stricter checks on yin/pyin parameters

### DIFF
--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -522,7 +522,7 @@ def yin(
         minimum frequency in Hertz.
         The recommended minimum is ``librosa.note_to_hz('C2')`` (~65 Hz)
         though lower values may be feasible.
-    fmax : number > fmin, < sr/2 [scalar]
+    fmax : number > fmin, <= sr/2 [scalar]
         maximum frequency in Hertz.
         The recommended maximum is ``librosa.note_to_hz('C7')`` (~2093 Hz)
         though higher values may be feasible.
@@ -692,7 +692,7 @@ def pyin(
         minimum frequency in Hertz.
         The recommended minimum is ``librosa.note_to_hz('C2')`` (~65 Hz)
         though lower values may be feasible.
-    fmax : number > fmin, < sr/2 [scalar]
+    fmax : number > fmin, <= sr/2 [scalar]
         maximum frequency in Hertz.
         The recommended maximum is ``librosa.note_to_hz('C7')`` (~2093 Hz)
         though higher values may be feasible.
@@ -956,7 +956,7 @@ def __check_yin_params(
     """Check the feasibility of yin/pyin parameters against
     the following conditions:
 
-    1. 0 < fmin <= fmax <= sr/2
+    1. 0 < fmin < fmax <= sr/2
     2. frame_length - win_length - 1 > sr/fmax
     """
 

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -957,7 +957,7 @@ def __check_yin_params(
     the following conditions:
 
     1. 0 < fmin <= fmax <= sr/2
-    2. frame_length - win_length - 1 > sr/fmin
+    2. frame_length - win_length - 1 > sr/fmax
     """
 
     if fmax >= sr / 2:
@@ -972,10 +972,10 @@ def __check_yin_params(
             f"win_length={win_length} cannot exceed given frame_length={frame_length}"
         )
 
-    if frame_length - win_length - 1 <= sr / fmin:
-        fmin_feasible = sr / (frame_length - win_length - 1)
-        frame_length_feasible = int(np.ceil(sr/fmin + win_length + 1))
+    if frame_length - win_length - 1 <= sr / fmax:
+        fmax_feasible = sr / (frame_length - win_length - 1)
+        frame_length_feasible = int(np.ceil(sr/fmax + win_length + 1))
         raise ParameterError(
-            f"fmin={fmin:.3f} is too small for frame_length={frame_length}, win_length={win_length}, and sr={sr}. "
-            f"Either increase to fmin={fmin_feasible:.3f} or frame_length={frame_length_feasible}"
+            f"fmax={fmax:.3f} is too small for frame_length={frame_length}, win_length={win_length}, and sr={sr}. "
+            f"Either increase to fmax={fmax_feasible:.3f} or frame_length={frame_length_feasible}"
         )

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -582,7 +582,9 @@ def yin(
     if win_length is None:
         win_length = frame_length // 2
 
-    __check_yin_params(sr=sr, fmax=fmax, fmin=fmin, frame_length=frame_length, win_length=win_length)
+    __check_yin_params(
+        sr=sr, fmax=fmax, fmin=fmin, frame_length=frame_length, win_length=win_length
+    )
 
     # Set the default hop if it is not already specified.
     if hop_length is None:
@@ -782,7 +784,9 @@ def pyin(
     if win_length is None:
         win_length = frame_length // 2
 
-    __check_yin_params(sr=sr, fmax=fmax, fmin=fmin, frame_length=frame_length, win_length=win_length)
+    __check_yin_params(
+        sr=sr, fmax=fmax, fmin=fmin, frame_length=frame_length, win_length=win_length
+    )
 
     # Set the default hop if it is not already specified.
     if hop_length is None:
@@ -946,7 +950,9 @@ def __pyin_helper(
     return observation_probs[np.newaxis], voiced_prob
 
 
-def __check_yin_params(*, sr, fmax, fmin, frame_length, win_length):
+def __check_yin_params(
+    *, sr: float, fmax: float, fmin: float, frame_length: int, win_length: int
+):
     """Check the feasibility of yin/pyin parameters against
     the following conditions:
 
@@ -954,7 +960,7 @@ def __check_yin_params(*, sr, fmax, fmin, frame_length, win_length):
     2. frame_length - win_length - 1 > sr/fmax
     """
 
-    if fmax >= sr/2:
+    if fmax >= sr / 2:
         raise ParameterError(f"fmax={fmax:.3f} cannot exceed Nyquist frequency {sr/2}")
     if fmin >= fmax:
         raise ParameterError(f"fmin={fmin:.3f} cannot exceed fmax={fmax:.3f}")

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -960,21 +960,21 @@ def __check_yin_params(
     2. frame_length - win_length - 1 > sr/fmax
     """
 
-    if fmax >= sr / 2:
+    if fmax > sr / 2:
         raise ParameterError(f"fmax={fmax:.3f} cannot exceed Nyquist frequency {sr/2}")
     if fmin >= fmax:
-        raise ParameterError(f"fmin={fmin:.3f} cannot exceed fmax={fmax:.3f}")
+        raise ParameterError(f"fmin={fmin:.3f} must be less than fmax={fmax:.3f}")
     if fmin <= 0:
         raise ParameterError(f"fmin={fmin:.3f} must be strictly positive")
 
     if win_length >= frame_length:
         raise ParameterError(
-            f"win_length={win_length} cannot exceed given frame_length={frame_length}"
+            f"win_length={win_length} must be less than frame_length={frame_length}"
         )
 
-    if frame_length - win_length - 1 <= sr / fmax:
+    if frame_length - win_length - 1 <= sr // fmax:
         fmax_feasible = sr / (frame_length - win_length - 1)
-        frame_length_feasible = int(np.ceil(sr/fmax + win_length + 1))
+        frame_length_feasible = int(np.ceil(sr/fmax) + win_length + 1)
         raise ParameterError(
             f"fmax={fmax:.3f} is too small for frame_length={frame_length}, win_length={win_length}, and sr={sr}. "
             f"Either increase to fmax={fmax_feasible:.3f} or frame_length={frame_length_feasible}"

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -603,7 +603,7 @@ def yin(
     y_frames = util.frame(y, frame_length=frame_length, hop_length=hop_length)
 
     # Calculate minimum and maximum periods
-    min_period = max(int(np.floor(sr / fmax)), 1)
+    min_period = int(np.floor(sr / fmax))
     max_period = min(int(np.ceil(sr / fmin)), frame_length - win_length - 1)
 
     # Calculate cumulative mean normalized difference function.
@@ -805,7 +805,7 @@ def pyin(
     y_frames = util.frame(y, frame_length=frame_length, hop_length=hop_length)
 
     # Calculate minimum and maximum periods
-    min_period = max(int(np.floor(sr / fmax)), 1)
+    min_period = int(np.floor(sr / fmax))
     max_period = min(int(np.ceil(sr / fmin)), frame_length - win_length - 1)
 
     # Calculate cumulative mean normalized difference function.
@@ -957,7 +957,7 @@ def __check_yin_params(
     the following conditions:
 
     1. 0 < fmin <= fmax <= sr/2
-    2. frame_length - win_length - 1 > sr/fmax
+    2. frame_length - win_length - 1 > sr/fmin
     """
 
     if fmax >= sr / 2:
@@ -972,8 +972,10 @@ def __check_yin_params(
             f"win_length={win_length} cannot exceed given frame_length={frame_length}"
         )
 
-    if frame_length - win_length - 1 <= sr / fmax:
-        fmax_feasible = sr / (frame_length - win_length - 1)
+    if frame_length - win_length - 1 <= sr / fmin:
+        fmin_feasible = sr / (frame_length - win_length - 1)
+        frame_length_feasible = int(np.ceil(sr/fmin + win_length + 1))
         raise ParameterError(
-            f"fmax={fmax:.3f} must be at least {fmax_feasible:.3f} for frame_length={frame_length}, win_length={win_length}, and sr={sr}"
+            f"fmin={fmin:.3f} is too small for frame_length={frame_length}, win_length={win_length}, and sr={sr}. "
+            f"Either increase to fmin={fmin_feasible:.3f} or frame_length={frame_length_feasible}"
         )

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -522,7 +522,7 @@ def yin(
         minimum frequency in Hertz.
         The recommended minimum is ``librosa.note_to_hz('C2')`` (~65 Hz)
         though lower values may be feasible.
-    fmax : number > 0 [scalar]
+    fmax : number > fmin, < sr/2 [scalar]
         maximum frequency in Hertz.
         The recommended maximum is ``librosa.note_to_hz('C7')`` (~2093 Hz)
         though higher values may be feasible.
@@ -692,7 +692,7 @@ def pyin(
         minimum frequency in Hertz.
         The recommended minimum is ``librosa.note_to_hz('C2')`` (~65 Hz)
         though lower values may be feasible.
-    fmax : number > 0 [scalar]
+    fmax : number > fmin, < sr/2 [scalar]
         maximum frequency in Hertz.
         The recommended maximum is ``librosa.note_to_hz('C7')`` (~2093 Hz)
         though higher values may be feasible.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1190,7 +1190,7 @@ def test_yin_chirp():
         (-1, 440, None, 2048),  # Negative fmin
         (440, 220, None, 2048),  # fmin > fmax
         (440, 16000, None, 2048),  # fmax > nyquist
-        (21, 440, None, 2048),  # frame_length - win_length - 1 <= sr/fmin
+        (10, 21, None, 2048),  # frame_length - win_length - 1 <= sr/fmax
     ],
 )
 def test_yin_fail(fmin, fmax, win_length, frame_length):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1187,6 +1187,10 @@ def test_yin_chirp():
         (110, None, None, 2048),
         (None, 880, None, 2048),
         (110, 880, 2049, 2048),
+        (-1, 440, None, 2048),  # Negative fmin
+        (440, 220, None, 2048),  # fmin > fmax
+        (440, 16000, None, 2048),  # fmax > nyquist
+        (110, 4410, 2042, 2048),  # frame_length - win_length - 1 <= sr/fmax
     ],
 )
 def test_yin_fail(fmin, fmax, win_length, frame_length):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1183,14 +1183,14 @@ def test_yin_chirp():
 @pytest.mark.parametrize(
     "fmin,fmax,win_length,frame_length",
     [
-        (None, None, None, 2048),
-        (110, None, None, 2048),
-        (None, 880, None, 2048),
-        (110, 880, 2049, 2048),
+        (None, None, None, 2048),  # neither
+        (110, None, None, 2048),  # no fmax
+        (None, 880, None, 2048),  # no fmin
+        (110, 880, 2049, 2048),  # win_length >= frame_length
         (-1, 440, None, 2048),  # Negative fmin
         (440, 220, None, 2048),  # fmin > fmax
         (440, 16000, None, 2048),  # fmax > nyquist
-        (110, 4410, 2042, 2048),  # frame_length - win_length - 1 <= sr/fmax
+        (21, 440, None, 2048),  # frame_length - win_length - 1 <= sr/fmin
     ],
 )
 def test_yin_fail(fmin, fmax, win_length, frame_length):


### PR DESCRIPTION
#### Reference Issue
fixes #1680 


#### What does this implement/fix? Explain your changes.

This PR adds some stricter parameter checks on yin and pyin, explicitly verifying:

1) fmin and fmax are feasible (with respect to Nyquist)
2) min_period and max_period are feasible, as derived from fmax and frame length parameters.

#### Any other comments?

I'm not sure I fully grasp why the difference between the frame and window lengths should be relevant here, but it does directly fall out from the derivation in #1680.

To-do: 
- [x] remove some dead branches (eg max period is always sr/fmax now).
- [x] update docstrings to clarify the feasible ranges
- [x] fill out test coverage for new checks