### PR TITLE
Update audio.py

### DIFF
--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -28,8 +28,8 @@ from typing import Any, BinaryIO, Callable, Generator, Optional, Tuple, Union, L
 from numpy.typing import DTypeLike, ArrayLike
 
 # Lazy-load optional dependencies
-samplerate = lazy.load("samplerate")
-resampy = lazy.load("resampy")
+samplerate = lazy.load("samplerate", error_on_import=True)
+resampy = lazy.load("resampy", error_on_import=True)
 
 __all__ = [
     "load",


### PR DESCRIPTION
Set error_on_import=True for lazily-loaded modules.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/main/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
There isn't an issue currently reflecting the problem solved by this PR.


#### What does this implement/fix? Explain your changes.

Currently, I don't think the full set of requirements (`resampy`, `samplerate`) are installed with librosa. This PR does not change that behavior. Instead, this PR addresses the problem that **when these modules  are lazily-loaded and not found, no ImportError is raised.**

Furthermore, in some cases, even `lazy.load` will fail to return an informative stack trace. Specifically, this happens if the call to `inspect.stack()` [here](https://github.com/scientific-python/lazy_loader/blob/79ccf2d64a090a2f192dd70e068d8913bc64b618/lazy_loader/__init__.py#L193) fails -- this happened for me when running librosa inside an Apache Beam pipeline, where (apparently) the line number and other metadata for the parent frame are not available to `lazy`.

#### Any other comments?

I will let the maintainers decide whether this is worth merging, but at least wanted to bring the issue to your attention, since this took me a surprisingly long time to debug given the simple nature of the problem.

Thanks for all of your efforts on this excellent toolkit.
