### PR TITLE
add cqa method to spectrum.py

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -104,6 +104,7 @@ Contributors
 * Shin Hyun <https://github.com/kyaryunha>
 * Iliya S <https://github.com/zenitismus>
 * Eugene Rabinovich <https://github.com/erabinov>
+* Shih-Kuang Lee <https://github.com/shihkuanglee>
 
 Some feature extraction code was based on <https://github.com/ronw/frontend> by Ron Weiss.
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
I developed a method that can compute constant q transform either faster or with higher resolution.
[https://github.com/shihkuanglee/ADFA](https://github.com/shihkuanglee/ADFA)

#### Any other comments?
The method I developed can take any length of signal to any resolution of spectrum in different scale.
But I am new to this community, I am not sure which way of method (python) fit the need of the community.
So I simply make the 'cqa' method based on the 'stft' method in spectrum.py.

Here is the figure you can get from the 'Examples' in docstring.
![specshow-CQ](https://github.com/librosa/librosa/assets/102346632/73bb2649-a75f-4406-ae15-0b20842ab6fc)
