### PR TITLE
bumping sphinx config, fixes #1671

### DIFF
--- a/.github/environment-docs.yml
+++ b/.github/environment-docs.yml
@@ -20,10 +20,10 @@ dependencies:
   - pooch>=1.0.0,<1.7
   - packaging>=20.0
   - matplotlib>=3.5
-  - sphinx>=5.1.0,<6
+  - sphinx>=5.1.0
   - msgpack-python>=1.0
   - sphinx-gallery>=0.10.1
-  - sphinx_rtd_theme>=1.0.0
+  - sphinx_rtd_theme>=1.2.0
   - lazy_loader>=0.1
   - typing_extensions>=4.1.1
   - ffmpeg

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,6 +71,7 @@ extensions = [
     "matplotlib.sphinxext.plot_directive",  # docstring examples
     "sphinxcontrib.inkscapeconverter",  # used for badge / logo conversion in tex
     "sphinx_multiversion",  # historical builds
+    "sphinx_rtd_theme",  # for proper jquery behavior
 ]
 
 autosummary_generate = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,8 +69,8 @@ librosa =
 [options.extras_require]
 docs =
     numpydoc
-    sphinx != 1.3.1,<6
-    sphinx_rtd_theme==1.*
+    sphinx != 1.3.1
+    sphinx_rtd_theme>=1.2.0
     numba >= 0.51
     matplotlib >= 3.3.0
     sphinx-multiversion >= 0.2.3


### PR DESCRIPTION
#### Reference Issue
fixes #1671


#### What does this implement/fix? Explain your changes.
This PR bumps the sphinx_rtd_theme dependency to 1.2, which allows support for sphinx > 6.0.

#### Any other comments?

No code changes, this is good to merge.