### PR TITLE
Update test_util.py to remove problematic "dummy".

### DIFF
--- a/docs/examples/plot_presets.py
+++ b/docs/examples/plot_presets.py
@@ -19,7 +19,7 @@ import matplotlib.pyplot as plt
 # Import the Preset class
 from presets import Preset
 
-# To use presets, we'll make a dummy import of librosa
+# To use presets, we'll make a mock import of librosa
 import librosa as _librosa
 
 #########################################################################

--- a/librosa/sequence.py
+++ b/librosa/sequence.py
@@ -910,7 +910,7 @@ def __rqa_dp(
     #
     # If knight moves are disabled, then only the first entry is used.
     #
-    # Using dummy vectors here makes the code a bit cleaner down below.
+    # Using placeholder vectors here makes the code a bit cleaner down below.
     sim_values = np.zeros(3)
     score_values = np.zeros(3)
     vec = np.zeros(3)

--- a/librosa/util/deprecation.py
+++ b/librosa/util/deprecation.py
@@ -8,7 +8,7 @@ from typing import Any
 
 
 class Deprecated(object):
-    """A dummy class to catch usage of deprecated variable names"""
+    """A placeholder class to catch usage of deprecated variable names"""
 
     def __repr__(self) -> str:
         """Pretty-print display for deprecated objects"""

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -745,11 +745,11 @@ def test_valid_intervals_fail(intval):
 
 def test_warning_deprecated():
     @librosa.util.decorators.deprecated(version="old_version", version_removed="new_version")
-    def __dummy():
+    def __placeholder():
         return True
 
     with warnings.catch_warnings(record=True) as out:
-        x = __dummy()
+        x = __placeholder()
 
         # Make sure we still get the right value
         assert x is True
@@ -766,11 +766,11 @@ def test_warning_deprecated():
 
 def test_warning_moved():
     @librosa.util.decorators.moved(moved_from="from", version="old_version", version_removed="new_version")
-    def __dummy():
+    def __placeholder():
         return True
 
     with warnings.catch_warnings(record=True) as out:
-        x = __dummy()
+        x = __placeholder()
 
         # Make sure we still get the right value
         assert x is True


### PR DESCRIPTION
"dummy" is deprecated by my organization and would be nice to expunge it from librosa.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/main/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
<!-- Example: Fixes #123 -->


#### What does this implement/fix? Explain your changes.
Substitutes "placeholder" for "dummy".

#### Any other comments?

