### PR TITLE
fixed bins_per_octave's docs type float to int

### DIFF
--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -282,7 +282,7 @@ def pitch_shift(
     n_steps : float [scalar]
         how many (fractional) steps to shift ``y``
 
-    bins_per_octave : float > 0 [scalar]
+    bins_per_octave : int > 0 [scalar]
         how many steps per octave
 
     res_type : string


### PR DESCRIPTION
#### Reference Issue


#### What does this implement/fix? Explain your changes.

I just edited one line.
The docs type of bin_per_octave of the pitch_shift function and the actual type do not match.


#### Any other comments?

Thanks for the nice library.