### PR TITLE
Fix name collision for norm argument in mfcc

### DIFF
--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -1836,7 +1836,7 @@ def mfcc(
     S: Optional[np.ndarray] = None,
     n_mfcc: int = 20,
     dct_type: int = 2,
-    norm_dct: Optional[str] = "ortho",
+    dct_norm: Optional[str] = "ortho",
     lifter: float = 0,
     **kwargs: Any,
 ) -> np.ndarray:
@@ -1860,8 +1860,8 @@ def mfcc(
     dct_type : {1, 2, 3}
         Discrete cosine transform (DCT) type.
         By default, DCT type-2 is used.
-    norm_dct : None or 'ortho'
-        If ``dct_type`` is `2 or 3`, setting ``norm='ortho'`` uses an ortho-normal
+    dct_norm : None or 'ortho'
+        If ``dct_type`` is `2 or 3`, setting ``dct_norm='ortho'`` uses an ortho-normal
         DCT basis.
         Normalization is not supported for ``dct_type=1``.
     lifter : number >= 0

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -17,6 +17,7 @@ from ..core.spectrum import power_to_db, _spectrogram
 from ..core.constantq import cqt, hybrid_cqt, vqt
 from ..core.pitch import estimate_tuning
 from typing import Any, Optional, Union, Collection
+from typing_extensions import Literal
 from numpy.typing import DTypeLike
 from .._typing import _FloatLike_co, _WindowSpec, _PadMode, _PadModeSTFT
 

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -1836,8 +1836,9 @@ def mfcc(
     S: Optional[np.ndarray] = None,
     n_mfcc: int = 20,
     dct_type: int = 2,
-    dct_norm: Optional[str] = "ortho",
+    norm: Optional[str] = "ortho",
     lifter: float = 0,
+    mel_norm: Optional[Union[Literal["slaney"], float]] = "slaney",
     **kwargs: Any,
 ) -> np.ndarray:
     """Mel-frequency cepstral coefficients (MFCCs)
@@ -1860,8 +1861,8 @@ def mfcc(
     dct_type : {1, 2, 3}
         Discrete cosine transform (DCT) type.
         By default, DCT type-2 is used.
-    dct_norm : None or 'ortho'
-        If ``dct_type`` is `2 or 3`, setting ``dct_norm='ortho'`` uses an ortho-normal
+    norm : None or 'ortho'
+        If ``dct_type`` is `2 or 3`, setting ``norm='ortho'`` uses an ortho-normal
         DCT basis.
         Normalization is not supported for ``dct_type=1``.
     lifter : number >= 0
@@ -1869,6 +1870,7 @@ def mfcc(
             M[n, :] <- M[n, :] * (1 + sin(pi * (n + 1) / lifter) * lifter / 2)
         Setting ``lifter >= 2 * n_mfcc`` emphasizes the higher-order coefficients.
         As ``lifter`` increases, the coefficient weighting becomes approximately linear.
+    mel_norm : `norm` argument to `melspectrogram`
     **kwargs : additional keyword arguments to `melspectrogram`
         if operating on time series input
     n_fft : int > 0 [scalar]
@@ -1986,9 +1988,9 @@ def mfcc(
     """
     if S is None:
         # multichannel behavior may be different due to relative noise floor differences between channels
-        S = power_to_db(melspectrogram(y=y, sr=sr, **kwargs))
+        S = power_to_db(melspectrogram(y=y, sr=sr, norm = mel_norm, **kwargs))
 
-    M: np.ndarray = scipy.fftpack.dct(S, axis=-2, type=dct_type, norm=norm_dct)[
+    M: np.ndarray = scipy.fftpack.dct(S, axis=-2, type=dct_type, norm=norm)[
         ..., :n_mfcc, :
     ]
 

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -1836,7 +1836,7 @@ def mfcc(
     S: Optional[np.ndarray] = None,
     n_mfcc: int = 20,
     dct_type: int = 2,
-    norm: Optional[str] = "ortho",
+    norm_dct: Optional[str] = "ortho",
     lifter: float = 0,
     **kwargs: Any,
 ) -> np.ndarray:
@@ -1860,7 +1860,7 @@ def mfcc(
     dct_type : {1, 2, 3}
         Discrete cosine transform (DCT) type.
         By default, DCT type-2 is used.
-    norm : None or 'ortho'
+    norm_dct : None or 'ortho'
         If ``dct_type`` is `2 or 3`, setting ``norm='ortho'`` uses an ortho-normal
         DCT basis.
         Normalization is not supported for ``dct_type=1``.
@@ -1988,7 +1988,7 @@ def mfcc(
         # multichannel behavior may be different due to relative noise floor differences between channels
         S = power_to_db(melspectrogram(y=y, sr=sr, **kwargs))
 
-    M: np.ndarray = scipy.fftpack.dct(S, axis=-2, type=dct_type, norm=norm)[
+    M: np.ndarray = scipy.fftpack.dct(S, axis=-2, type=dct_type, norm=norm_dct)[
         ..., :n_mfcc, :
     ]
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/main/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
fixes https://github.com/librosa/librosa/issues/1842


#### What does this implement/fix? Explain your changes.
This pr fixes name collisions between norm arguments in `mfcc` for `melspectrogram` and for `scipy.fftpack.dct`.

