### PR TITLE
README.md typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ If you want to cite librosa in a scholarly work, there are two ways to do it.
 
     [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.591533.svg)](https://doi.org/10.5281/zenodo.591533)
 
-- If you wish to cite librosa for its design, motivation etc., please cite the paper
+- If you wish to cite librosa for its design, motivation, etc., please cite the paper
   published at SciPy 2015:
 
     McFee, Brian, Colin Raffel, Dawen Liang, Daniel PW Ellis, Matt McVicar, Eric Battenberg, and Oriol Nieto. "librosa: Audio and music signal analysis in python." In Proceedings of the 14th python in science conference, pp. 18-25. 2015.


### PR DESCRIPTION
Fixes punctuation in the Citing portion of the readme.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/main/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
<!-- Example: Fixes #123 -->


#### What does this implement/fix? Explain your changes.


#### Any other comments?

