### PR TITLE
Rewrite of phase vocoder

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -177,7 +177,7 @@ intersphinx_mapping = {
     "matplotlib": ("https://matplotlib.org/stable/", None),
     "sklearn": ("https://scikit-learn.org/stable/", None),
     "resampy": ("https://resampy.readthedocs.io/en/stable/", None),
-    "soundfile": ("https://pysoundfile.readthedocs.io/en/latest", None),
+    "soundfile": ("https://python-soundfile.readthedocs.io/en/latest", None),
     "samplerate": ("https://python-samplerate.readthedocs.io/en/latest/", None),
     "pyrubberband": ("https://pyrubberband.readthedocs.io/en/stable/", None),
     "pooch": ("https://www.fatiando.org/pooch/latest/", None),

--- a/docs/ioformats.rst
+++ b/docs/ioformats.rst
@@ -15,7 +15,7 @@ For a list of codecs supported by `soundfile`, see the *libsndfile* `documentati
 
 .. warning:: audioread support is deprecated as of librosa 0.10.0, and will be removed completely in version 1.0.
 
-.. note:: See installation instruction for PySoundFile `here <https://pysoundfile.readthedocs.io/en/latest/>`_.
+.. note:: See installation instruction for PySoundFile `here <https://python-soundfile.readthedocs.io/en/latest/>`_.
 
 Librosa's load function is meant for the common case where you want to load an entire (fragment of a) recording into memory, but some applications require more flexibility.
 In these cases, we recommend using `soundfile` directly.
@@ -119,7 +119,7 @@ Download and read from URL:
 
 Write out audio files
 ---------------------
-`PySoundFile <https://pysoundfile.readthedocs.io/en/latest/>`_ provides output functionality that can be used directly with numpy array audio buffers:
+`PySoundFile <https://python-soundfile.readthedocs.io/en/latest/>`_ provides output functionality that can be used directly with numpy array audio buffers:
 
 .. code-block:: python
     :linenos:

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1392,13 +1392,13 @@ def phase_vocoder(
     >>> # Play at double speed
     >>> y, sr   = librosa.load(librosa.ex('trumpet'))
     >>> D       = librosa.stft(y, n_fft=2048, hop_length=512)
-    >>> D_fast  = librosa.phase_vocoder(D, rate=2.0, hop_length=512)
+    >>> D_fast  = librosa.phase_vocoder(D, rate=2.0)
     >>> y_fast  = librosa.istft(D_fast, hop_length=512)
 
     >>> # Or play at 1/3 speed
     >>> y, sr   = librosa.load(librosa.ex('trumpet'))
     >>> D       = librosa.stft(y, n_fft=2048, hop_length=512)
-    >>> D_slow  = librosa.phase_vocoder(D, rate=1./3, hop_length=512)
+    >>> D_slow  = librosa.phase_vocoder(D, rate=1./3)
     >>> y_slow  = librosa.istft(D_slow, hop_length=512)
 
     Parameters
@@ -1414,16 +1414,22 @@ def phase_vocoder(
         Default is linear interpolation.
         See `scipy.interpolation.interp1d` for supported modes.
 
-    hop_length : int > 0 [scalar] or None
+    hop_length : Deprecated; int > 0 [scalar] or None
         The number of samples between successive columns of ``D``.
 
         If None, defaults to ``n_fft//4 = (D.shape[0]-1)//2``
 
-    n_fft : int > 0 or None
+        .. warning:: This parameter is deprecated as of 0.10.2 and will
+            be removed in 1.0.  This parameter is now ignored.
+
+    n_fft : Deprecated; int > 0 or None
         The number of samples per frame in D.
         By default (None), this will be inferred from the shape of D.
         However, if D was constructed using an odd-length window, the correct
         frame length can be specified here.
+
+        .. warning:: This parameter is deprecated as of 0.10.2 and will
+            be removed in 1.0.  This parameter is now ignored.
 
     Returns
     -------

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1441,10 +1441,10 @@ def phase_vocoder(
     pyrubberband
     scipy.interpolate.interp1d
     """
-    time_in = np.arange(0, D.shape[-1], 1)
+    frames_in = np.arange(0, D.shape[-1], 1)
 
     # Build the interpolator for magnitudes
-    fmag = scipy.interpolate.interp1d(time_in,
+    fmag = scipy.interpolate.interp1d(frames_in,
                                       np.abs(D),
                                       fill_value='extrapolate',
                                       kind=kind,
@@ -1453,7 +1453,7 @@ def phase_vocoder(
                                       axis=-1)
 
     # Compute the output time grid
-    time_out = np.arange(0, D.shape[-1], rate)
+    frames_out = np.arange(0, D.shape[-1], rate)
 
     
     # Compute the unwrapped phase differentials
@@ -1462,14 +1462,16 @@ def phase_vocoder(
 
     # For each output frame, we'll estimate the phase advance by looking up
     # the phase advance from the subsequent input frame
-    lookup = np.ceil(time_out)
+    lookup = np.ceil(frames_out)
 
     # Compute angle by accumulating phase differential estimates    
     # clip-mode here to prevent walking off the end of the array
     angles = np.cumsum(np.take(phase_diff, lookup.astype(int), axis=-1, mode='clip'), axis=-1)
     
-    return util.phasor(angles=angles, mag=fmag(time_out))
+    stretched: np.ndarray = util.phasor(angles=angles, mag=fmag(frames_out))
     
+    return stretched
+
 
 @cache(level=20)
 def iirt(

--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -237,8 +237,6 @@ def time_stretch(y: np.ndarray, *, rate: float, **kwargs: Any) -> np.ndarray:
     stft_stretch = core.phase_vocoder(
         stft,
         rate=rate,
-        hop_length=kwargs.get("hop_length", None),
-        n_fft=kwargs.get("n_fft", None),
     )
 
     # Predict the length of y_stretch

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2660,6 +2660,6 @@ def test_phase_vocoder_noop(y_22050):
 
     # Test no-op at full precision
     D = librosa.stft(y_22050, dtype=np.complex128)
-    Dout = librosa.phase_vocoder(D, rate=1)
-    assert np.allclose(D, Dout)
-    assert D is not Dout
+    D_out = librosa.phase_vocoder(D, rate=1)
+    assert np.allclose(D, D_out)
+    assert D is not D_out

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2654,3 +2654,12 @@ def test_f0_harmonics_incompat():
     harmonics = np.arange(1, 3)
 
     librosa.f0_harmonics(data, freqs=freqs, harmonics=harmonics, f0=f0)
+
+
+def test_phase_vocoder_noop(y_22050):
+
+    # Test no-op at full precision
+    D = librosa.stft(y_22050, dtype=np.complex128)
+    Dout = librosa.phase_vocoder(D, rate=1)
+    assert np.allclose(D, Dout)
+    assert D is not Dout

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -55,6 +55,7 @@ def test_time_stretch(ysr, rate, ctx, n_fft):
         # We don't have to be too precise here, since this goes through an STFT
         assert np.allclose(orig_duration, rate * new_duration, rtol=1e-2, atol=1e-3)
 
+
 def test_time_stretch_multi(y_multi):
     y, sr = y_multi
 


### PR DESCRIPTION
#### Reference Issue
Fixes #1770 

#### What does this implement/fix? Explain your changes.

This PR implements the rewrite of the phase vocoder function described in the comment thread of #1770.

The function's behavior is not substantially changed, but it is significantly faster and simpler now.  The outputs are different from the old implementation only in the final frames, where phase advance could not be reliably estimated anyway.

The hop length and nfft parameters have been deprecated, as they are no longer used in the new implementation.

A basic unit test has been implemented to verify that `rate=1` acts as a no-op.  Note that this only passes when using high precision (complex128) input STFTs, but I consider this to be good enough.