### PR TITLE
Fix audio load sampling rate type

### DIFF
--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -57,13 +57,13 @@ def load(
         str, int, os.PathLike[Any], sf.SoundFile, audioread.AudioFile, BinaryIO
     ],
     *,
-    sr: Optional[float] = 22050.0,
+    sr: Optional[float] = 22050,
     mono: bool = True,
     offset: float = 0.0,
     duration: Optional[float] = None,
     dtype: DTypeLike = np.float32,
     res_type: str = "soxr_hq",
-) -> Tuple[np.ndarray, float]:
+) -> Tuple[np.ndarray, Union[int, float]]:
     """Load an audio file as a floating point time series.
 
     Audio will be automatically resampled to the given rate
@@ -195,7 +195,8 @@ def load(
         sr = sr_native
 
     # SR Cast
-    sr = float(sr)
+    if isinstance(sr, float) and sr.is_integer():
+        sr = int(sr)
 
     return y, sr
 

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -194,10 +194,6 @@ def load(
     else:
         sr = sr_native
 
-    # SR Cast
-    if isinstance(sr, float) and sr.is_integer():
-        sr = int(sr)
-
     return y, sr
 
 

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -57,7 +57,7 @@ def load(
         str, int, os.PathLike[Any], sf.SoundFile, audioread.AudioFile, BinaryIO
     ],
     *,
-    sr: Optional[float] = 22050,
+    sr: Optional[float] = 22050.0,
     mono: bool = True,
     offset: float = 0.0,
     duration: Optional[float] = None,
@@ -193,6 +193,9 @@ def load(
 
     else:
         sr = sr_native
+
+    # SR Cast
+    sr = float(sr)
 
     return y, sr
 


### PR DESCRIPTION
#### Reference Issue
Fixes #1748 

#### What does this implement/fix? Explain your changes.
Fix `librosa.load`'s actual return type as described in above issue.  

Two semantic changes are implemented:  

- default value (int -> float)
- casting (int OR float -> float)