### PR TITLE
Add python 3.11 to build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,13 +42,18 @@ jobs:
                       channel-priority: "strict"
                       envfile: ".github/environment-ci.yml"
 
+                    - os: ubuntu-latest
+                      python-version: "3.11"
+                      channel-priority: "strict"
+                      envfile: ".github/environment-ci.yml"
+
                     - os: macos-latest
-                      python-version: "3.10"
+                      python-version: "3.11"
                       channel-priority: "strict"
                       envfile: ".github/environment-ci.yml"
 
                     - os: windows-latest
-                      python-version: "3.10"
+                      python-version: "3.11"
                       channel-priority: "strict"
                       envfile: ".github/environment-ci.yml"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 
 [options]
 packages = find:


### PR DESCRIPTION
#### Reference Issue
Fixes #1767 


#### What does this implement/fix? Explain your changes.

Adds 3.11 to the setup.cfg, and updates the build matrix to use 3.11 on all platforms with a 3.10 historical build on ubuntu.

