### PR TITLE
[documentation][Issue #1855] Update Fast Mellin Transform doc example

### DIFF
--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -2208,14 +2208,14 @@ def fmt(
     >>> # Auto-correlate with up to 10 seconds lag
     >>> odf_ac = librosa.autocorrelate(odf, max_size=10 * sr // 512)
     >>> # Normalize
-    >>> odf_ac = librosa.util.normalize(odf_ac, norm=np.inf)
+    >>> odf_ac_norm = librosa.util.normalize(odf_ac, norm=np.inf)
     >>> # Compute the scale transform
-    >>> odf_ac_scale = librosa.fmt(librosa.util.normalize(odf_ac), n_fmt=512)
+    >>> odf_ac_scale = librosa.fmt(odf_ac_norm, n_fmt=512)
     >>> # Plot the results
     >>> fig, ax = plt.subplots(nrows=3)
     >>> ax[0].plot(odf, label='Onset strength')
     >>> ax[0].set(xlabel='Time (frames)', title='Onset strength')
-    >>> ax[1].plot(odf_ac, label='Onset autocorrelation')
+    >>> ax[1].plot(odf_ac_norm, label='Onset autocorrelation')
     >>> ax[1].set(xlabel='Lag (frames)', title='Onset autocorrelation')
     >>> ax[2].semilogy(np.abs(odf_ac_scale), label='Scale transform magnitude')
     >>> ax[2].set(xlabel='scale coefficients')


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/main/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
<!-- Example: Fixes #123 -->
Fixes #1855

#### What does this implement/fix? Explain your changes.

Following changes have been made:
* Remove duplicate function calls to `librosa.util.normalize`
* Rename normalized version of `odf_ac` to `odf_ac_norm`.
* Renaming would explicitly reflect that we plot normalized version in onset autocorrelation plot.

#### Any other comments?

