### PR TITLE
Fix docstring for the `writeable` argument of `util.frame` function

### DIFF
--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -119,8 +119,8 @@ def frame(
     axis : int
         The axis along which to frame.
     writeable : bool
-        If ``True``, then the framed view of ``x`` is read-only.
-        If ``False``, then the framed view is read-write.  Note that writing to the framed view
+        If ``False``, then the framed view of ``x`` is read-only.
+        If ``True``, then the framed view is read-write.  Note that writing to the framed view
         will also write to the input array ``x`` in this case.
     subok : bool
         If True, sub-classes will be passed-through, otherwise the returned array will be


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/main/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue

Fixes #1779 

#### What does this implement/fix? Explain your changes.

This fixes the docstring for the `writeable` argument of `util.frame` function to match its actual behavior.

The framed view can only be written when the `writeable` argument is set to `True`.  The previous docstring description is the opposite of this behavior.