### PR TITLE
Remove .H for conjugate().T

### DIFF
--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -708,7 +708,7 @@ def icqt(
         )
 
         # Transpose the basis
-        inv_basis = fft_basis.H.todense()
+        inv_basis = fft_basis.conjugate().T.todense()
 
         # Compute each filter's frequency-domain power
         freq_power = 1 / np.sum(util.abs2(np.asarray(inv_basis)), axis=0)


### PR DESCRIPTION
#### Reference Issue
Fixes #1849 


#### What does this implement/fix? Explain your changes.

Computing Hermitians the long way around, since the shortcut was deprecated.

#### Any other comments?

Should be good to merge ASAP.