### PR TITLE
add volume adjustment(rms-mean) at pitch_shift

### DIFF
--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -40,6 +40,7 @@ from . import core
 from . import decompose
 from . import feature
 from . import util
+from .feature import rms
 from .util.exceptions import ParameterError
 from typing import Any, Callable, Iterable, Optional, Tuple, Union, overload
 from typing_extensions import Literal
@@ -265,6 +266,7 @@ def pitch_shift(
     n_steps: float,
     bins_per_octave: int = 12,
     res_type: str = "soxr_hq",
+    volume: Union[str, None] = None,
     **kwargs: Any,
 ) -> np.ndarray:
     """Shift the pitch of a waveform by ``n_steps`` steps.
@@ -289,6 +291,10 @@ def pitch_shift(
         Resample type. By default, 'soxr_hq' is used.
 
         See `librosa.resample` for more information.
+
+    volume: string or None
+        Volume adjustment. By default, None is used.
+        Current List - [rms-mean]
 
     **kwargs : additional keyword arguments.
         See `librosa.decompose.stft` for details.
@@ -338,6 +344,11 @@ def pitch_shift(
         target_sr=sr,
         res_type=res_type,
     )
+
+    if volume == 'rms-mean':
+        original_rms_volume = np.mean(rms(y=y))
+        shifted_rms_volume = np.mean(rms(y=y_shift))
+        y_shift = y_shift * (original_rms_volume / shifted_rms_volume)
 
     # Crop to the same dimension as the input
     return util.fix_length(y_shift, size=y.shape[-1])


### PR DESCRIPTION
#### Reference Issue
It's simple, so I left an opinion as a pull request without any issues.

#### What does this implement/fix? Explain your changes.

If the volume is changed due to pitch_shift, the average value of the volume can be adjusted.

For compatibility, the default value is None,
Since the volume control method can be various other than rms average, it can be received as a string like res_type.

#### Any other comments?
Thanks for reading and adding if you like!

Or if there is a better way to recalculate volume, please let me know!
I'm still learning about audio, so I don't know much about it.
