### PR TITLE
Switch from pkg_resources to importlib.resources

### DIFF
--- a/librosa/core/intervals.py
+++ b/librosa/core/intervals.py
@@ -12,9 +12,10 @@ from .._cache import cache
 from .._typing import _FloatLike_co
 
 
-with open(resources.files("librosa.core") / "intervals.msgpack", "rb") as _fdesc:
-    # We use floats for dictionary keys, so strict mapping is disabled
-    INTERVALS = msgpack.load(_fdesc, strict_map_key=False)
+with resources.path("librosa.core", "intervals.msgpack") as imsgpack:
+    with imsgpack.open("rb") as _fdesc:
+        # We use floats for dictionary keys, so strict mapping is disabled
+        INTERVALS = msgpack.load(_fdesc, strict_map_key=False)
 
 
 @cache(level=10)

--- a/librosa/core/intervals.py
+++ b/librosa/core/intervals.py
@@ -2,17 +2,17 @@
 # -*- encoding: utf-8 -*-
 """Functions for interval construction"""
 
+from importlib import resources
 from typing import Collection, Dict, List, Union, overload, Iterable
 from typing_extensions import Literal
 import msgpack
-from pkg_resources import resource_filename
 import numpy as np
 from numpy.typing import ArrayLike
 from .._cache import cache
 from .._typing import _FloatLike_co
 
 
-with open(resource_filename(__name__, "intervals.msgpack"), "rb") as _fdesc:
+with open(resources.files("librosa.core") / "intervals.msgpack", "rb") as _fdesc:
     # We use floats for dictionary keys, so strict mapping is disabled
     INTERVALS = msgpack.load(_fdesc, strict_map_key=False)
 

--- a/librosa/util/example_data/__init__.py
+++ b/librosa/util/example_data/__init__.py
@@ -1,1 +1,1 @@
-'''Resources for loading example data'''
+"""Resources for loading example data"""

--- a/librosa/util/example_data/__init__.py
+++ b/librosa/util/example_data/__init__.py
@@ -1,0 +1,1 @@
+'''Resources for loading example data'''

--- a/librosa/util/files.py
+++ b/librosa/util/files.py
@@ -7,9 +7,9 @@ from typing import List, Optional, Union, Any, Set
 import os
 import glob
 import json
+from importlib import resources
 from pathlib import Path
 
-from pkg_resources import resource_filename
 import pooch
 
 from .exceptions import ParameterError
@@ -30,14 +30,12 @@ __GOODBOY = pooch.create(
     __data_path, base_url="https://librosa.org/data/audio/", registry=None
 )
 
-__GOODBOY.load_registry(
-    resource_filename(__name__, str(Path("example_data") / "registry.txt"))
-)
+with resources.path("librosa.util.example_data", "registry.txt") as reg:
+    __GOODBOY.load_registry(str(reg))
 
-with open(
-    resource_filename(__name__, str(Path("example_data") / "index.json")), "r"
-) as _fdesc:
-    __TRACKMAP = json.load(_fdesc)
+with resources.path("librosa.util.example_data", "index.json") as index:
+    with index.open("r") as _fdesc:
+        __TRACKMAP = json.load(_fdesc)
 
 
 def example(key: str, *, hq: bool = False) -> str:

--- a/setup.cfg
+++ b/setup.cfg
@@ -156,9 +156,6 @@ ignore_missing_imports = True
 [mypy-msgpack.*]
 ignore_missing_imports = True
 
-[mypy-pkg_resources.*]
-ignore_missing_imports = True
-
 [mypy-packaging.*]
 ignore_missing_imports = True
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/main/CONTRIBUTING.md#how-to-contribute
-->


#### What does this implement/fix? Explain your changes.

When using librosa, `interval.py` gives a deprecation warning about the use of `pkg_resources`, which is described at the top of the `pkg_resources` documentation [here](https://setuptools.pypa.io/en/latest/pkg_resources.html). This PR fixes this by switching (as suggested in the documentation) to using [`importlib`](https://docs.python.org/3/library/importlib.html), in particular, the ~[`resources.files`](https://docs.python.org/3/library/importlib.resources.html#importlib.resources.files)~ [`resources.path`](https://docs.python.org/3.9/library/importlib.html#importlib.resources.path) function.  


