### PR TITLE
Explicitly allow scalars in decibel conversion

### DIFF
--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Utilities for spectral processing"""
+from __future__ import annotations
 import warnings
 
 import numpy as np

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1821,9 +1821,33 @@ def power_to_db(
     return log_spec
 
 
+@overload
+def db_to_power(
+    S_db: np.floating[Any],
+    *,
+    ref: float = ...,
+) -> np.floating[Any]:
+    ...
+
+@overload
+def db_to_power(
+        S_db: np.ndarray,
+    *,
+    ref: float = ...,
+) -> np.ndarray:
+    ...
+
+@overload
+def db_to_power(
+    S_db: Union[np.floating[Any], np.ndarray],
+    *,
+    ref: float = ...,
+) -> Union[np.floating[Any], np.ndarray]:
+    ...
+
 @cache(level=30)
-def db_to_power(S_db: np.ndarray, *, ref: float = 1.0) -> np.ndarray:
-    """Convert a dB-scale spectrogram to a power spectrogram.
+def db_to_power(S_db: Union[np.floating[Any], np.ndarray], *, ref: float = 1.0) -> Union[np.floating[Any], np.ndarray]:
+    """Convert dB-scale values to a power values.
 
     This effectively inverts ``power_to_db``::
 
@@ -1832,20 +1856,20 @@ def db_to_power(S_db: np.ndarray, *, ref: float = 1.0) -> np.ndarray:
     Parameters
     ----------
     S_db : np.ndarray
-        dB-scaled spectrogram
+        dB-scaled values
     ref : number > 0
         Reference power: output will be scaled by this value
 
     Returns
     -------
     S : np.ndarray
-        Power spectrogram
+        Power values
 
     Notes
     -----
     This function caches at level 30.
     """
-    return ref * np.power(10.0, 0.1 * S_db)
+    return ref * np.power(10.0, S_db * 0.1)
 
 
 @overload
@@ -1948,8 +1972,32 @@ def amplitude_to_db(
     return db
 
 
+@overload
+def db_to_amplitude(
+    S_db: np.floating[Any],
+    *,
+    ref: float = ...,
+) -> np.floating[Any]:
+    ...
+
+@overload
+def db_to_amplitude(
+    S_db: np.ndarray,
+    *,
+    ref: float = ...,
+) -> np.ndarray:
+    ...
+
+@overload
+def db_to_amplitude(
+    S_db: Union[np.floating[Any], np.ndarray],
+    *,
+    ref: float = ...,
+) -> Union[np.floating[Any], np.ndarray]:
+    ...
+
 @cache(level=30)
-def db_to_amplitude(S_db: np.ndarray, *, ref: float = 1.0) -> np.ndarray:
+def db_to_amplitude(S_db: Union[np.floating[Any], np.ndarray], *, ref: float = 1.0) -> Union[np.floating[Any], np.ndarray]:
     """Convert a dB-scaled spectrogram to an amplitude spectrogram.
 
     This effectively inverts `amplitude_to_db`::
@@ -1959,14 +2007,14 @@ def db_to_amplitude(S_db: np.ndarray, *, ref: float = 1.0) -> np.ndarray:
     Parameters
     ----------
     S_db : np.ndarray
-        dB-scaled spectrogram
+        dB-scaled values
     ref : number > 0
-        Optional reference power.
+        Optional reference amplitude.
 
     Returns
     -------
     S : np.ndarray
-        Linear magnitude spectrogram
+        Linear magnitude values
 
     Notes
     -----

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -22,7 +22,14 @@ from ..filters import window_sumsquare
 from numpy.typing import DTypeLike
 from typing import Any, Callable, Optional, Tuple, List, Union, overload
 from typing_extensions import Literal
-from .._typing import _WindowSpec, _PadMode, _PadModeSTFT
+from .._typing import (
+    _WindowSpec,
+    _PadMode,
+    _PadModeSTFT,
+    _SequenceLike,
+    _ScalarOrSequence,
+    _ComplexLike_co
+)
 
 __all__ = [
     "stft",
@@ -1810,14 +1817,44 @@ def db_to_power(S_db: np.ndarray, *, ref: float = 1.0) -> np.ndarray:
     return ref * np.power(10.0, 0.1 * S_db)
 
 
+@overload
+def amplitude_to_db(
+    S: _ComplexLike_co,
+    *,
+    ref: Union[float, Callable] = ...,
+    amin: float = ...,
+    top_db: Optional[float] = ...,
+) -> np.floating[Any]:
+    ...
+
+@overload
+def amplitude_to_db(
+    S: _SequenceLike[_ComplexLike_co],
+    *,
+    ref: Union[float, Callable] = ...,
+    amin: float = ...,
+    top_db: Optional[float] = ...,
+) -> np.ndarray:
+    ...
+
+@overload
+def amplitude_to_db(
+    S: _ScalarOrSequence[_ComplexLike_co],
+    *,
+    ref: Union[float, Callable] = ...,
+    amin: float = ...,
+    top_db: Optional[float] = ...,
+) -> Union[np.floating[Any], np.ndarray]:
+    ...
+
 @cache(level=30)
 def amplitude_to_db(
-    S: np.ndarray,
+    S: _ScalarOrSequence[_ComplexLike_co],
     *,
     ref: Union[float, Callable] = 1.0,
     amin: float = 1e-5,
     top_db: Optional[float] = 80.0,
-) -> np.ndarray:
+) -> Union[np.floating[Any], np.ndarray]:
     """Convert an amplitude spectrogram to dB-scaled spectrogram.
 
     This is equivalent to ``power_to_db(S**2, ref=ref**2, amin=amin**2, top_db=top_db)``,

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1873,7 +1873,8 @@ def amplitude_to_db(
     else:
         ref_value = np.abs(ref)
 
-    power = np.square(magnitude, out=magnitude)
+    out_array = magnitude if isinstance(magnitude, np.ndarray) else None
+    power = np.square(magnitude, out=out_array)
 
     return power_to_db(power, ref=ref_value**2, amin=amin**2, top_db=top_db)
 

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1944,7 +1944,8 @@ def amplitude_to_db(
     out_array = magnitude if isinstance(magnitude, np.ndarray) else None
     power = np.square(magnitude, out=out_array)
 
-    return power_to_db(power, ref=ref_value**2, amin=amin**2, top_db=top_db)
+    db: np.ndarray = power_to_db(power, ref=ref_value**2, amin=amin**2, top_db=top_db)
+    return db
 
 
 @cache(level=30)

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -29,7 +29,8 @@ from .._typing import (
     _PadModeSTFT,
     _SequenceLike,
     _ScalarOrSequence,
-    _ComplexLike_co
+    _ComplexLike_co,
+    _FloatLike_co
 )
 
 __all__ = [
@@ -1823,7 +1824,7 @@ def power_to_db(
 
 @overload
 def db_to_power(
-    S_db: np.floating[Any],
+    S_db: _FloatLike_co,
     *,
     ref: float = ...,
 ) -> np.floating[Any]:
@@ -1839,14 +1840,14 @@ def db_to_power(
 
 @overload
 def db_to_power(
-    S_db: Union[np.floating[Any], np.ndarray],
+    S_db: Union[_FloatLike_co, np.ndarray],
     *,
     ref: float = ...,
 ) -> Union[np.floating[Any], np.ndarray]:
     ...
 
 @cache(level=30)
-def db_to_power(S_db: Union[np.floating[Any], np.ndarray], *, ref: float = 1.0) -> Union[np.floating[Any], np.ndarray]:
+def db_to_power(S_db: Union[_FloatLike_co, np.ndarray], *, ref: float = 1.0) -> Union[np.floating[Any], np.ndarray]:
     """Convert dB-scale values to a power values.
 
     This effectively inverts ``power_to_db``::
@@ -1974,7 +1975,7 @@ def amplitude_to_db(
 
 @overload
 def db_to_amplitude(
-    S_db: np.floating[Any],
+    S_db: _FloatLike_co,
     *,
     ref: float = ...,
 ) -> np.floating[Any]:
@@ -1990,14 +1991,14 @@ def db_to_amplitude(
 
 @overload
 def db_to_amplitude(
-    S_db: Union[np.floating[Any], np.ndarray],
+    S_db: Union[_FloatLike_co, np.ndarray],
     *,
     ref: float = ...,
 ) -> Union[np.floating[Any], np.ndarray]:
     ...
 
 @cache(level=30)
-def db_to_amplitude(S_db: Union[np.floating[Any], np.ndarray], *, ref: float = 1.0) -> Union[np.floating[Any], np.ndarray]:
+def db_to_amplitude(S_db: Union[_FloatLike_co, np.ndarray], *, ref: float = 1.0) -> Union[np.floating[Any], np.ndarray]:
     """Convert a dB-scaled spectrogram to an amplitude spectrogram.
 
     This effectively inverts `amplitude_to_db`::

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1663,14 +1663,44 @@ def iirt(
     return bands_power
 
 
+@overload
+def power_to_db(
+    S: _ComplexLike_co,
+    *,
+    ref: Union[float, Callable] = ...,
+    amin: float = ...,
+    top_db: Optional[float] = ...,
+) -> np.floating[Any]:
+    ...
+
+@overload
+def power_to_db(
+    S: _SequenceLike[_ComplexLike_co],
+    *,
+    ref: Union[float, Callable] = ...,
+    amin: float = ...,
+    top_db: Optional[float] = ...,
+) -> np.ndarray:
+    ...
+
+@overload
+def power_to_db(
+    S: _ScalarOrSequence[_ComplexLike_co],
+    *,
+    ref: Union[float, Callable] = ...,
+    amin: float = ...,
+    top_db: Optional[float] = ...,
+) -> Union[np.floating[Any], np.ndarray]:
+    ...
+
 @cache(level=30)
 def power_to_db(
-    S: np.ndarray,
+    S: _ScalarOrSequence[_ComplexLike_co],
     *,
     ref: Union[float, Callable] = 1.0,
     amin: float = 1e-10,
     top_db: Optional[float] = 80.0,
-) -> np.ndarray:
+) -> Union[np.floating[Any], np.ndarray]:
     """Convert a power spectrogram (amplitude squared) to decibel (dB) units
 
     This computes the scaling ``10 * log10(S / ref)`` in a numerically

--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -448,7 +448,7 @@ def _signal_to_frame_nonsilent(
     mse = feature.rms(y=y, frame_length=frame_length, hop_length=hop_length)
 
     # Convert to decibels and slice out the mse channel
-    db = core.amplitude_to_db(mse[..., 0, :], ref=ref, top_db=None)
+    db: np.ndarray = core.amplitude_to_db(mse[..., 0, :], ref=ref, top_db=None)
 
     # Aggregate everything but the time dimension
     if db.ndim > 1:

--- a/librosa/feature/inverse.py
+++ b/librosa/feature/inverse.py
@@ -276,7 +276,8 @@ def mfcc_to_mel(
         raise ParameterError("MFCC to mel lifter must be a non-negative number.")
 
     logmel = scipy.fftpack.idct(mfcc, axis=-2, type=dct_type, norm=norm, n=n_mels)
-    return db_to_power(logmel, ref=ref)
+    melspec: np.ndarray = db_to_power(logmel, ref=ref)
+    return melspec
 
 
 def mfcc_to_audio(

--- a/librosa/onset.py
+++ b/librosa/onset.py
@@ -560,6 +560,9 @@ def onset_strength_multi(
         # Convert to dBs
         S = core.power_to_db(S)
 
+    # Assertion to make type checking happy
+    assert S is not None
+
     # Ensure that S is at least 2-d
     S = np.atleast_2d(S)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1463,8 +1463,13 @@ def test_amplitude_to_db_complex():
 
 
 def test_amplitude_to_db_scalar():
-    assert librosa.amplitude_to_db(1) == 0
+    assert np.isclose(librosa.amplitude_to_db(1), 0)
     assert np.isclose(librosa.amplitude_to_db(2), 6.0206)
+
+
+def test_power_to_db_scalar():
+    assert np.isclose(librosa.power_to_db(1), 0)
+    assert np.isclose(librosa.power_to_db(2), 3.0103)
 
 
 @pytest.mark.parametrize("ref_p", range(-3, 4))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1462,6 +1462,11 @@ def test_amplitude_to_db_complex():
     assert np.allclose(db1, db2)
 
 
+def test_amplitude_to_db_scalar():
+    assert librosa.amplitude_to_db(1) == 0
+    assert np.isclose(librosa.amplitude_to_db(2), 6.0206)
+
+
 @pytest.mark.parametrize("ref_p", range(-3, 4))
 @pytest.mark.parametrize("xp", [(np.abs(np.random.randn(1000)) + 1e-5) ** 2])
 def test_db_to_power_inv(ref_p, xp):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1472,6 +1472,16 @@ def test_power_to_db_scalar():
     assert np.isclose(librosa.power_to_db(2), 3.0103)
 
 
+def test_db_to_amplitude_scalar():
+    assert np.isclose(librosa.db_to_amplitude(0), 1)
+    assert np.isclose(librosa.db_to_amplitude(6.0206), 2)
+
+
+def test_db_to_power_scalar():
+    assert np.isclose(librosa.db_to_power(0), 1)
+    assert np.isclose(librosa.db_to_power(3.0103), 2)
+
+
 @pytest.mark.parametrize("ref_p", range(-3, 4))
 @pytest.mark.parametrize("xp", [(np.abs(np.random.randn(1000)) + 1e-5) ** 2])
 def test_db_to_power_inv(ref_p, xp):


### PR DESCRIPTION
#### Reference Issue
This PR continues the work of #1768 


#### What does this implement/fix? Explain your changes.

Updates to db conversion code and type annotations to explicitly support scalars as well as ndarray inputs.
