### PR TITLE
Bump minimum matplotlib to 3.5.0

### DIFF
--- a/.github/environment-ci.yml
+++ b/.github/environment-ci.yml
@@ -21,7 +21,7 @@ dependencies:
   - typing_extensions>=4.1.1
 
   # optional, but required for testing
-  - matplotlib>=3.3.0
+  - matplotlib>=3.5.0
   - pytest-mpl
   - pytest-cov
   - pytest

--- a/.github/environment-minimal.yml
+++ b/.github/environment-minimal.yml
@@ -21,7 +21,7 @@ dependencies:
   - typing_extensions==4.1.1
 
   # optional, but required for testing
-  - matplotlib==3.3.0
+  - matplotlib==3.5.0
   - pytest-mpl
   - pytest-cov
   - pytest

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,7 +8,13 @@ v0.10
 
 v0.10.2.post1
 -------------
-2024-05-xx
+2024-05-14
+
+Maintenance
+    - `#1839`_ Updated minimum matplotlib to 3.5.0.  There are no changes to the code in this release, only package metadata and tests.
+
+
+.. _#1839: https://github.com/librosa/librosa/pull/1839
 
 
 v0.10.2

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,12 @@ Changelog
 v0.10
 =====
 
+
+v0.10.2.post1
+-------------
+2024-05-xx
+
+
 v0.10.2
 -------
 2024-05-02
@@ -23,7 +29,6 @@ Bug fixes
     - `#1755`_ Avoid deprecated features in matplotlib and ensure compatibility with mpl 3.8. *Brian McFee*
 
 Documentation
-    - `#1801`_ Improved top-level structure of the documentation site. *Dana Lee*
     - `#1827`_ Improvements to example code in documentation to include sampling rate parameters whenever necessary. *Brian McFee*
     - `#1821`_ Added "copy button" to code examples in documentation. *Brian McFee*
     - `#1789`_ Fixed type annotations for sampling rate parameters. *Brian McFee*
@@ -50,7 +55,6 @@ Other changes and maintenance
 .. _#1784: https://github.com/librosa/librosa/issues/1784
 .. _#1733: https://github.com/librosa/librosa/issues/1733
 .. _#1755: https://github.com/librosa/librosa/issues/1755
-.. _#1801: https://github.com/librosa/librosa/issues/1801
 .. _#1827: https://github.com/librosa/librosa/issues/1827
 .. _#1821: https://github.com/librosa/librosa/issues/1821
 .. _#1789: https://github.com/librosa/librosa/issues/1789

--- a/librosa/version.py
+++ b/librosa/version.py
@@ -6,7 +6,7 @@ import sys
 import importlib
 
 short_version = "0.10"
-version = "0.10.2"
+version = "0.10.2.post1"
 
 
 def __get_mod_version(modname):

--- a/setup.cfg
+++ b/setup.cfg
@@ -91,7 +91,7 @@ docs =
     sphinx != 1.3.1
     sphinx_rtd_theme>=1.2.0
     numba >= 0.51
-    matplotlib >= 3.3.0
+    matplotlib >= 3.5.0
     sphinx-multiversion >= 0.2.3
     sphinx-gallery >= 0.7
     mir_eval >= 0.5
@@ -100,7 +100,7 @@ docs =
     presets
     sphinx-copybutton >= 0.5.2
 tests =
-    matplotlib >= 3.3.0
+    matplotlib >= 3.5.0
     packaging >= 20.0
     pytest-mpl
     pytest-cov
@@ -109,7 +109,7 @@ tests =
     resampy >= 0.2.2
     types-decorator
 display =
-    matplotlib >= 3.3.0
+    matplotlib >= 3.5.0
 
 
 [mypy]

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -16,7 +16,7 @@ from packaging import version
 
 import pytest
 
-matplotlib = pytest.importorskip("matplotlib", minversion="3.4")
+import matplotlib
 
 STYLE = "default"
 


### PR DESCRIPTION
#### Reference Issue
Fixes #1838 


#### What does this implement/fix? Explain your changes.

Does what it says on the tin: minimum matplotlib is now 3.5.0.

#### Any other comments?

I've also corrected an error in the changelog and bumped the version spec.  If CI passes clean on this, I'll merge and cut a post-release.