### PR TITLE
Docstring and comment improvements

### DIFF
--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -1465,7 +1465,7 @@ def tone(
     --------
     Generate a pure sine tone A4
 
-    >>> tone = librosa.tone(440, duration=1)
+    >>> tone = librosa.tone(440, duration=1, sr=22050)
 
     Or generate the same signal using `length`
 
@@ -1559,7 +1559,7 @@ def chirp(
     --------
     Generate a exponential chirp from A2 to A8
 
-    >>> exponential_chirp = librosa.chirp(fmin=110, fmax=110*64, duration=1)
+    >>> exponential_chirp = librosa.chirp(fmin=110, fmax=110*64, duration=1, sr=22050)
 
     Or generate the same signal using ``length``
 
@@ -1567,7 +1567,7 @@ def chirp(
 
     Or generate a linear chirp instead
 
-    >>> linear_chirp = librosa.chirp(fmin=110, fmax=110*64, duration=1, linear=True)
+    >>> linear_chirp = librosa.chirp(fmin=110, fmax=110*64, duration=1, linear=True, sr=22050)
 
     Display spectrogram for both exponential and linear chirps.
 

--- a/librosa/core/convert.py
+++ b/librosa/core/convert.py
@@ -114,7 +114,7 @@ def frames_to_samples(
     --------
     >>> y, sr = librosa.load(librosa.ex('choice'))
     >>> tempo, beats = librosa.beat.beat_track(y=y, sr=sr)
-    >>> beat_samples = librosa.frames_to_samples(beats)
+    >>> beat_samples = librosa.frames_to_samples(beats, sr=sr)
     """
     offset = 0
     if n_fft is not None:
@@ -463,7 +463,7 @@ def samples_to_time(
     --------
     Get timestamps corresponding to every 512 samples
 
-    >>> librosa.samples_to_time(np.arange(0, 22050, 512))
+    >>> librosa.samples_to_time(np.arange(0, 22050, 512), sr=22050)
     array([ 0.   ,  0.023,  0.046,  0.07 ,  0.093,  0.116,  0.139,
             0.163,  0.186,  0.209,  0.232,  0.255,  0.279,  0.302,
             0.325,  0.348,  0.372,  0.395,  0.418,  0.441,  0.464,
@@ -1756,7 +1756,7 @@ def tempo_frequencies(
     --------
     Get the tempo frequencies corresponding to a 384-bin (8-second) tempogram
 
-    >>> librosa.tempo_frequencies(384)
+    >>> librosa.tempo_frequencies(384, sr=22050)
     array([      inf,  2583.984,  1291.992, ...,     6.782,
                6.764,     6.747])
     """
@@ -1792,7 +1792,7 @@ def fourier_tempo_frequencies(
     --------
     Get the tempo frequencies corresponding to a 384-bin (8-second) tempogram
 
-    >>> librosa.fourier_tempo_frequencies(win_length=384)
+    >>> librosa.fourier_tempo_frequencies(win_length=384, sr=22050)
     array([ 0.   ,  0.117,  0.234, ..., 22.266, 22.383, 22.5  ])
     """
     # sr / hop_length gets the frame rate
@@ -2320,14 +2320,14 @@ def times_like(
 
     >>> y, sr = librosa.load(librosa.ex('trumpet'))
     >>> D = librosa.stft(y)
-    >>> times = librosa.times_like(D)
+    >>> times = librosa.times_like(D, sr=sr)
     >>> times
     array([0.   , 0.023, ..., 5.294, 5.317])
 
     Provide a scalar input:
 
     >>> n_frames = 2647
-    >>> times = librosa.times_like(n_frames)
+    >>> times = librosa.times_like(n_frames, sr=sr)
     >>> times
     array([  0.00000000e+00,   2.32199546e-02,   4.64399093e-02, ...,
              6.13935601e+01,   6.14167800e+01,   6.14400000e+01])

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -563,8 +563,8 @@ def yin(
     --------
     Computing a fundamental frequency (F0) curve from an audio input
 
-    >>> y = librosa.chirp(fmin=440, fmax=880, duration=5.0)
-    >>> librosa.yin(y, fmin=440, fmax=880)
+    >>> y = librosa.chirp(fmin=440, fmax=880, duration=5.0, sr=22050)
+    >>> librosa.yin(y, fmin=440, fmax=880, sr=22050)
     array([442.66354675, 441.95299983, 441.58010963, ...,
         871.161732  , 873.99001454, 877.04297681])
     """
@@ -754,9 +754,10 @@ def pyin(
 
     >>> y, sr = librosa.load(librosa.ex('trumpet'))
     >>> f0, voiced_flag, voiced_probs = librosa.pyin(y,
+    ...                                              sr=sr,
     ...                                              fmin=librosa.note_to_hz('C2'),
     ...                                              fmax=librosa.note_to_hz('C7'))
-    >>> times = librosa.times_like(f0)
+    >>> times = librosa.times_like(f0, sr=sr)
 
     Overlay F0 over a spectrogram
 

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1565,7 +1565,7 @@ def iirt(
     --------
     >>> import matplotlib.pyplot as plt
     >>> y, sr = librosa.load(librosa.ex('trumpet'), duration=3)
-    >>> D = np.abs(librosa.iirt(y))
+    >>> D = np.abs(librosa.iirt(y, sr=sr))
     >>> C = np.abs(librosa.cqt(y=y, sr=sr))
     >>> fig, ax = plt.subplots(nrows=2, sharex=True, sharey=True)
     >>> img = librosa.display.specshow(librosa.amplitude_to_db(C, ref=np.max),

--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -624,7 +624,7 @@ def trim(
     Silence here is determined as being more than a specified
     `top_db` decibels below the reference value `ref`.
     By default, `ref` is taken as the maximum RMS value over the signal.
-    
+
     Note that if the signal has a constant RMS value over its duration,
     then no regions will be significantly quieter than the maximum, and
     no trimming will be performed.  Specifically, this means that a silent

--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -621,15 +621,14 @@ def trim(
 ) -> Tuple[np.ndarray, np.ndarray]:
     """Trim leading and trailing silence from an audio signal.
 
-    Silence here is determined as being more than a specified
-    `top_db` decibels below the reference value `ref`.
-    By default, `ref` is taken as the maximum RMS value over the signal.
-
-    Note that if the signal has a constant RMS value over its duration,
-    then no regions will be significantly quieter than the maximum, and
-    no trimming will be performed.  Specifically, this means that a silent
-    signal, by default, will not be trimmed at all with the default `ref`
-    setting.
+    Silence is defined as segments of the audio signal that are `top_db`
+    decibels (or more) quieter than a reference level, `ref`.
+    By default, `ref` is set to the signal's maximum RMS value.
+    It's important to note that if the entire signal maintains a uniform
+    RMS value, there will be no segments considered quieter than the maximum,
+    leading to no trimming.
+    This implies that a completely silent signal will remain untrimmed with the default `ref` setting.
+    In these situations, an explicit value for `ref` (in decibels) should be used instead.
 
     Parameters
     ----------

--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -664,7 +664,7 @@ def trim(
     >>> # Trim the beginning and ending silence
     >>> yt, index = librosa.effects.trim(y)
     >>> # Print the durations
-    >>> print(librosa.get_duration(y), librosa.get_duration(yt))
+    >>> print(librosa.get_duration(y, sr=sr), librosa.get_duration(yt, sr=sr))
     25.025986394557822 25.007891156462584
     """
     non_silent = _signal_to_frame_nonsilent(

--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -621,6 +621,16 @@ def trim(
 ) -> Tuple[np.ndarray, np.ndarray]:
     """Trim leading and trailing silence from an audio signal.
 
+    Silence here is determined as being more than a specified
+    `top_db` decibels below the reference value `ref`.
+    By default, `ref` is taken as the maximum RMS value over the signal.
+    
+    Note that if the signal has a constant RMS value over its duration,
+    then no regions will be significantly quieter than the maximum, and
+    no trimming will be performed.  Specifically, this means that a silent
+    signal, by default, will not be trimmed at all with the default `ref`
+    setting.
+
     Parameters
     ----------
     y : np.ndarray, shape=(..., n)
@@ -677,7 +687,7 @@ def trim(
             int(core.frames_to_samples(nonzero[-1] + 1, hop_length=hop_length)),
         )
     else:
-        # The signal only contains zeros
+        # The entire signal is trimmed here: nothing is above the threshold
         start, end = 0, 0
 
     # Build the mono/stereo index

--- a/librosa/onset.py
+++ b/librosa/onset.py
@@ -313,7 +313,7 @@ def onset_strength(
     >>> import matplotlib.pyplot as plt
     >>> y, sr = librosa.load(librosa.ex('trumpet'), duration=3)
     >>> D = np.abs(librosa.stft(y))
-    >>> times = librosa.times_like(D)
+    >>> times = librosa.times_like(D, sr=sr)
     >>> fig, ax = plt.subplots(nrows=2, sharex=True)
     >>> librosa.display.specshow(librosa.amplitude_to_db(D, ref=np.max),
     ...                          y_axis='log', x_axis='time', ax=ax[0])
@@ -399,7 +399,7 @@ def onset_backtrack(events: np.ndarray, energy: np.ndarray) -> np.ndarray:
 
     >>> y, sr = librosa.load(librosa.ex('trumpet'), duration=3)
     >>> oenv = librosa.onset.onset_strength(y=y, sr=sr)
-    >>> times = librosa.times_like(oenv)
+    >>> times = librosa.times_like(oenv, sr=sr)
     >>> # Detect events without backtracking
     >>> onset_raw = librosa.onset.onset_detect(onset_envelope=oenv,
     ...                                        backtrack=False)

--- a/scripts/audit_docstring_examples.py
+++ b/scripts/audit_docstring_examples.py
@@ -6,6 +6,9 @@
 #
 # It is then up to the user of this script to audit the docstring in question to determine
 # if any correction is necessary.
+#
+# Script co-authored by chatgpt v4 and Brian McFee
+
 import pkgutil
 import inspect
 import ast

--- a/scripts/parse_examples.py
+++ b/scripts/parse_examples.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python
+"""Scan module docstrings for usage of functions relying on a specific parameter (sr)"""
+# This script exists primarily in service of issue #1708, and is designed to help
+# us identify docstring example calls which depend on librosa functions accepting the sr
+# parameter.
+#
+# It is then up to the user of this script to audit the docstring in question to determine
+# if any correction is necessary.
+import pkgutil
+import inspect
+import ast
+import numpydoc.docscrape as nds
+
+import librosa
+
+
+def find_functions_with_param(package, param_name):
+    """
+    Scan all functions in a package and its submodules to find functions that include a given parameter.
+
+    Parameters:
+    - package: The package to scan. Should be the actual package/module object, not a string.
+    - param_name: The name of the parameter to look for.
+
+    Returns:
+    - A set of strings, each containing the module path and function name where the parameter is found.
+    """
+    functions_with_param = []
+
+    def check_function(module, func):
+        """Check if a function has the given parameter and add it to the list if it does."""
+        sig = inspect.signature(func)
+        if param_name in sig.parameters:
+            functions_with_param.append(f"{module.__name__}.{func.__name__}")
+
+    def visit_module(module):
+        """Visit a module, check its functions, and recursively visit its submodules."""
+        for name, obj in inspect.getmembers(module):
+            if inspect.isfunction(obj):
+                check_function(module, obj)
+            elif inspect.ismodule(obj) and obj.__package__ == module.__package__:
+                # Recursively visit submodules, but only within the same package
+                visit_module(obj)
+
+    # Start the scanning process with the root package
+    visit_module(package)
+
+    return set(functions_with_param)
+
+
+def find_functions(package):
+    """
+    Scan all functions in a package and its submodules to find functions.
+
+    Parameters:
+    - package: The package to scan. Should be the actual package/module object, not a string.
+
+    Returns:
+    - A set of functions in the package.
+    """
+    functions = []
+
+    def visit_module(module):
+        """Visit a module, check its functions, and recursively visit its submodules."""
+        for name, obj in inspect.getmembers(module):
+            if inspect.isfunction(obj):
+                functions.append(obj)
+            elif inspect.ismodule(obj) and obj.__package__ == module.__package__:
+                # Recursively visit submodules, but only within the same package
+                visit_module(obj)
+
+    # Start the scanning process with the root package
+    visit_module(package)
+
+    return set(functions)
+
+
+class LibrosaCallVisitor(ast.NodeVisitor):
+    def __init__(self):
+        self.librosa_calls = []
+
+    def visit_Call(self, node):
+        # Recursively check the call node to see if it's a librosa call
+        if self.is_librosa_call(node.func):
+            # Extract the full function name (including submodules) and arguments
+            func_name = self.get_full_func_name(node.func)
+            args = [ast.unparse(arg) for arg in node.args]  # Converts arguments back to Python code snippets
+            kwargs = [arg.arg for arg in node.keywords]  # Converts arguments back to Python code snippets
+            self.librosa_calls.append((func_name, args + kwargs))
+        # Continue traversing the tree
+        self.generic_visit(node)
+
+    def is_librosa_call(self, node):
+        # If the node represents an attribute access (e.g., librosa.feature.mfcc)
+        if isinstance(node, ast.Attribute):
+            return self.is_librosa_call(node.value)
+        # If the node is a name and it's 'librosa', we've found a librosa call
+        elif isinstance(node, ast.Name):
+            return node.id == 'librosa'
+        return False
+
+    def get_full_func_name(self, node):
+        # Collect parts of the function name (including submodules)
+        parts = []
+        while isinstance(node, ast.Attribute):
+            parts.append(node.attr)
+            node = node.value
+        if isinstance(node, ast.Name):
+            parts.append(node.id)
+        return '.'.join(reversed(parts))
+
+
+def extract_librosa_calls(code_blocks, target_functions, desc=""):
+    for i, block in enumerate(code_blocks, start=1):
+        # Parse the code block into an AST
+        tree = ast.parse(block)
+
+        # Create a visitor instance and visit the nodes
+        visitor = LibrosaCallVisitor()
+        visitor.visit(tree)
+
+        # Print the librosa function calls found in this block
+        if visitor.librosa_calls:
+            offending = False
+            for func_name, args in visitor.librosa_calls:
+                if func_name in target_functions and "sr" not in args and func_name != "librosa.load":
+                    offending = True
+            if not offending:
+                return
+            print(f"{desc} code block {i} has the following librosa calls:")
+            for func_name, args in visitor.librosa_calls:
+                if func_name in target_functions and "sr" not in args and func_name != "librosa.load":
+                    print(f"  - {func_name}({', '.join(args)})")
+            print()
+
+
+
+def extract_code_blocks(docstring):
+    # Parse the docstring
+    parsed_doc = nds.NumpyDocString(docstring)
+
+    code_blocks = []
+
+    # Extract the "Examples" section (which is a list)
+    examples = parsed_doc['Examples']
+    
+    current_block = []
+
+    for line in examples:
+        stripped_line = line.lstrip()  # Strip leading whitespace
+
+        if stripped_line.startswith('>>>') or stripped_line.startswith('...'):
+            # Remove '>>>' or '...' from the start, but preserve indentation for continuation lines
+            code_line = stripped_line[4:] if stripped_line.startswith('>>>') else stripped_line[3:]
+            current_block.append(code_line)
+        elif current_block:
+            # If we hit a non-code line and there's an ongoing block, end and save the current block
+            code_blocks.append('\n'.join(current_block))
+            current_block = []
+
+    # Add the last block if it exists
+    if current_block:
+        code_blocks.append('\n'.join(current_block))
+
+    return code_blocks
+
+
+if __name__ == '__main__':
+    target_functions = find_functions_with_param(librosa, "sr")
+
+    # Extract code blocks from the function's docstring
+    all_functions = find_functions(librosa)
+
+    for function in all_functions:
+        if function.__doc__ is None:
+            continue
+        try:
+            code_blocks = extract_code_blocks(function.__doc__)
+            extract_librosa_calls(code_blocks, target_functions, desc=function.__name__)
+        except:
+            print(f"Could not parse {function.__name__}, skipping.  CHECK MANUALLY.")


### PR DESCRIPTION
#### Reference Issue
Fixes #1802
Fixes #1708


#### What does this implement/fix? Explain your changes.

This PR expands documentation on `effects.trim` to explain what happens with constant / silent inputs.

This PR also adds a (single use?) script to help audit docstring examples for cases where we might have forgotten to specify the `sr=` parameter.  Yeah this is totally unrelated to the #1802 issue, but i was working on documentation already. :shrug:

#### Any other comments?

No functionality changes here, but a CR on the documentation would be appreciated.