### PR TITLE
Update index.rst corrected broken link

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@ blocks necessary to create music information retrieval systems.
 
 For a quick introduction to using librosa, please refer to the :doc:`tutorial`.
 For a more advanced introduction which describes the package design principles, please refer to the
-`librosa paper <https://conference.scipy.org/proceedings/scipy2015/pdfs/brian_mcfee.pdf>`_ at
+`librosa paper <http://conference.scipy.org.s3-website-us-east-1.amazonaws.com/proceedings/scipy2015/brian_mcfee.html>`_ at
 `SciPy 2015 <https://scipy2015.scipy.org>`_.
 
 Citing librosa


### PR DESCRIPTION
#### Reference Issue
<!-- Example: Fixes #123 -->
![image](https://github.com/librosa/librosa/assets/67859818/3a3a72c6-9af0-4766-bff2-62860defd436)

Changed the broken link to correct one
from 
https://conference.scipy.org/proceedings/scipy2015/pdfs/brian_mcfee.pdf  
![image](https://github.com/librosa/librosa/assets/67859818/497884bc-2758-447c-9dc9-6f8b5d072c77)

to 

#### What does this implement/fix? Explain your changes.
http://conference.scipy.org.s3-website-us-east-1.amazonaws.com/proceedings/scipy2015/brian_mcfee.html
![image](https://github.com/librosa/librosa/assets/67859818/5b4c7337-c92a-4b39-a656-6b608bb51657)

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/main/CONTRIBUTING.md#how-to-contribute
-->






#### Any other comments?
I didn't find any issue no. related to similar issue. Kindly merge my request!
Guide me for future!
