### PR TITLE
Updates matplotlib colormap usage to remove deprecation warnings.

### DIFF
--- a/librosa/display.py
+++ b/librosa/display.py
@@ -41,7 +41,7 @@ from itertools import product
 import warnings
 
 import numpy as np
-import matplotlib.cm as mcm
+from matplotlib import colormaps as mcm
 import matplotlib.axes as mplaxes
 import matplotlib.ticker as mplticker
 import matplotlib.pyplot as plt
@@ -844,7 +844,7 @@ def cmap(
     data = np.atleast_1d(data)
 
     if data.dtype == "bool":
-        return mcm.get_cmap(cmap_bool, lut=2)
+        return mcm[cmap_bool]
 
     data = data[np.isfinite(data)]
 
@@ -856,9 +856,9 @@ def cmap(
     min_val, max_val = np.percentile(data, [min_p, max_p])
 
     if min_val >= 0 or max_val <= 0:
-        return mcm.get_cmap(cmap_seq)
+        return mcm[cmap_seq]
 
-    return mcm.get_cmap(cmap_div)
+    return mcm[cmap_div]
 
 
 def __envelope(x, hop):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/main/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
Fixes #1781.


#### What does this implement/fix? Explain your changes.
Changes colormap calls from ```matplotlib.cm.get_cmap(name)``` to ```matplotlib.colormaps[name]``` per deprecation warnings upstream on ```matplotlib>=3.7.0```.

#### Any other comments?

Reduces ```pytest``` warnings from:

```bash
13989 passed, 2 skipped, 522 xfailed, 10002 warnings in 479.77s (0:07:59)
```

to

```bash
13989 passed, 2 skipped, 522 xfailed, 9891 warnings in 383.95s (0:06:23)
```
