### PR TITLE
fixed broken 'latest' link generator

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,7 +69,7 @@ jobs:
             sphinx-multiversion -D smv_latest_version=$(./scripts/get_latest_release.sh) docs build/html
             touch build/html/.nojekyll
             cp docs/docsite-index-redirect.html build/html/index.html
-            ln -srf build/html/$(git tag -l --sort=creatordate |grep -v rc |tail -1) build/html/latest  # auto-link the latest tag
+            ln -srf build/html/$(./scripts/get_latest_release.sh) build/html/latest  # auto-link the latest tag
 
         - name: Push to web
           uses: tagus/git-deploy@v0.4.1


### PR DESCRIPTION
#### Reference Issue
Should fix #1715 


#### What does this implement/fix? Explain your changes.
This PR updates the doc build script so that the `smv_latest_version` is properly synchronized with the "latest" symlink.


#### Any other comments?

No code changes, should deploy immediately.