### PR TITLE
Documentation sidebar restructuring

### DIFF
--- a/docs/harmonics.rst
+++ b/docs/harmonics.rst
@@ -1,0 +1,11 @@
+.. _harmonics:
+
+---------
+Harmonics
+---------
+
+.. include:: generated/librosa.interp_harmonics.rst
+.. include:: generated/librosa.salience.rst
+.. include:: generated/librosa.f0_harmonics.rst
+
+.. include:: generated/librosa.phase_vocoder.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,6 +42,7 @@ If you want to cite librosa in a scholarly work, there are two ways to do it.
 
     spectral_representation
     magnitude_scaling
+    unit_conversion
     phase_recovery
     core
     display

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,6 +40,7 @@ If you want to cite librosa in a scholarly work, there are two ways to do it.
     :caption: API documentation
     :maxdepth: 1
 
+    spectral_representation
     magnitude_scaling
     phase_recovery
     core

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,6 +44,7 @@ If you want to cite librosa in a scholarly work, there are two ways to do it.
     magnitude_scaling
     unit_conversion
     music_notation
+    pitch_and_tuning
     phase_recovery
     core
     display

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,6 +40,7 @@ If you want to cite librosa in a scholarly work, there are two ways to do it.
     :caption: API documentation
     :maxdepth: 1
 
+    signals
     spectral_representation
     magnitude_scaling
     unit_conversion

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,6 +58,7 @@ If you want to cite librosa in a scholarly work, there are two ways to do it.
     segment
     sequence
     util
+    miscellaneous
 
 
 .. toctree::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,6 +43,7 @@ If you want to cite librosa in a scholarly work, there are two ways to do it.
     spectral_representation
     magnitude_scaling
     unit_conversion
+    music_notation
     phase_recovery
     core
     display

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,6 +40,7 @@ If you want to cite librosa in a scholarly work, there are two ways to do it.
     :caption: API documentation
     :maxdepth: 1
 
+    phase_recovery
     core
     display
     feature

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,7 +48,6 @@ If you want to cite librosa in a scholarly work, there are two ways to do it.
     pitch_and_tuning
     harmonics
     phase_recovery
-    core
     display
     feature
     onset

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,6 +40,7 @@ If you want to cite librosa in a scholarly work, there are two ways to do it.
     :caption: API documentation
     :maxdepth: 1
 
+    magnitude_scaling
     phase_recovery
     core
     display

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,6 +45,7 @@ If you want to cite librosa in a scholarly work, there are two ways to do it.
     unit_conversion
     music_notation
     pitch_and_tuning
+    harmonics
     phase_recovery
     core
     display

--- a/docs/magnitude_scaling.rst
+++ b/docs/magnitude_scaling.rst
@@ -1,0 +1,20 @@
+.. _magnitude_scaling:
+
+-----------------
+Magnitude Scaling
+-----------------
+
+.. include:: generated/librosa.amplitude_to_db.rst
+.. include:: generated/librosa.db_to_amplitude.rst
+.. include:: generated/librosa.power_to_db.rst
+.. include:: generated/librosa.db_to_power.rst
+
+.. include:: generated/librosa.perceptual_weighting.rst
+.. include:: generated/librosa.frequency_weighting.rst
+.. include:: generated/librosa.multi_frequency_weighting.rst
+.. include:: generated/librosa.A_weighting.rst
+.. include:: generated/librosa.B_weighting.rst
+.. include:: generated/librosa.C_weighting.rst
+.. include:: generated/librosa.D_weighting.rst
+
+.. include:: generated/librosa.pcen.rst

--- a/docs/miscellaneous.rst
+++ b/docs/miscellaneous.rst
@@ -1,0 +1,15 @@
+.. _miscellaneous:
+
+-------
+Miscellaneous
+-------
+
+.. include:: generated/librosa.samples_like.rst
+.. include:: generated/librosa.times_like.rst
+.. include:: generated/librosa.get_fftlib.rst
+.. include:: generated/librosa.set_fftlib.rst
+.. include:: generated/librosa.fft_frequencies.rst
+.. include:: generated/librosa.cqt_frequencies.rst
+.. include:: generated/librosa.mel_frequencies.rst
+.. include:: generated/librosa.tempo_frequencies.rst
+.. include:: generated/librosa.fourier_tempo_frequencies.rst

--- a/docs/music_notation.rst
+++ b/docs/music_notation.rst
@@ -1,0 +1,22 @@
+.. _music_notation:
+
+--------------
+Music Notation
+--------------
+
+.. include:: generated/librosa.key_to_notes.rst
+.. include:: generated/librosa.key_to_degrees.rst
+
+.. include:: generated/librosa.mela_to_svara.rst
+.. include:: generated/librosa.mela_to_degrees.rst
+
+.. include:: generated/librosa.thaat_to_degrees.rst
+
+.. include:: generated/librosa.list_mela.rst
+.. include:: generated/librosa.list_thaat.rst
+
+.. include:: generated/librosa.fifths_to_note.rst
+.. include:: generated/librosa.interval_to_fjs.rst
+.. include:: generated/librosa.interval_frequencies.rst
+.. include:: generated/librosa.pythagorean_intervals.rst
+.. include:: generated/librosa.plimit_intervals.rst

--- a/docs/phase_recovery.rst
+++ b/docs/phase_recovery.rst
@@ -1,0 +1,11 @@
+.. _phase_recovery:
+
+--------------
+Phase Recovery
+--------------
+
+.. toctree::
+   :maxdepth: 2
+
+.. include:: generated/librosa.griffinlim.rst
+.. include:: generated/librosa.griffinlim_cqt.rst

--- a/docs/pitch_and_tuning.rst
+++ b/docs/pitch_and_tuning.rst
@@ -1,0 +1,12 @@
+.. _pitch_and_tuning:
+
+----------------
+Pitch and Tuning
+----------------
+
+.. include:: generated/librosa.pyin.rst
+.. include:: generated/librosa.yin.rst
+
+.. include:: generated/librosa.estimate_tuning.rst
+.. include:: generated/librosa.pitch_tuning.rst
+.. include:: generated/librosa.piptrack.rst

--- a/docs/signals.rst
+++ b/docs/signals.rst
@@ -1,0 +1,25 @@
+.. _signals:
+
+-------
+Signals
+-------
+
+.. include:: generated/librosa.clicks.rst
+.. include:: generated/librosa.tone.rst
+.. include:: generated/librosa.chirp.rst
+.. include:: generated/librosa.load.rst
+.. include:: generated/librosa.stream.rst
+.. include:: generated/librosa.to_mono.rst
+.. include:: generated/librosa.resample.rst
+.. include:: generated/librosa.get_duration.rst
+.. include:: generated/librosa.get_samplerate.rst
+.. include:: generated/librosa.autiocorrelate.rst
+.. include:: generated/librosa.lpc.rst
+.. include:: generated/librosa.zero_crossings.rst
+.. include:: generated/librosa.mu_compress.rst
+.. include:: generated/librosa.mu_expand.rst
+.. include:: generated/librosa.fft_frequencies.rst
+.. include:: generated/librosa.cqt_frequencies.rst
+.. include:: generated/librosa.mel_frequencies.rst
+.. include:: generated/librosa.tempo_frequencies.rst
+.. include:: generated/librosa.fourier_tempo_frequencies.rst

--- a/docs/spectral_representation.rst
+++ b/docs/spectral_representation.rst
@@ -1,0 +1,22 @@
+.. _spectral_representation:
+
+-----------------------
+Spectral Representation
+-----------------------
+
+.. include:: generated/librosa.stft.rst
+.. include:: generated/librosa.istft.rst
+.. include:: generated/librosa.reassigned_spectrogram.rst
+
+.. include:: generated/librosa.cql.rst
+.. include:: generated/librosa.icqt.rst
+.. include:: generated/librosa.hybrid_cqt.rst
+.. include:: generated/librosa.pseudo_cqt.rst
+
+.. include:: generated/librosa.vqt.rst
+
+.. include:: generated/librosa.iirt.rst
+
+.. include:: generated/librosa.fmt.rst
+
+.. include:: generated/librosa.magphase.rst

--- a/docs/unit_conversion.rst
+++ b/docs/unit_conversion.rst
@@ -1,0 +1,38 @@
+.. _unit_coversion:
+
+---------------
+Unit Conversion
+---------------
+
+.. include:: generated/librosa.frames_to_samples.rst
+.. include:: generated/librosa.frames_to_time.rst
+.. include:: generated/librosa.samples_to_frames.rst
+.. include:: generated/librosa.samples_to_time.rst
+.. include:: generated/librosa.time_to_frames.rst
+.. include:: generated/librosa.time_to_samples.rst
+
+.. include:: generated/librosa.blocks_to_frames.rst
+.. include:: generated/librosa.blocks_to_samples.rst
+.. include:: generated/librosa.blocks_to_time.rst
+
+.. include:: generated/librosa.hz_to_note.rst
+.. include:: generated/librosa.hz_to_midi.rst
+.. include:: generated/librosa.hz_to_svara_h.rst
+.. include:: generated/librosa.hz_to_svara_c.rst
+.. include:: generated/librosa.hz_to_fjs.rst
+.. include:: generated/librosa.midi_to_hz.rst
+.. include:: generated/librosa.midi_to_note.rst
+.. include:: generated/librosa.midi_to_svara_h.rst
+.. include:: generated/librosa.midi_to_svara_c.rst
+.. include:: generated/librosa.note_to_hz.rst
+.. include:: generated/librosa.note_to_midi.rst
+.. include:: generated/librosa.note_to_svara_h.rst
+.. include:: generated/librosa.note_to_svara_c.rst
+
+.. include:: generated/librosa.hz_to_mel.rst
+.. include:: generated/librosa.hz_to_octs.rst
+.. include:: generated/librosa.mel_to_hz.rst
+.. include:: generated/librosa.octs_to_hz.rst
+
+.. include:: generated/librosa.A4_to_tuning.rst
+.. include:: generated/librosa.tuning_to_A4.rst

--- a/librosa/__init__.py
+++ b/librosa/__init__.py
@@ -3,16 +3,6 @@
 """
 Core IO and DSP
 ===============
-Miscellaneous
--------------
-.. autosummary::
-    :toctree: generated/
-
-    samples_like
-    times_like
-
-    get_fftlib
-    set_fftlib
 """
 
 import lazy_loader as lazy

--- a/librosa/__init__.py
+++ b/librosa/__init__.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-"""
-Core IO and DSP
-===============
-"""
 
 import lazy_loader as lazy
 from .version import version as __version__

--- a/librosa/__init__.py
+++ b/librosa/__init__.py
@@ -51,51 +51,6 @@ Harmonics
     phase_vocoder
 
 
-Time unit conversion
---------------------
-.. autosummary::
-    :toctree: generated/
-
-    frames_to_samples
-    frames_to_time
-    samples_to_frames
-    samples_to_time
-    time_to_frames
-    time_to_samples
-
-    blocks_to_frames
-    blocks_to_samples
-    blocks_to_time
-
-
-Frequency unit conversion
--------------------------
-.. autosummary::
-    :toctree: generated/
-
-    hz_to_note
-    hz_to_midi
-    hz_to_svara_h
-    hz_to_svara_c
-    hz_to_fjs
-    midi_to_hz
-    midi_to_note
-    midi_to_svara_h
-    midi_to_svara_c
-    note_to_hz
-    note_to_midi
-    note_to_svara_h
-    note_to_svara_c
-
-    hz_to_mel
-    hz_to_octs
-    mel_to_hz
-    octs_to_hz
-
-    A4_to_tuning
-    tuning_to_A4
-
-
 Music notation
 --------------
 .. autosummary::

--- a/librosa/__init__.py
+++ b/librosa/__init__.py
@@ -62,15 +62,6 @@ Spectral representations
     magphase
 
 
-Phase recovery
---------------
-.. autosummary::
-    :toctree: generated/
-
-    griffinlim
-    griffinlim_cqt
-
-
 Harmonics
 ---------
 .. autosummary::

--- a/librosa/__init__.py
+++ b/librosa/__init__.py
@@ -39,29 +39,6 @@ Signal generation
     chirp
 
 
-Spectral representations
-------------------------
-.. autosummary::
-    :toctree: generated/
-
-    stft
-    istft
-    reassigned_spectrogram
-
-    cqt
-    icqt
-    hybrid_cqt
-    pseudo_cqt
-
-    vqt
-
-    iirt
-
-    fmt
-
-    magphase
-
-
 Harmonics
 ---------
 .. autosummary::

--- a/librosa/__init__.py
+++ b/librosa/__init__.py
@@ -39,18 +39,6 @@ Signal generation
     chirp
 
 
-Harmonics
----------
-.. autosummary::
-    :toctree: generated/
-
-    interp_harmonics
-    salience
-    f0_harmonics
-
-    phase_vocoder
-
-
 Frequency range generation
 --------------------------
 .. autosummary::

--- a/librosa/__init__.py
+++ b/librosa/__init__.py
@@ -3,54 +3,6 @@
 """
 Core IO and DSP
 ===============
-
-Audio loading
--------------
-.. autosummary::
-    :toctree: generated/
-
-    load
-    stream
-    to_mono
-    resample
-    get_duration
-    get_samplerate
-
-
-Time-domain processing
-----------------------
-.. autosummary::
-    :toctree: generated/
-
-    autocorrelate
-    lpc
-    zero_crossings
-    mu_compress
-    mu_expand
-
-
-Signal generation
------------------
-.. autosummary::
-    :toctree: generated/
-
-    clicks
-    tone
-    chirp
-
-
-Frequency range generation
---------------------------
-.. autosummary::
-    :toctree: generated/
-
-    fft_frequencies
-    cqt_frequencies
-    mel_frequencies
-    tempo_frequencies
-    fourier_tempo_frequencies
-
-
 Miscellaneous
 -------------
 .. autosummary::

--- a/librosa/__init__.py
+++ b/librosa/__init__.py
@@ -63,19 +63,6 @@ Frequency range generation
     fourier_tempo_frequencies
 
 
-Pitch and tuning
-----------------
-.. autosummary::
-    :toctree: generated/
-
-    pyin
-    yin
-
-    estimate_tuning
-    pitch_tuning
-    piptrack
-
-
 Miscellaneous
 -------------
 .. autosummary::

--- a/librosa/__init__.py
+++ b/librosa/__init__.py
@@ -51,29 +51,6 @@ Harmonics
     phase_vocoder
 
 
-Music notation
---------------
-.. autosummary::
-    :toctree: generated/
-
-    key_to_notes
-    key_to_degrees
-
-    mela_to_svara
-    mela_to_degrees
-
-    thaat_to_degrees
-
-    list_mela
-    list_thaat
-
-    fifths_to_note
-    interval_to_fjs
-    interval_frequencies
-    pythagorean_intervals
-    plimit_intervals
-
-
 Frequency range generation
 --------------------------
 .. autosummary::

--- a/librosa/__init__.py
+++ b/librosa/__init__.py
@@ -74,27 +74,6 @@ Harmonics
     phase_vocoder
 
 
-Magnitude scaling
------------------
-.. autosummary::
-    :toctree: generated/
-
-    amplitude_to_db
-    db_to_amplitude
-    power_to_db
-    db_to_power
-
-    perceptual_weighting
-    frequency_weighting
-    multi_frequency_weighting
-    A_weighting
-    B_weighting
-    C_weighting
-    D_weighting
-
-    pcen
-
-
 Time unit conversion
 --------------------
 .. autosummary::


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/main/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
Fixes https://github.com/librosa/librosa/issues/1478

#### What does this implement/fix? Explain your changes.
This restructures the Core IO section of documentation sidebar. Core IO no longer exists and is replaced by the following:

- [x] Signals (includes load, stream, resample, and any signal generators and helper utilities)
- [x] Spectral representations
- [x] Magnitude scaling
- [x] Unit conversion (time, frequency)
- [x] Music notation
- [x] Pitch and tuning
- [x] Harmonics
- [x] Phase recovery
- [x] Miscellaneous (collects current misc + frequency range generators)

#### Any other comments?
None
