### PR TITLE
pin numpy version to < 1.24 in doc environment

### DIFF
--- a/.github/environment-docs.yml
+++ b/.github/environment-docs.yml
@@ -6,7 +6,7 @@ dependencies:
   # required
   - pip
   - audioread>=2.1.9
-  - numpy>=1.20.3
+  - numpy>=1.20.3,<1.24.0
   - scipy>=1.2.0
   - scikit-learn>=1.2.0
   - joblib>=0.14.0


### PR DESCRIPTION
This PR upper-pins the numpy version in the doc CI environment to <1.24.0.  This is because our historical doc build 0.8.1 fails on numpy 1.24.0 by using a now-expired deprecation.

No changes in the code here - merge should be immediate.