### PR TITLE
reworked lazy loading of matplotlib

### DIFF
--- a/librosa/display.py
+++ b/librosa/display.py
@@ -41,7 +41,10 @@ from itertools import product
 import warnings
 
 import numpy as np
-import lazy_loader as lazy
+import matplotlib.cm as mcm
+import matplotlib.axes as mplaxes
+import matplotlib.ticker as mplticker
+import matplotlib.pyplot as plt
 
 from . import core
 from . import util
@@ -52,21 +55,11 @@ from ._typing import _FloatLike_co
 
 if TYPE_CHECKING:
     import matplotlib
-    import matplotlib.cm as mcm
-    import matplotlib.axes as mplaxes
-    import matplotlib.ticker as mplticker
-    import matplotlib.pyplot as plt
     from matplotlib.collections import QuadMesh, PolyCollection
     from matplotlib.lines import Line2D
     from matplotlib.path import Path as MplPath
     from matplotlib.markers import MarkerStyle
     from matplotlib.colors import Colormap
-else:
-    matplotlib = lazy.load("matplotlib")
-    mcm = lazy.load("matplotlib.cm")
-    mplaxes = lazy.load("matplotlib.axes")
-    mplticker = lazy.load("matplotlib.ticker")
-    plt = lazy.load("matplotlib.pyplot")
 
 
 __all__ = [


### PR DESCRIPTION
#### Reference Issue
Fixes #1721 (sort of)

#### What does this implement/fix? Explain your changes.

This PR partially reverts our use of lazy-loading to import matplotlib in the display module.  The reasoning here is that due to some quirks in how matplotlib depends on state manipulation triggered by import, lazy-loading can actually break things downstream in some unpredictable ways.

The display module overall is still attached lazily at the top-level `__init__.py(i)` though.  This means that we should retain the intended behavior: display (and matplotlib) are optional, mpl is only loaded if the user explicitly does so, but an explicit import of `librosa.display` is not necessary.


#### Any other comments?

This is probably not a good long-term solution, but I think it will help in the short term until the issues around lazy-loading settle down upstream.