### PR TITLE
Correct phase advance for odd frame lengths in phase_vocoder

### DIFF
--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1441,7 +1441,7 @@ def phase_vocoder(
     d_stretch = np.zeros_like(D, shape=shape)
 
     # Expected phase advance in each bin per frame
-    phi_advance = hop_length * fft_frequencies(sr=2 * np.pi, n_fft=n_fft)
+    phi_advance = hop_length * convert.fft_frequencies(sr=2 * np.pi, n_fft=n_fft)
 
     # Phase accumulator; initialize to the first sample
     phase_acc = np.angle(D[..., 0])

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1440,8 +1440,8 @@ def phase_vocoder(
     shape[-1] = len(time_steps)
     d_stretch = np.zeros_like(D, shape=shape)
 
-    # Expected phase advance in each bin
-    phi_advance = np.linspace(0, np.pi * hop_length, D.shape[-2])
+    # Expected phase advance in each bin per frame
+    phi_advance = hop_length * fft_frequencies(sr=2 * np.pi, n_fft=n_fft)
 
     # Phase accumulator; initialize to the first sample
     phase_acc = np.angle(D[..., 0])


### PR DESCRIPTION
#### Reference Issue

#1700


#### What does this implement/fix? Explain your changes.
This PR corrects the phase advance calculation in the phase vocoder to handle odd frame lengths correctly.

#### Any other comments?

This PR does not implement any other changes to the phase vocoder described in #1700.  It should be good to merge when CI passes.