### PR TITLE
Replace deprecated pkg_resources with importlib.resources

### DIFF
--- a/librosa/core/intervals.py
+++ b/librosa/core/intervals.py
@@ -2,17 +2,28 @@
 # -*- encoding: utf-8 -*-
 """Functions for interval construction"""
 
+import sys
 from typing import Collection, Dict, List, Union, overload, Iterable
 from typing_extensions import Literal
 import msgpack
-from pkg_resources import resource_filename
+
 import numpy as np
 from numpy.typing import ArrayLike
 from .._cache import cache
 from .._typing import _FloatLike_co
 
 
-with open(resource_filename(__name__, "intervals.msgpack"), "rb") as _fdesc:
+if sys.version_info < (3, 9):
+    # Use the old pkg_resources method to maintain backwards compatibility for Python < 3.9
+    from pkg_resources import resource_filename
+
+    resource_path = resource_filename(__name__, "intervals.msgpack")
+else:
+    from importlib import resources
+
+    resource_path = resources.files(__name__).joinpath("intervals.msgpack").as_posix()
+
+with open(resource_path, "rb") as _fdesc:
     # We use floats for dictionary keys, so strict mapping is disabled
     INTERVALS = msgpack.load(_fdesc, strict_map_key=False)
 

--- a/librosa/util/files.py
+++ b/librosa/util/files.py
@@ -7,9 +7,9 @@ from typing import List, Optional, Union, Any, Set
 import os
 import glob
 import json
+from importlib import resources
 from pathlib import Path
 
-from pkg_resources import resource_filename
 import pooch
 
 from .exceptions import ParameterError
@@ -30,13 +30,12 @@ __GOODBOY = pooch.create(
     __data_path, base_url="https://librosa.org/data/audio/", registry=None
 )
 
-__GOODBOY.load_registry(
-    resource_filename(__name__, str(Path("example_data") / "registry.txt"))
-)
+registry_path = resources.path(__name__, str(Path("example_data") / "registry.txt"))
+with registry_path as path:
+    __GOODBOY.load_registry(str(path))
 
-with open(
-    resource_filename(__name__, str(Path("example_data") / "index.json")), "r"
-) as _fdesc:
+index_path = resources.path(__name__, str(Path("example_data") / "index.json"))
+with index_path as path, open(path, "r") as _fdesc:
     __TRACKMAP = json.load(_fdesc)
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/main/CONTRIBUTING.md#how-to-contribute
### Reference Issue
Example: Fixes #123 -->


### What does this implement/fix? Explain your changes.
#### Background

The use of pkg_resources is now deprecated in favor of importlib.resources, importlib.metadata, and their respective backports (importlib_resources, importlib_metadata). Additional useful APIs are provided by the packaging module, such as requirements and version parsing.
#### Changes

In this PR, the following changes have been made:
- Replaced instances of pkg_resources, [as it has been deprecated in favor of importlib.resources](https://setuptools.pypa.io/en/latest/pkg_resources.html)

#### Justification

Moving away from pkg_resources:
- Reduces reliance on a deprecated module.
- Improves performance. importlib based solutions are generally faster and more efficient than pkg_resources.
- Ensures that librosa stays up-to-date with best practices in the Python ecosystem.


#### Any other comments?
I kindly request a review of these changes. Please let me know if there are any additional steps or modifications required.