### PR TITLE
Multiple accidentals

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -101,6 +101,7 @@ Contributors
 * Fabian Keller <https://github.com/bluenote10>
 * BdeGraff <https://github.com/BdeGraff>
 * Jon Petter Åsen <https://github.com/jpaasen>
+* Eugene Rabinovich <https://github.com/erabinov>
 
 Some feature extraction code was based on <https://github.com/ronw/frontend> by Ron Weiss.
 

--- a/librosa/core/notation.py
+++ b/librosa/core/notation.py
@@ -5,7 +5,7 @@
 import re
 import numpy as np
 from numba import jit
-from collections import Counter, deque
+from collections import Counter
 from .intervals import INTERVALS
 from .._cache import cache
 from ..util.exceptions import ParameterError
@@ -513,10 +513,15 @@ def note_to_degree(key: Union[str, _IterableLike[str], Iterable[str]]) -> Union[
 @overload
 def simplify_note(key: str, additional_acc: str =..., unicode: bool= ...) -> str:
     ...
-def simplify_degree(key: _IterableLike[str], additional_acc: str=..., unicode: bool = ... ) -> np.ndarray:
+
+@overload
+def simplify_note(key: _IterableLike[str], additional_acc: str=..., unicode: bool = ... ) -> np.ndarray:
     ...
+
+@overload
 def simplify_note(key: Union[str, _IterableLike[str], Iterable[str]], additional_acc: str =..., unicode: bool = ...) -> Union[str, np.ndarray]:
     ...
+
 def simplify_note(key: str, additional_acc='', unicode: bool = True) -> str:
     """Take in a note name and simplify by canceling sharp-flat pairs, and doubling accidentals as appropriate.
 
@@ -636,7 +641,6 @@ def key_to_notes(key: str, *, unicode: bool = True) -> List[str]:
     if not match:
         raise ParameterError(f"Improper key format: {key:s}")
     
-
     pitch_map = {"C": 0, "D": 2, "E": 4, "F": 5, "G": 7, "A": 9, "B": 11}
 
     tonic = match.group("tonic").upper()

--- a/librosa/core/notation.py
+++ b/librosa/core/notation.py
@@ -532,7 +532,7 @@ def __simplify_note(key: Union[str, _IterableLike[str], Iterable[str]], addition
     'C♭𝄫'
 
     >>> librosa.__simplify_note(['C♭♯', 'C♭♭♭'])
-    array(['C', 'C♭𝄫']
+    array(['C', 'C♭𝄫'])
 
     """
     if not isinstance(key,str):

--- a/librosa/core/notation.py
+++ b/librosa/core/notation.py
@@ -483,7 +483,7 @@ def list_thaat() -> List[str]:
 0
 
 >>> librosa.note_to_degree('D♮##b')
-2
+3
 
 """
 def note_to_degree(key: str) -> int:

--- a/librosa/core/notation.py
+++ b/librosa/core/notation.py
@@ -475,7 +475,7 @@ def list_thaat() -> List[str]:
 
 
 def note_to_degree(key: str) -> int:
-    """Takes a note name and spits out the degree of that note (e.g. 'C#' -> 1). We allow possibilities like "C#b".
+    """Take a note name and spit out the degree of that note (e.g. 'C#' -> 1). We allow possibilities like "C#b".
 
     >>> librosa.note_to_degree('B#')
     0
@@ -497,7 +497,7 @@ def note_to_degree(key: str) -> int:
 
 
 def simplify_note(key: str, unicode: bool = True) -> str:
-    """Takes in a note name and simplifies by canceling sharp-flat pairs, and doubling accidentals as appropriate.
+    """Take in a note name and simplify by canceling sharp-flat pairs, and doubling accidentals as appropriate.
 
     >>> librosa.simplify_note('C♭♯')
     'C'

--- a/librosa/core/notation.py
+++ b/librosa/core/notation.py
@@ -536,7 +536,7 @@ def simplify_note(key: str, additional_acc='', unicode: bool = True) -> str:
 
     """
     if not isinstance(key,str):
-        return np.array([simplify_note(n+additional_acc) for n in key])
+        return np.array([simplify_note(n+additional_acc, unicode=unicode) for n in key])
 
     match = NOTE_RE.match(key+additional_acc)
 

--- a/librosa/core/notation.py
+++ b/librosa/core/notation.py
@@ -661,7 +661,6 @@ def key_to_notes(key: str, *, unicode: bool = True) -> List[str]:
         notes = [simplify_note(note, additional_acc) for note in intermediate_notes]
         degrees = note_to_degree(notes)
         notes = np.roll(notes, shift=-np.argwhere(degrees == 0)[0])
-        #Cycle until the equivalent of 'C' is in the first position. This may be a bit inefficient; if additional_acc == +1, then we need to cycle all the way through.
         
         notes = list(notes)
 

--- a/librosa/core/notation.py
+++ b/librosa/core/notation.py
@@ -474,29 +474,29 @@ def list_thaat() -> List[str]:
     return list(THAAT_MAP.keys())
 
 @overload
-def note_to_degree(key: str) -> int:
+def __note_to_degree(key: str) -> int:
     ...
 @overload
-def note_to_degree(key: _IterableLike[str]) -> np.ndarray:
+def __note_to_degree(key: _IterableLike[str]) -> np.ndarray:
     ...
 @overload
-def note_to_degree(key: Union[str, _IterableLike[str], Iterable[str]]) -> Union[int, np.ndarray]:
+def __note_to_degree(key: Union[str, _IterableLike[str], Iterable[str]]) -> Union[int, np.ndarray]:
     ...
-def note_to_degree(key: Union[str, _IterableLike[str], Iterable[str]]) -> Union[int,np.ndarray]:
+def __note_to_degree(key: Union[str, _IterableLike[str], Iterable[str]]) -> Union[int,np.ndarray]:
     """Take a note name and spit out the degree of that note (e.g. 'C#' -> 1). We allow possibilities like "C#b".
 
-    >>> librosa.note_to_degree('B#')
+    >>> librosa.__note_to_degree('B#')
     0
 
-    >>> librosa.note_to_degree('D♮##b')
+    >>> librosa.__note_to_degree('D♮##b')
     3
 
-    >>> librosa.note_to_degree(['B#','D♮##b'])
+    >>> librosa.__note_to_degree(['B#','D♮##b'])
     array([0,3])
 
     """
     if not isinstance(key, str):
-        return np.array([note_to_degree(n) for n in key])
+        return np.array([__note_to_degree(n) for n in key])
 
 
     match = NOTE_RE.match(key)
@@ -511,32 +511,32 @@ def note_to_degree(key: Union[str, _IterableLike[str], Iterable[str]]) -> Union[
     return (pitch_map[letter]+sum([ACC_MAP[acc] * counter[acc] for acc in ACC_MAP]))%12
 
 @overload
-def simplify_note(key: str, additional_acc: str =..., unicode: bool= ...) -> str:
+def __simplify_note(key: str, additional_acc: str =..., unicode: bool= ...) -> str:
     ...
 
 @overload
-def simplify_note(key: _IterableLike[str], additional_acc: str=..., unicode: bool = ... ) -> np.ndarray:
+def __simplify_note(key: _IterableLike[str], additional_acc: str=..., unicode: bool = ... ) -> np.ndarray:
     ...
 
 @overload
-def simplify_note(key: Union[str, _IterableLike[str], Iterable[str]], additional_acc: str =..., unicode: bool = ...) -> Union[str, np.ndarray]:
+def __simplify_note(key: Union[str, _IterableLike[str], Iterable[str]], additional_acc: str =..., unicode: bool = ...) -> Union[str, np.ndarray]:
     ...
 
-def simplify_note(key: Union[str, _IterableLike[str], Iterable[str]], additional_acc: str='', unicode: bool = True) -> Union[str, np.ndarray]:
+def __simplify_note(key: Union[str, _IterableLike[str], Iterable[str]], additional_acc: str='', unicode: bool = True) -> Union[str, np.ndarray]:
     """Take in a note name and simplify by canceling sharp-flat pairs, and doubling accidentals as appropriate.
 
-    >>> librosa.simplify_note('C♭♯')
+    >>> librosa.__simplify_note('C♭♯')
     'C'
 
-    >>> librosa.simplify_note('C♭♭♭')
+    >>> librosa.__simplify_note('C♭♭♭')
     'C♭𝄫'
 
-    >>> librosa.simplify_note(['C♭♯', 'C♭♭♭'])
+    >>> librosa.__simplify_note(['C♭♯', 'C♭♭♭'])
     array(['C', 'C♭𝄫']
 
     """
     if not isinstance(key,str):
-        return np.array([simplify_note(n+additional_acc, unicode=unicode) for n in key])
+        return np.array([__simplify_note(n+additional_acc, unicode=unicode) for n in key])
 
     match = NOTE_RE.match(key+additional_acc)
 
@@ -658,8 +658,8 @@ def key_to_notes(key: str, *, unicode: bool = True) -> List[str]:
         sign_map = {+1: "♯", -1: "♭"}
         additional_acc = sign_map[np.sign(offset)]
         intermediate_notes = key_to_notes(tonic+additional_acc*(abs(offset)-1)+':'+scale)
-        notes = [simplify_note(note, additional_acc) for note in intermediate_notes]
-        degrees = note_to_degree(notes)
+        notes = [__simplify_note(note, additional_acc) for note in intermediate_notes]
+        degrees = __note_to_degree(notes)
         notes = np.roll(notes, shift=-np.argwhere(degrees == 0)[0])
         
         notes = list(notes)

--- a/librosa/core/notation.py
+++ b/librosa/core/notation.py
@@ -522,7 +522,7 @@ def simplify_note(key: _IterableLike[str], additional_acc: str=..., unicode: boo
 def simplify_note(key: Union[str, _IterableLike[str], Iterable[str]], additional_acc: str =..., unicode: bool = ...) -> Union[str, np.ndarray]:
     ...
 
-def simplify_note(key: str, additional_acc='', unicode: bool = True) -> str:
+def simplify_note(key: Union[str, _IterableLike[str], Iterable[str]], additional_acc: str='', unicode: bool = True) -> Union[str, np.ndarray]:
     """Take in a note name and simplify by canceling sharp-flat pairs, and doubling accidentals as appropriate.
 
     >>> librosa.simplify_note('C♭♯')

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -168,7 +168,8 @@ def test_cqt(
         # This is our most common peak index in the CQT spectrum
         # we use the mode here over frames to sidestep transient effects
         # at the beginning and end of the CQT
-        common_peak = scipy.stats.mode(peaks)[0][0]
+        #common_peak = scipy.stats.mode(peaks, keepdims=True)[0][0]
+        common_peak = np.argmax(np.bincount(peaks))
 
         # Convert peak index to frequency
         peak_frequency = fmin * 2 ** (common_peak / bins_per_octave)
@@ -206,7 +207,8 @@ def test_cqt_early_downsample(y_cqt_110, sr_cqt, n_bins, fmin, bins_per_octave):
         # This is our most common peak index in the CQT spectrum
         # we use the mode here over frames to sidestep transient effects
         # at the beginning and end of the CQT
-        common_peak = scipy.stats.mode(peaks)[0][0]
+        #common_peak = scipy.stats.mode(peaks, keepdims=True)[0][0]
+        common_peak = np.argmax(np.bincount(peaks))
 
         # Convert peak index to frequency
         peak_frequency = fmin * 2 ** (common_peak / bins_per_octave)
@@ -298,12 +300,14 @@ def test_vqt(
         # This is our most common peak index in the CQT spectrum
         # we use the mode here over frames to sidestep transient effects
         # at the beginning and end of the CQT
-        common_peak = scipy.stats.mode(peaks)[0][0]
+        #common_peak = scipy.stats.mode(peaks, keepdims=True)[0][0]
+        common_peak = np.argmax(np.bincount(peaks))
 
         # Convert peak index to frequency
         peak_frequency = fmin * 2 ** (common_peak / bins_per_octave)
 
         # Check that it matches 110, which is an analysis frequency
+        assert np.isclose(peak_frequency, 110)
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_notation.py
+++ b/tests/test_notation.py
@@ -62,6 +62,11 @@ def test_key_to_notes_badkey():
                 "A##",
             ],
         ),
+
+        # Test for multiple accidentals in tonic name.
+        ("F##:maj", ["B#", "C#", "C##", "D#", "D##", "E#", "E##", "F##", "G#", "G##", "A#", "A##"]),
+        ("Fbb:maj", ["Dbb", "Db", "Ebb", "Fbb", "Fb", "Gbb", "Gb", "Abb", "Bbbb", "Bbb", "Cbb", "Cb"]),
+        ("A###:min", ["A###", "B##", "B###", "C###", "D##", "D###", "E##", "E###", "F###", "G##", "G###", "A##"])
     ],
 )
 def test_key_to_notes(key, ref_notes):
@@ -103,6 +108,7 @@ def test_key_to_degrees_badkey():
         ("C:min", [0, 2, 3, 5, 7, 8, 10]),
         ("A:min", [9, 11, 0, 2, 4, 5, 7]),
         ("Gb:maj", [6, 8, 10, 11, 1, 3, 5]),
+        ("A###:maj", [0, 2, 4, 5, 7, 9, 11])
     ],
 )
 def test_key_to_degrees(key, ref_degrees):

--- a/tests/test_notation.py
+++ b/tests/test_notation.py
@@ -22,11 +22,11 @@ def test_key_to_notes_badkey():
 
 @pytest.mark.xfail(raises=librosa.ParameterError)
 def test_simplify_note_badnote():
-    librosa.simplify_note("not a note")
+    librosa.core.notation.simplify_note("not a note")
 
 @pytest.mark.xfail(raises=librosa.ParameterError)
 def test_note_to_degree_badnote():
-    librosa.note_to_degree("not a note")
+    librosa.core.notation.note_to_degree("not a note")
 
 
 @pytest.mark.parametrize(
@@ -111,10 +111,9 @@ def test_key_to_notes_unicode(key, ref_notes):
     ],
 )
 def test_simplify_note_ascii(note, ref_simplified_ascii):
-    simplified_note = librosa.simplify_note(note, unicode=False)
+    simplified_note = librosa.core.notation.simplify_note(note, unicode=False)
     for (n, rn) in zip(simplified_note, ref_simplified_ascii):
         assert n == rn
-
 
 @pytest.mark.xfail(raises=librosa.ParameterError)
 def test_key_to_degrees_badkey():

--- a/tests/test_notation.py
+++ b/tests/test_notation.py
@@ -20,6 +20,14 @@ import librosa
 def test_key_to_notes_badkey():
     librosa.key_to_notes("not a key")
 
+@pytest.mark.xfail(raises=librosa.ParameterError)
+def test_simplify_note_badnote():
+    librosa.simplify_note("not a note")
+
+@pytest.mark.xfail(raises=librosa.ParameterError)
+def test_note_to_degree_badnote():
+    librosa.note_to_degree("not a note")
+
 
 @pytest.mark.parametrize(
     "key,ref_notes",
@@ -75,7 +83,6 @@ def test_key_to_notes(key, ref_notes):
     for (n, rn) in zip(notes, ref_notes):
         assert n == rn
 
-
 @pytest.mark.parametrize(
     "key,ref_notes",
     [
@@ -93,6 +100,19 @@ def test_key_to_notes_unicode(key, ref_notes):
     notes = librosa.key_to_notes(key, unicode=True)
     assert len(notes) == len(ref_notes)
     for (n, rn) in zip(notes, ref_notes):
+        assert n == rn
+
+@pytest.mark.parametrize(
+    "note, ref_simplified_ascii",
+    [
+        (
+            "G####bb", "G##"
+        )
+    ],
+)
+def test_simplify_note_ascii(note, ref_simplified_ascii):
+    simplified_note = librosa.simplify_note(note, unicode=False)
+    for (n, rn) in zip(simplified_note, ref_simplified_ascii):
         assert n == rn
 
 

--- a/tests/test_notation.py
+++ b/tests/test_notation.py
@@ -115,6 +115,19 @@ def test_simplify_note_ascii(note, ref_simplified_ascii):
     for (n, rn) in zip(simplified_note, ref_simplified_ascii):
         assert n == rn
 
+@pytest.mark.parametrize(
+    "notes, ref_simplified_array",
+    [
+        (
+            ['C♭♯', 'C♭♭♭'], ['C', 'C♭𝄫']
+        )
+    ],
+)
+def test_simplify_note_array(notes, ref_simplified_array):
+    simplified_note = librosa.core.notation.__simplify_note(notes)
+    for (n, rn) in zip(simplified_note, ref_simplified_array):
+        assert n == rn
+
 @pytest.mark.xfail(raises=librosa.ParameterError)
 def test_key_to_degrees_badkey():
     librosa.key_to_degrees("not a key")

--- a/tests/test_notation.py
+++ b/tests/test_notation.py
@@ -22,11 +22,11 @@ def test_key_to_notes_badkey():
 
 @pytest.mark.xfail(raises=librosa.ParameterError)
 def test_simplify_note_badnote():
-    librosa.core.notation.simplify_note("not a note")
+    librosa.core.notation.__simplify_note("not a note")
 
 @pytest.mark.xfail(raises=librosa.ParameterError)
 def test_note_to_degree_badnote():
-    librosa.core.notation.note_to_degree("not a note")
+    librosa.core.notation.__note_to_degree("not a note")
 
 
 @pytest.mark.parametrize(
@@ -111,7 +111,7 @@ def test_key_to_notes_unicode(key, ref_notes):
     ],
 )
 def test_simplify_note_ascii(note, ref_simplified_ascii):
-    simplified_note = librosa.core.notation.simplify_note(note, unicode=False)
+    simplified_note = librosa.core.notation.__simplify_note(note, unicode=False)
     for (n, rn) in zip(simplified_note, ref_simplified_ascii):
         assert n == rn
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/main/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
Multiple accidentals in tonics, expanded support for modes in note spelling #1724


#### What does this implement/fix? Explain your changes.

I made a first pass at support for multiple accidentals in  `key_to_degrees` and `key_to_notes`.

The `key_to_degrees` method required very little modification.

The basic idea for the approach for `key_to_notes` was: for 'Cbb:min', add flats to each note `key_to_notes('Cb:min')` and then rearrange the scale so that the enharmonic equivalent of C is first.


#### Any other comments?

Some decisions still need to be made regarding whether more than two accidentals are allowed, and the appropriate regular expressions need to be modified.
I have modified one of the existing regular expressions, and added one of my own.

I've also added a few helper methods, namely `note_to_degree` and `simplify_note`.

I've made some comments about places where the code could be made a bit more efficient.



