### PR TITLE
Allow amplitude_to_db to accept scalars

### DIFF
--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Utilities for spectral processing"""
+from __future__ import annotations
 import warnings
 
 import numpy as np

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1869,7 +1869,8 @@ def amplitude_to_db(
     else:
         ref_value = np.abs(ref)
 
-    power = np.square(magnitude, out=magnitude)
+    out_array = magnitude if isinstance(magnitude, np.ndarray) else None
+    power = np.square(magnitude, out=out_array)
 
     return power_to_db(power, ref=ref_value**2, amin=amin**2, top_db=top_db)
 

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -22,7 +22,14 @@ from ..filters import window_sumsquare
 from numpy.typing import DTypeLike
 from typing import Any, Callable, Optional, Tuple, List, Union, overload
 from typing_extensions import Literal
-from .._typing import _WindowSpec, _PadMode, _PadModeSTFT
+from .._typing import (
+    _WindowSpec,
+    _PadMode,
+    _PadModeSTFT,
+    _SequenceLike,
+    _ScalarOrSequence,
+    _ComplexLike_co
+)
 
 __all__ = [
     "stft",
@@ -1806,14 +1813,44 @@ def db_to_power(S_db: np.ndarray, *, ref: float = 1.0) -> np.ndarray:
     return ref * np.power(10.0, 0.1 * S_db)
 
 
+@overload
+def amplitude_to_db(
+    S: _ComplexLike_co,
+    *,
+    ref: Union[float, Callable] = ...,
+    amin: float = ...,
+    top_db: Optional[float] = ...,
+) -> np.floating[Any]:
+    ...
+
+@overload
+def amplitude_to_db(
+    S: _SequenceLike[_ComplexLike_co],
+    *,
+    ref: Union[float, Callable] = ...,
+    amin: float = ...,
+    top_db: Optional[float] = ...,
+) -> np.ndarray:
+    ...
+
+@overload
+def amplitude_to_db(
+    S: _ScalarOrSequence[_ComplexLike_co],
+    *,
+    ref: Union[float, Callable] = ...,
+    amin: float = ...,
+    top_db: Optional[float] = ...,
+) -> Union[np.floating[Any], np.ndarray]:
+    ...
+
 @cache(level=30)
 def amplitude_to_db(
-    S: np.ndarray,
+    S: _ScalarOrSequence[_ComplexLike_co],
     *,
     ref: Union[float, Callable] = 1.0,
     amin: float = 1e-5,
     top_db: Optional[float] = 80.0,
-) -> np.ndarray:
+) -> Union[np.floating[Any], np.ndarray]:
     """Convert an amplitude spectrogram to dB-scaled spectrogram.
 
     This is equivalent to ``power_to_db(S**2, ref=ref**2, amin=amin**2, top_db=top_db)``,

--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -448,7 +448,7 @@ def _signal_to_frame_nonsilent(
     mse = feature.rms(y=y, frame_length=frame_length, hop_length=hop_length)
 
     # Convert to decibels and slice out the mse channel
-    db = core.amplitude_to_db(mse[..., 0, :], ref=ref, top_db=None)
+    db: np.ndarray = core.amplitude_to_db(mse[..., 0, :], ref=ref, top_db=None)
 
     # Aggregate everything but the time dimension
     if db.ndim > 1:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1462,6 +1462,11 @@ def test_amplitude_to_db_complex():
     assert np.allclose(db1, db2)
 
 
+def test_amplitude_to_db_scalar():
+    assert librosa.amplitude_to_db(1) == 0
+    assert np.isclose(librosa.amplitude_to_db(2), 6.0206)
+
+
 @pytest.mark.parametrize("ref_p", range(-3, 4))
 @pytest.mark.parametrize("xp", [(np.abs(np.random.randn(1000)) + 1e-5) ** 2])
 def test_db_to_power_inv(ref_p, xp):


### PR DESCRIPTION
`amplitude_to_db` can now accept a scalar. This brings it in line with `db_to_amplitude` and similar methods.

```python
# Without this fix:
>>> librosa.amplitude_to_db(2)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/matan/code/librosa/librosa/core/spectrum.py", line 1874, in amplitude_to_db
    power = np.square(magnitude, out=out_array)
TypeError: return arrays must be of ArrayType

# With this fix:
>>> librosa.amplitude_to_db(2)
6.020599913279624
```