### PR TITLE
Better handling of warnings in test suite

### DIFF
--- a/librosa/beat.py
+++ b/librosa/beat.py
@@ -504,7 +504,7 @@ def __last_beat(cumscore):
 
 def __trim_beats(localscore: np.ndarray, beats: np.ndarray, trim: bool) -> np.ndarray:
     """Remove spurious leading and trailing beats"""
-    smooth_boe = scipy.signal.convolve(localscore[beats], scipy.signal.hann(5), "same")
+    smooth_boe = scipy.signal.convolve(localscore[beats], scipy.signal.get_window("hann", 5), "same")
 
     if trim:
         threshold = 0.5 * ((smooth_boe**2).mean() ** 0.5)

--- a/librosa/beat.py
+++ b/librosa/beat.py
@@ -504,7 +504,7 @@ def __last_beat(cumscore):
 
 def __trim_beats(localscore: np.ndarray, beats: np.ndarray, trim: bool) -> np.ndarray:
     """Remove spurious leading and trailing beats"""
-    smooth_boe = scipy.signal.convolve(localscore[beats], scipy.signal.get_window("hann", 5), "same")
+    smooth_boe = scipy.signal.convolve(localscore[beats], scipy.signal.get_window("hann", 5, fftbins=False), "same")
 
     if trim:
         threshold = 0.5 * ((smooth_boe**2).mean() ** 0.5)

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -704,7 +704,6 @@ def icqt(
             norm,
             sparsity,
             window=window,
-            dtype=dtype,
             alpha=alpha[sl],
         )
 

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -957,7 +957,7 @@ def __reassign_times(
     # equation 5.23 of Flandrin, Auger, & Chassande-Mottin 2002
     # the sign of the correction is reversed in some papers - see Plante,
     # Meyer, & Ainsworth 1998 pp. 283-284
-    correction = np.real(S_th / (S_h + util.tiny(S_h)))
+    correction = np.real(S_th / S_h)
 
     if center:
         pad_length = None

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -785,7 +785,7 @@ def __reassign_frequencies(
     # equation 5.20 of Flandrin, Auger, & Chassande-Mottin 2002
     # the sign of the correction is reversed in some papers - see Plante,
     # Meyer, & Ainsworth 1998 pp. 283-284
-    correction = -np.imag(S_dh / S_h)
+    correction = -np.imag(S_dh / (S_h + util.tiny(S_h)))
 
     freqs = convert.fft_frequencies(sr=sr, n_fft=n_fft)
     freqs = util.expand_to(freqs, ndim=correction.ndim, axes=-2) + correction * (
@@ -957,7 +957,7 @@ def __reassign_times(
     # equation 5.23 of Flandrin, Auger, & Chassande-Mottin 2002
     # the sign of the correction is reversed in some papers - see Plante,
     # Meyer, & Ainsworth 1998 pp. 283-284
-    correction = np.real(S_th / S_h)
+    correction = np.real(S_th / (S_h + util.tiny(S_h)))
 
     if center:
         pad_length = None

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -785,7 +785,7 @@ def __reassign_frequencies(
     # equation 5.20 of Flandrin, Auger, & Chassande-Mottin 2002
     # the sign of the correction is reversed in some papers - see Plante,
     # Meyer, & Ainsworth 1998 pp. 283-284
-    with np.errstate(divide="ignore"):
+    with np.errstate(invalid="ignore"):
         # We can ignore divide-by-zero here because NaN is an acceptable correction value
         correction = -np.imag(S_dh / S_h)
 
@@ -959,7 +959,7 @@ def __reassign_times(
     # equation 5.23 of Flandrin, Auger, & Chassande-Mottin 2002
     # the sign of the correction is reversed in some papers - see Plante,
     # Meyer, & Ainsworth 1998 pp. 283-284
-    with np.errstate(divide="ignore"):
+    with np.errstate(invalid="ignore"):
         # We can ignore divide-by-zero here because NaN is an acceptable correction value
         correction = np.real(S_th / S_h)
 

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -785,7 +785,9 @@ def __reassign_frequencies(
     # equation 5.20 of Flandrin, Auger, & Chassande-Mottin 2002
     # the sign of the correction is reversed in some papers - see Plante,
     # Meyer, & Ainsworth 1998 pp. 283-284
-    correction = -np.imag(S_dh / S_h)
+    with np.errstate(divide="ignore"):
+        # We can ignore divide-by-zero here because NaN is an acceptable correction value
+        correction = -np.imag(S_dh / S_h)
 
     freqs = convert.fft_frequencies(sr=sr, n_fft=n_fft)
     freqs = util.expand_to(freqs, ndim=correction.ndim, axes=-2) + correction * (
@@ -957,7 +959,9 @@ def __reassign_times(
     # equation 5.23 of Flandrin, Auger, & Chassande-Mottin 2002
     # the sign of the correction is reversed in some papers - see Plante,
     # Meyer, & Ainsworth 1998 pp. 283-284
-    correction = np.real(S_th / S_h)
+    with np.errstate(divide="ignore"):
+        # We can ignore divide-by-zero here because NaN is an acceptable correction value
+        correction = np.real(S_th / S_h)
 
     if center:
         pad_length = None

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -785,7 +785,7 @@ def __reassign_frequencies(
     # equation 5.20 of Flandrin, Auger, & Chassande-Mottin 2002
     # the sign of the correction is reversed in some papers - see Plante,
     # Meyer, & Ainsworth 1998 pp. 283-284
-    correction = -np.imag(S_dh / (S_h + util.tiny(S_h)))
+    correction = -np.imag(S_dh / S_h)
 
     freqs = convert.fft_frequencies(sr=sr, n_fft=n_fft)
     freqs = util.expand_to(freqs, ndim=correction.ndim, axes=-2) + correction * (

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -1314,7 +1314,7 @@ def peak_pick(
     max_origin = np.ceil(0.5 * (pre_max - post_max))
     # Using mode='constant' and cval=x.min() effectively truncates
     # the sliding window at the boundaries
-    mov_max = scipy.ndimage.filters.maximum_filter1d(
+    mov_max = scipy.ndimage.maximum_filter1d(
         x, int(max_length), mode="constant", origin=int(max_origin), cval=x.min()
     )
 
@@ -1323,7 +1323,7 @@ def peak_pick(
     avg_origin = np.ceil(0.5 * (pre_avg - post_avg))
     # Here, there is no mode which results in the behavior we want,
     # so we'll correct below.
-    mov_avg = scipy.ndimage.filters.uniform_filter1d(
+    mov_avg = scipy.ndimage.uniform_filter1d(
         x, int(avg_length), mode="nearest", origin=int(avg_origin)
     )
 

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -2216,7 +2216,7 @@ def stack(arrays: List[np.ndarray], *, axis: int = 0) -> np.ndarray:
         shape = tuple([len(arrays)] + list(shape_in))
 
         # Find the common dtype for all inputs
-        dtype = np.find_common_type([arr.dtype for arr in arrays], [])
+        dtype = np.result_type(*arrays) 
 
         # Allocate an empty array of the right shape and type
         result = np.empty(shape, dtype=dtype, order="F")

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ addopts = --cov-report term-missing --cov librosa --cov-report=xml --mpl --mpl-b
 filterwarnings =
     ignore::DeprecationWarning:audioread.*
     ignore::DeprecationWarning:resampy.*
+    ignore::FutureWarning:librosa.*
 
 
 [flake8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ addopts = --cov-report term-missing --cov librosa --cov-report=xml --mpl --mpl-b
 filterwarnings =
     ignore::DeprecationWarning:audioread.*
     ignore::DeprecationWarning:resampy.*
-    ignore::FutureWarning:librosa.*
 
 
 [flake8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ filterwarnings =
     ignore::DeprecationWarning:audioread.*
     ignore::DeprecationWarning:resampy.*
 
-
 [flake8]
 count = True
 statistics = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,9 +9,11 @@ ignore = D107,D203,D205,D212,D213,D400,D402,D413,D415,D416,D417
 
 [tool:pytest]
 xfail_strict = true
-addopts = -W always --cov-report term-missing --cov librosa --cov-report=xml --mpl --mpl-baseline-path=tests/baseline_images/test_display
+addopts = --cov-report term-missing --cov librosa --cov-report=xml --mpl --mpl-baseline-path=tests/baseline_images/test_display
+# ignoring deprecation warnings from packages that we're phasing out anyway
 filterwarnings =
-	ignore:Using a non-tuple sequence:FutureWarning:scipy.*
+    ignore::DeprecationWarning:audioread.*
+    ignore::DeprecationWarning:resampy.*
 
 
 [flake8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,10 +8,11 @@ ignore = E203,W503
 ignore = D107,D203,D205,D212,D213,D400,D402,D413,D415,D416,D417
 
 [tool:pytest]
-addopts = --cov-report term-missing --cov librosa --cov-report=xml --disable-pytest-warnings --mpl --mpl-baseline-path=tests/baseline_images/test_display
 xfail_strict = true
+addopts = -W always --cov-report term-missing --cov librosa --cov-report=xml --mpl --mpl-baseline-path=tests/baseline_images/test_display
 filterwarnings =
-    ignore:Using a non-tuple sequence:FutureWarning:scipy.*
+	ignore:Using a non-tuple sequence:FutureWarning:scipy.*
+
 
 [flake8]
 count = True

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -235,6 +235,7 @@ def test_beat_units(ysr, hop_length, units, ctx):
 @pytest.mark.parametrize(
     "prior", [None, scipy.stats.lognorm(s=1, loc=np.log(120), scale=120)]
 )
+@pytest.mark.filterwarnings("ignore:n_fft=.*is too large")  # our test signal is short, but this is fine here
 def test_plp(ysr, hop_length, win_length, tempo_min, tempo_max, use_onset, prior, ctx):
 
     y, sr = ysr

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -184,14 +184,15 @@ def test_cqt(
 @pytest.mark.parametrize("bins_per_octave", [12])
 @pytest.mark.parametrize("n_bins", [88])
 def test_cqt_early_downsample(y_cqt_110, sr_cqt, n_bins, fmin, bins_per_octave):
-    C = librosa.cqt(
-        y=y_cqt_110,
-        sr=sr_cqt,
-        fmin=fmin,
-        n_bins=n_bins,
-        bins_per_octave=bins_per_octave,
-        res_type=None,
-    )
+    with pytest.warns(FutureWarning, match="Support for VQT with res_type=None"):
+        C = librosa.cqt(
+            y=y_cqt_110,
+            sr=sr_cqt,
+            fmin=fmin,
+            n_bins=n_bins,
+            bins_per_octave=bins_per_octave,
+            res_type=None,
+        )
 
     # type is complex
     assert np.iscomplexobj(C)

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -509,7 +509,9 @@ def test_hybrid_cqt_white_noise(y_white, sr_white, fmin, n_bins, scale):
     )
 
     if not scale:
-        lengths = librosa.filters.constant_q_lengths(sr=sr_white, fmin=fmin, n_bins=n_bins)
+        # lengths = librosa.filters.constant_q_lengths(sr=sr_white, fmin=fmin, n_bins=n_bins)
+        freqs = fmin * 2.0**(np.arange(n_bins) / 12)
+        lengths, _ = librosa.filters.wavelet_lengths(freqs=freqs, sr=sr_white)
         C /= np.sqrt(lengths[:, np.newaxis])
 
     assert np.allclose(np.mean(C, axis=1), 1.0, atol=2.5e-1), np.mean(C, axis=1)

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -124,7 +124,8 @@ def test_cqt_exceed_passband(y_cqt, sr_cqt, bpo):
 @pytest.mark.parametrize("res_type", ["polyphase"])
 @pytest.mark.parametrize("hop_length", [512, 2000])
 @pytest.mark.parametrize("sparsity", [0.01])
-@pytest.mark.filterwarnings("ignore:n_fft=.*is too large")
+@pytest.mark.filterwarnings("ignore:n_fft=.*is too large")  # this is fine here
+@pytest.mark.filterwarnings("ignore:Trying to estimate tuning")  # we can ignore this too
 def test_cqt(
     y_cqt_110,
     sr_cqt,
@@ -513,7 +514,6 @@ def test_hybrid_cqt_white_noise(y_white, sr_white, fmin, n_bins, scale):
     )
 
     if not scale:
-        # lengths = librosa.filters.constant_q_lengths(sr=sr_white, fmin=fmin, n_bins=n_bins)
         freqs = fmin * 2.0**(np.arange(n_bins) / 12)
         lengths, _ = librosa.filters.wavelet_lengths(freqs=freqs, sr=sr_white)
         C /= np.sqrt(lengths[:, np.newaxis])
@@ -538,6 +538,7 @@ def y_icqt(sr_icqt):
 @pytest.mark.parametrize("length", [None, True])
 @pytest.mark.parametrize("res_type", ["soxr_hq", "polyphase"])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
+@pytest.mark.filterwarnings("ignore:n_fft=.*is too large")  # our test signal is short; this is fine
 def test_icqt(y_icqt, sr_icqt, scale, hop_length, over_sample, length, res_type, dtype):
 
     bins_per_octave = over_sample * 12

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -124,6 +124,7 @@ def test_cqt_exceed_passband(y_cqt, sr_cqt, bpo):
 @pytest.mark.parametrize("res_type", ["polyphase"])
 @pytest.mark.parametrize("hop_length", [512, 2000])
 @pytest.mark.parametrize("sparsity", [0.01])
+@pytest.mark.filterwarnings("ignore:n_fft=.*is too large")
 def test_cqt(
     y_cqt_110,
     sr_cqt,
@@ -254,6 +255,7 @@ def test_icqt_odd_hop(y_cqt_110, sr_cqt):
 @pytest.mark.parametrize("res_type", ["polyphase"])
 @pytest.mark.parametrize("sparsity", [0.01])
 @pytest.mark.parametrize("hop_length", [512])
+@pytest.mark.filterwarnings("ignore:n_fft=.*is too large")
 def test_vqt(
     y_cqt_110,
     sr_cqt,
@@ -440,6 +442,7 @@ def y_impulse(sr_impulse, hop_impulse):
     return x
 
 
+@pytest.mark.filterwarnings("ignore:n_fft=.*is too large")
 def test_cqt_impulse(y_impulse, sr_impulse, hop_impulse):
     # Test to resolve issue #348
     # Updated in #417 to use integrated energy, rather than frame-wise max
@@ -454,6 +457,7 @@ def test_cqt_impulse(y_impulse, sr_impulse, hop_impulse):
     assert np.max(continuity) < 5e-4, continuity
 
 
+@pytest.mark.filterwarnings("ignore:n_fft=.*is too large")
 def test_hybrid_cqt_impulse(y_impulse, sr_impulse, hop_impulse):
     # Test to resolve issue #341
     # Updated in #417 to use integrated energy instead of pointwise max

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -490,7 +490,8 @@ def test_cqt_white_noise(y_white, sr_white, fmin, n_bins, scale):
     )
 
     if not scale:
-        lengths = librosa.filters.constant_q_lengths(sr=sr_white, fmin=fmin, n_bins=n_bins)
+        freqs = librosa.cqt_frequencies(fmin=fmin, n_bins=n_bins)
+        lengths, _ = librosa.filters.wavelet_lengths(sr=sr_white, freqs=freqs)
         C /= np.sqrt(lengths[:, np.newaxis])
 
     # Only compare statistics across the time dimension

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -601,6 +601,7 @@ def y_chirp():
 @pytest.mark.parametrize("fmin", [40.0])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 @pytest.mark.parametrize("init", [None])
+@pytest.mark.filterwarnings("ignore:n_fft=.*is too large")
 def test_griffinlim_cqt(
     y_chirp,
     hop_length,
@@ -681,6 +682,7 @@ def test_griffinlim_cqt(
 
 
 @pytest.mark.parametrize("momentum", [0, 0.95])
+@pytest.mark.filterwarnings("ignore:n_fft=.*is too large")
 def test_griffinlim_cqt_momentum(y_chirp, momentum):
 
     C = librosa.cqt(y=y_chirp, sr=22050, res_type="polyphase")
@@ -692,6 +694,7 @@ def test_griffinlim_cqt_momentum(y_chirp, momentum):
 
 
 @pytest.mark.parametrize("random_state", [None, 0, np.random.RandomState()])
+@pytest.mark.filterwarnings("ignore:n_fft=.*is too large")
 def test_griffinlim_cqt_rng(y_chirp, random_state):
 
     C = librosa.cqt(y=y_chirp, sr=22050, res_type="polyphase")
@@ -703,6 +706,7 @@ def test_griffinlim_cqt_rng(y_chirp, random_state):
 
 
 @pytest.mark.parametrize("init", [None, "random"])
+@pytest.mark.filterwarnings("ignore:n_fft=.*is too large")
 def test_griffinlim_cqt_init(y_chirp, init):
     C = librosa.cqt(y=y_chirp, sr=22050, res_type="polyphase")
     y_rec = librosa.griffinlim_cqt(
@@ -713,12 +717,14 @@ def test_griffinlim_cqt_init(y_chirp, init):
 
 
 @pytest.mark.xfail(raises=librosa.ParameterError)
+@pytest.mark.filterwarnings("ignore:n_fft=.*is too large")
 def test_griffinlim_cqt_badinit():
     x = np.zeros((33, 3))
     librosa.griffinlim_cqt(x, init="garbage")
 
 
 @pytest.mark.xfail(raises=librosa.ParameterError)
+@pytest.mark.filterwarnings("ignore:n_fft=.*is too large")
 def test_griffinlim_cqt_badrng():
     x = np.zeros((33, 3))
     librosa.griffinlim_cqt(x, random_state="garbage")  # type: ignore

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -965,7 +965,7 @@ def test_get_duration_mp3():
 
 @pytest.mark.xfail(raises=librosa.ParameterError)
 def test_get_duration_fail():
-    librosa.get_duration(y=None, S=None, filename=None)
+    librosa.get_duration(y=None, S=None, path=None)
 
 
 @pytest.mark.parametrize(
@@ -1339,10 +1339,11 @@ def test_estimate_tuning(sr, center_note: int, tuning: np.float_, bins_per_octav
 @pytest.mark.parametrize("resolution", [1e-2])
 @pytest.mark.parametrize("bins_per_octave", [12])
 def test_estimate_tuning_null(y, sr, resolution, bins_per_octave):
-    tuning_est = librosa.estimate_tuning(
-        resolution=resolution, bins_per_octave=bins_per_octave, y=y, sr=sr
-    )
-    assert np.allclose(tuning_est, 0)
+    with pytest.warns(UserWarning, match="Trying to estimate tuning"):
+        tuning_est = librosa.estimate_tuning(
+            resolution=resolution, bins_per_octave=bins_per_octave, y=y, sr=sr
+        )
+        assert np.allclose(tuning_est, 0)
 
 
 @pytest.mark.parametrize("n_fft", [1024, 755, 2048, 2049])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -74,6 +74,7 @@ def test_load_soundfile():
     assert np.isclose(sr, sr2)
 
 
+@pytest.mark.filterwarnings("ignore:librosa.core.audio.__audioread_load")
 def test_load_audioread():
     fname = os.path.join("tests", "data", "test1_44100.wav")
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1402,7 +1402,13 @@ def test__spectrogram_no_nfft():
 @pytest.mark.parametrize("top_db", [None, 0, 40, 80])
 def test_power_to_db(x, ref, amin, top_db):
 
-    y = librosa.power_to_db(x, ref=ref, amin=amin, top_db=top_db)
+    if np.iscomplexobj(x):
+        with warnings.catch_warnings(record=True) as out:
+            y = librosa.power_to_db(x, ref=ref, amin=amin, top_db=top_db)
+            assert len(out) > 0
+            assert "power_to_db was called on complex input" in str(out[0].message).lower()
+    else:
+        y = librosa.power_to_db(x, ref=ref, amin=amin, top_db=top_db)
 
     assert np.isrealobj(y)
     assert y.shape == x.shape

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2509,6 +2509,7 @@ def test_load_force_audioread():
         assert "audioread" in str(out[0].message).lower()
 
 
+@pytest.mark.filterwarnings("ignore:PySoundFile failed")
 def test_get_duration_audioread():
     path = os.path.join("tests", "data", "test2_8000.mkv")
     duration = librosa.get_duration(path=path)
@@ -2516,6 +2517,7 @@ def test_get_duration_audioread():
     assert duration == 30.2
 
 
+@pytest.mark.filterwarnings("ignore:PySoundFile failed")
 def test_get_samplerate_audioread():
     path = os.path.join("tests", "data", "test2_8000.mkv")
     sr = librosa.get_samplerate(path=path)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2213,7 +2213,6 @@ def test_griffinlim(
         n_fft=n_fft,
         window=window,
         center=center,
-        dtype=dtype,
         pad_mode=pad_mode,
     )
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -481,11 +481,9 @@ def test___reassign_times(sr, n_fft):
     expected_times = librosa.samples_to_time(impulse_indices, sr=sr)
     expected[:, expected_bins] = np.tile(expected_times, (n_fft // 2 + 1, 1))
 
-    # ignore divide-by-zero warnings for frames with no energy
-    with warnings.catch_warnings(record=True):
-        times, S = librosa.core.spectrum.__reassign_times(
-            y=y, sr=sr, n_fft=n_fft, hop_length=n_fft, center=False
-        )
+    times, S = librosa.core.spectrum.__reassign_times(
+        y=y, sr=sr, n_fft=n_fft, hop_length=n_fft, center=False
+    )
 
     # times should be reassigned within 0.5% of the window duration
     assert np.allclose(times, expected, atol=0.005 * n_fft / sr, equal_nan=True)
@@ -498,11 +496,9 @@ def test___reassign_times_center():
     sr = 4000
     n_fft = 2048
 
-    # ignore divide-by-zero warnings for frames with no energy
-    with warnings.catch_warnings(record=True):
-        times, S = librosa.core.spectrum.__reassign_times(
-            y=y, sr=sr, hop_length=n_fft, win_length=n_fft, center=True
-        )
+    times, S = librosa.core.spectrum.__reassign_times(
+        y=y, sr=sr, hop_length=n_fft, win_length=n_fft, center=True
+    )
 
     expected = np.full_like(times, np.nan)
     expected[:, 1] = 2049 / float(sr)
@@ -1404,10 +1400,8 @@ def test__spectrogram_no_nfft():
 def test_power_to_db(x, ref, amin, top_db):
 
     if np.iscomplexobj(x):
-        with warnings.catch_warnings(record=True) as out:
+        with pytest.warns(UserWarning, match="power_to_db was called on complex input"):
             y = librosa.power_to_db(x, ref=ref, amin=amin, top_db=top_db)
-            assert len(out) > 0
-            assert "power_to_db was called on complex input" in str(out[0].message).lower()
     else:
         y = librosa.power_to_db(x, ref=ref, amin=amin, top_db=top_db)
 
@@ -1459,10 +1453,8 @@ def test_amplitude_to_db_complex():
     # Make some noise
     x = np.abs(np.random.randn(1000)) + NOISE_FLOOR
 
-    with warnings.catch_warnings(record=True) as out:
+    with pytest.warns(UserWarning, match="amplitude_to_db was called on complex input"):
         db1 = librosa.amplitude_to_db(x.astype(complex), top_db=None)
-        assert len(out) > 0
-        assert "complex" in str(out[0].message).lower()
 
     db2 = librosa.power_to_db(x**2, top_db=None)
 

--- a/tests/test_decompose.py
+++ b/tests/test_decompose.py
@@ -62,7 +62,6 @@ def test_decompose_fit():
 
 
 @pytest.mark.xfail(raises=librosa.ParameterError)
-@pytest.mark.filterwarnings("ignore:Maximum number of iterations")
 def test_decompose_multi_sort():
     librosa.decompose.decompose(np.zeros((3,3,3)), sort=True)
 

--- a/tests/test_decompose.py
+++ b/tests/test_decompose.py
@@ -62,10 +62,12 @@ def test_decompose_fit():
 
 
 @pytest.mark.xfail(raises=librosa.ParameterError)
+@pytest.mark.filterwarnings("ignore:Maximum number of iterations")
 def test_decompose_multi_sort():
     librosa.decompose.decompose(np.zeros((3,3,3)), sort=True)
 
 
+@pytest.mark.filterwarnings("ignore:Maximum number of iterations")
 def test_decompose_multi():
     srand()
     X = np.random.random_sample(size=(2, 20, 100))

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -636,7 +636,7 @@ def test_waveshow_stereo(y, sr):
 def test_unknown_wavaxis(y, sr):
 
     plt.figure()
-    librosa.display.waveshow(y, sr=sr, x_axis="something not in the axis map")
+    librosa.display.waveshow(y, sr=sr, axis="something not in the axis map")
     return plt.gcf()
 
 
@@ -644,7 +644,7 @@ def test_unknown_wavaxis(y, sr):
 def test_waveshow_unknown_wavaxis(y, sr):
 
     plt.figure()
-    librosa.display.waveshow(y, sr=sr, x_axis="something not in the axis map")
+    librosa.display.waveshow(y, sr=sr, axis="something not in the axis map")
     return plt.gcf()
 
 
@@ -719,7 +719,7 @@ def test_sharex_specshow_ms(S_abs, y, sr):
                              x_axis="time", ax=ax)
     ax.set(xlabel="")  # hide the x label here, which is not propagated automatically
     ax2.margins(x=0)
-    librosa.display.waveshow(y, sr=sr, x_axis="ms", ax=ax2)
+    librosa.display.waveshow(y, sr=sr, axis="ms", ax=ax2)
     ax2.set(xlabel="")  # hide the x label here, which is not propagated automatically
     return fig
 

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -177,6 +177,7 @@ def test_tempo(y, sr):
     baseline_images=["fourier_tempo"], extensions=["png"], tolerance=6, style=STYLE
 )
 @pytest.mark.xfail(OLD_FT, reason=f"freetype version < {FT_VERSION}", strict=False)
+@pytest.mark.filterwarnings("ignore:n_fft=.*is too large")  # our test signal is short, but this is fine here
 def test_fourier_tempo(y, sr):
     T = librosa.feature.fourier_tempogram(y=y, sr=sr)
 

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -118,7 +118,8 @@ def test_unknown_time_unit(y):
 @pytest.mark.xfail(OLD_FT, reason=f"freetype version < {FT_VERSION}", strict=False)
 def test_complex_input(S):
     plt.figure()
-    librosa.display.specshow(S)
+    with pytest.warns(UserWarning, match="Trying to display complex"):
+        librosa.display.specshow(S)
     return plt.gcf()
 
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -663,6 +663,7 @@ def test_fourier_tempogram_fail_noinput():
 
 
 @pytest.mark.parametrize("hop_length", [512, 1024])
+@pytest.mark.filterwarnings("ignore:n_fft=.*is too large")  # our test signal is short, but this is fine here
 def test_fourier_tempogram_audio(y_ex, hop_length):
     y, sr = y_ex
     oenv = librosa.onset.onset_strength(y=y, sr=sr, hop_length=hop_length)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -373,7 +373,7 @@ def test_constant_q_badparams(sr, fmin, n_bins, bins_per_octave, filter_scale, n
 def test_window_bandwidth():
 
     hann_bw = librosa.filters.window_bandwidth("hann")
-    hann_scipy_bw = librosa.filters.window_bandwidth(scipy.signal.hann)
+    hann_scipy_bw = librosa.filters.window_bandwidth(scipy.signal.windows.hann)
     assert hann_bw == hann_scipy_bw
 
 
@@ -483,7 +483,7 @@ def test_get_window_func():
 
 
 @pytest.mark.parametrize(
-    "pre_win", [scipy.signal.hann(16), list(scipy.signal.hann(16)), [1, 1, 1]]
+    "pre_win", [scipy.signal.windows.hann(16), list(scipy.signal.windows.hann(16)), [1, 1, 1]]
 )
 def test_get_window_pre(pre_win):
     win = librosa.filters.get_window(pre_win, len(pre_win))

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -99,7 +99,7 @@ def test_melfb(infile):
 
     # Our version only returns the real-valued part.
     # Pad out.
-    wts = np.pad(wts, [(0, 0), (0, int(DATA["nfft"][0] // 2 - 1))], mode="constant")
+    wts = np.pad(wts, [(0, 0), (0, DATA["nfft"][0, 0] // 2 - 1)], mode="constant")
 
     assert wts.shape == DATA["wts"].shape
     assert np.allclose(wts, DATA["wts"])
@@ -125,7 +125,7 @@ def test_melfbnorm(infile):
         norm=norm,
     )
     # Pad out.
-    wts = np.pad(wts, [(0, 0), (0, int(DATA["nfft"][0] // 2 - 1))], mode="constant")
+    wts = np.pad(wts, [(0, 0), (0, DATA["nfft"][0, 0] // 2 - 1)], mode="constant")
 
     assert wts.shape == DATA["wts"].shape
     assert np.allclose(wts, DATA["wts"])
@@ -191,7 +191,7 @@ def test_chromafb(infile):
 
     # Our version only returns the real-valued part.
     # Pad out.
-    wts = np.pad(wts, [(0, 0), (0, int(DATA["nfft"][0, 0] // 2 - 1))], mode="constant")
+    wts = np.pad(wts, [(0, 0), (0, DATA["nfft"][0, 0] // 2 - 1)], mode="constant")
 
     assert wts.shape == DATA["wts"].shape
     assert np.allclose(wts, DATA["wts"])

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -20,6 +20,7 @@ except KeyError:
     pass
 
 from contextlib import nullcontext as dnr
+import warnings
 import glob
 import numpy as np
 import scipy.io
@@ -257,15 +258,19 @@ def test__window(n, window_name):
 @pytest.mark.parametrize("pad_fft", [False, True])
 def test_constant_q(sr, fmin, n_bins, bins_per_octave, filter_scale, pad_fft, norm):
 
-    F, lengths = librosa.filters.constant_q(
-        sr=sr,
-        fmin=fmin,
-        n_bins=n_bins,
-        bins_per_octave=bins_per_octave,
-        filter_scale=filter_scale,
-        pad_fft=pad_fft,
-        norm=norm,
-    )
+    with warnings.catch_warnings(record=True) as out:
+        F, lengths = librosa.filters.constant_q(
+            sr=sr,
+            fmin=fmin,
+            n_bins=n_bins,
+            bins_per_octave=bins_per_octave,
+            filter_scale=filter_scale,
+            pad_fft=pad_fft,
+            norm=norm,
+        )
+
+        assert len(out) > 0
+        assert "Deprecated" in str(out[0].message)
 
     assert np.all(lengths <= F.shape[1])
 
@@ -359,15 +364,19 @@ def test_wavelet_lengths_noalpha():
     ],
 )
 def test_constant_q_badparams(sr, fmin, n_bins, bins_per_octave, filter_scale, norm):
-    librosa.filters.constant_q(
-        sr=sr,
-        fmin=fmin,
-        n_bins=n_bins,
-        bins_per_octave=bins_per_octave,
-        filter_scale=filter_scale,
-        pad_fft=True,
-        norm=norm,
-    )
+    with warnings.catch_warnings(record=True) as out:
+        librosa.filters.constant_q(
+            sr=sr,
+            fmin=fmin,
+            n_bins=n_bins,
+            bins_per_octave=bins_per_octave,
+            filter_scale=filter_scale,
+            pad_fft=True,
+            norm=norm,
+        )
+
+        assert len(out) > 0
+        assert "Deprecated" in str(out[0].message)
 
 
 def test_window_bandwidth():

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -85,6 +85,7 @@ def test_hz_to_octs(infile):
 @pytest.mark.parametrize(
     "infile", files(os.path.join("tests", "data", "feature-melfb-*.mat"))
 )
+@pytest.mark.filterwarnings("ignore:Empty filters detected")
 def test_melfb(infile):
 
     DATA = load(infile)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -477,7 +477,7 @@ def test_get_window(window):
 
 def test_get_window_func():
 
-    w1 = librosa.filters.get_window(scipy.signal.boxcar, 32)
+    w1 = librosa.filters.get_window(scipy.signal.windows.boxcar, 32)
     w2 = scipy.signal.get_window("boxcar", 32)
     assert np.allclose(w1, w2)
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -259,7 +259,7 @@ def test__window(n, window_name):
 @pytest.mark.parametrize("pad_fft", [False, True])
 def test_constant_q(sr, fmin, n_bins, bins_per_octave, filter_scale, pad_fft, norm):
 
-    with warnings.catch_warnings(record=True) as out:
+    with pytest.warns(FutureWarning, match="Deprecated"):
         F, lengths = librosa.filters.constant_q(
             sr=sr,
             fmin=fmin,
@@ -269,9 +269,6 @@ def test_constant_q(sr, fmin, n_bins, bins_per_octave, filter_scale, pad_fft, no
             pad_fft=pad_fft,
             norm=norm,
         )
-
-        assert len(out) > 0
-        assert "Deprecated" in str(out[0].message)
 
     assert np.all(lengths <= F.shape[1])
 
@@ -365,7 +362,7 @@ def test_wavelet_lengths_noalpha():
     ],
 )
 def test_constant_q_badparams(sr, fmin, n_bins, bins_per_octave, filter_scale, norm):
-    with warnings.catch_warnings(record=True) as out:
+    with pytest.warns(FutureWarning, match="Deprecated"):
         librosa.filters.constant_q(
             sr=sr,
             fmin=fmin,
@@ -375,9 +372,6 @@ def test_constant_q_badparams(sr, fmin, n_bins, bins_per_octave, filter_scale, n
             pad_fft=True,
             norm=norm,
         )
-
-        assert len(out) > 0
-        assert "Deprecated" in str(out[0].message)
 
 
 def test_window_bandwidth():

--- a/tests/test_met_features.py
+++ b/tests/test_met_features.py
@@ -31,7 +31,7 @@ def met_stft(y, n_fft, hop_length, win_length, normalize):
             n_fft=n_fft,
             hop_length=hop_length,
             win_length=win_length,
-            window=scipy.signal.hamming,
+            window=scipy.signal.windows.hamming,
             center=False,
         )
     )

--- a/tests/test_multichannel.py
+++ b/tests/test_multichannel.py
@@ -351,9 +351,9 @@ def test_icqt_multi(y_multi, scale, length):
     if length is not None:
         assert yboth.shape[-1] == length
 
-    # Check each channel
-    assert np.allclose(yboth[0], y0), np.max(np.abs(yboth[0] - y0))
-    assert np.allclose(yboth[1], y1), np.max(np.abs(yboth[1] - y1))
+    # Check each channel - slightly relaxed tolerance here
+    assert np.allclose(yboth[0], y0, atol=1e-6), np.max(np.abs(yboth[0] - y0))
+    assert np.allclose(yboth[1], y1, atol=1e-6), np.max(np.abs(yboth[1] - y1))
 
     # Check that they're not the same
     assert not np.allclose(yboth[0], yboth[1])

--- a/tests/test_multichannel.py
+++ b/tests/test_multichannel.py
@@ -320,6 +320,7 @@ def test_cqt_multi(y_multi, scale, res_type):
 
 @pytest.mark.parametrize("scale", [False, True])
 @pytest.mark.parametrize("res_type", [None, "polyphase"])
+@pytest.mark.filterwarnings("ignore:Support for VQT with res_type=None")
 def test_hybrid_cqt_multi(y_multi, scale, res_type):
 
     y, sr = y_multi

--- a/tests/test_multichannel.py
+++ b/tests/test_multichannel.py
@@ -352,8 +352,8 @@ def test_icqt_multi(y_multi, scale, length):
         assert yboth.shape[-1] == length
 
     # Check each channel
-    assert np.allclose(yboth[0], y0)
-    assert np.allclose(yboth[1], y1)
+    assert np.allclose(yboth[0], y0), np.max(np.abs(yboth[0] - y0))
+    assert np.allclose(yboth[1], y1), np.max(np.abs(yboth[1] - y1))
 
     # Check that they're not the same
     assert not np.allclose(yboth[0], yboth[1])

--- a/tests/test_multichannel.py
+++ b/tests/test_multichannel.py
@@ -299,6 +299,8 @@ def test_griffinlim_multi(y_multi):
 
 @pytest.mark.parametrize("scale", [False, True])
 @pytest.mark.parametrize("res_type", [None, "polyphase"])
+# The following warning is fine in context here
+@pytest.mark.filterwarnings("ignore:Support for VQT with res_type=None")
 def test_cqt_multi(y_multi, scale, res_type):
 
     y, sr = y_multi

--- a/tests/test_multichannel.py
+++ b/tests/test_multichannel.py
@@ -531,6 +531,8 @@ def test_poly_multi_static(s_multi):
     assert not np.allclose(P0, P1)
 
 
+# Not worried about polyfit conditioning for this test
+@pytest.mark.filterwarnings("ignore:Polyfit may be poorly conditioned")
 def test_poly_multi_varying(tfr_multi):
 
     # Get some time-varying frequencies
@@ -755,6 +757,8 @@ def test_interp_harmonics_multi_static(s_multi):
     assert not np.allclose(H0, H1)
 
 
+# Not worried about this warning here
+@pytest.mark.filterwarnings("ignore:Frequencies are not unique")
 def test_interp_harmonics_multi_vary(tfr_multi):
     times, freqs, mags = tfr_multi
 
@@ -805,6 +809,8 @@ def test_salience_multi_static(s_multi, filter_peaks):
 
 
 @pytest.mark.parametrize("filter_peaks", [False, True])
+# Not worried about this warning here
+@pytest.mark.filterwarnings("ignore:Frequencies are not unique")
 def test_salience_multi_dynamic(tfr_multi, filter_peaks):
     times, freqs, S = tfr_multi
 
@@ -1040,6 +1046,8 @@ def test_resample_highdim_axis(x, axis, res_type):
 
 
 @pytest.mark.parametrize('dynamic', [False, True])
+# Not worried about this warning here
+@pytest.mark.filterwarnings("ignore:Frequencies are not unique")
 def test_f0_harmonics(y_multi, dynamic):
 
     y, sr = y_multi

--- a/tests/test_segment.py
+++ b/tests/test_segment.py
@@ -378,6 +378,8 @@ def test_recurrence_to_lag_fail(size):
     "rec", [librosa.segment.recurrence_matrix(np.random.randn(3, 100), sparse=True)]
 )
 @pytest.mark.parametrize("fmt", ["csc", "csr", "lil", "bsr", "dia"])
+# This warning is expected when using fmt='dia'
+@pytest.mark.filterwarnings("ignore:Constructing a DIA matrix")
 def test_recurrence_to_lag_sparse(pad, axis, rec, fmt):
 
     rec_dense = rec.toarray()

--- a/tests/test_segment.py
+++ b/tests/test_segment.py
@@ -85,7 +85,7 @@ def test_cross_similarity_affinity(metric, bandwidth):
     i, j, vals = scipy.sparse.find(rec)
     logvals = np.log(vals)
 
-    ratio = -logvals / distance[i, j]
+    ratio = -logvals / (distance[i, j] + librosa.util.tiny(distance))
 
     if bandwidth is None:
         assert np.allclose(-logvals, distance[i, j] * np.nanmax(ratio))
@@ -255,7 +255,7 @@ def test_recurrence_affinity(metric, bandwidth, self):
     logvals = np.log(vals)
 
     # After log-scaling, affinity will match distance up to a constant factor
-    ratio = -logvals / distance[i, j]
+    ratio = -logvals / (distance[i, j] + librosa.util.tiny(distance))
     if bandwidth is None:
         # Estimate the global bandwidth using non-zero distances
         assert np.allclose(-logvals, distance[i, j] * np.nanmax(ratio))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -748,20 +748,11 @@ def test_warning_deprecated():
     def __placeholder():
         return True
 
-    with warnings.catch_warnings(record=True) as out:
+    with pytest.warns(FutureWarning, match="Deprecated"):
         x = __placeholder()
 
         # Make sure we still get the right value
         assert x is True
-
-        # And that the warning triggered
-        assert len(out) > 0
-
-        # And that the category is correct
-        assert out[0].category is FutureWarning
-
-        # And that it says the right thing (roughly)
-        assert "deprecated" in str(out[0].message).lower()
 
 
 def test_warning_moved():
@@ -804,19 +795,10 @@ def test_warning_rename_kw_fail():
     ov = 27
     nv = 23
 
-    with warnings.catch_warnings(record=True) as out:
+    with pytest.warns(FutureWarning, match="renamed"):
         v = librosa.util.rename_kw(old_name="old", old_value=ov, new_name="new", new_value=nv, version_deprecated="0", version_removed="1")
 
         assert v == ov
-
-        # Make sure the warning triggered
-        assert len(out) > 0
-
-        # And that the category is correct
-        assert out[0].category is FutureWarning
-
-        # And that it says the right thing (roughly)
-        assert "renamed" in str(out[0].message).lower()
 
 
 @pytest.mark.parametrize("idx", [np.arange(10, 90, 10), np.arange(10, 90, 15)])


### PR DESCRIPTION
#### Reference Issue

Our test suite currently triggers a pretty large number of warnings.  These are currently suppressed, making it difficult to identify futurewarnings (and other things we should keep tabs on) up front.

#### What does this implement/fix? Explain your changes.

This PR changes the pytest config to dump warnings out in the log.  After that, I'll go through and clean up whatever deprecated usages I can find.

#### Any other comments?

