### PR TITLE
fix onset documentation specshow samplerate

### DIFF
--- a/librosa/onset.py
+++ b/librosa/onset.py
@@ -142,7 +142,7 @@ def onset_detect(
     >>> D = np.abs(librosa.stft(y))
     >>> fig, ax = plt.subplots(nrows=2, sharex=True)
     >>> librosa.display.specshow(librosa.amplitude_to_db(D, ref=np.max),
-    ...                          x_axis='time', y_axis='log', ax=ax[0])
+    ...                          x_axis='time', y_axis='log', ax=ax[0], sr=sr)
     >>> ax[0].set(title='Power spectrogram')
     >>> ax[0].label_outer()
     >>> ax[1].plot(times, o_env, label='Onset strength')
@@ -316,7 +316,7 @@ def onset_strength(
     >>> times = librosa.times_like(D, sr=sr)
     >>> fig, ax = plt.subplots(nrows=2, sharex=True)
     >>> librosa.display.specshow(librosa.amplitude_to_db(D, ref=np.max),
-    ...                          y_axis='log', x_axis='time', ax=ax[0])
+    ...                          y_axis='log', x_axis='time', ax=ax[0], sr=sr)
     >>> ax[0].set(title='Power spectrogram')
     >>> ax[0].label_outer()
 


### PR DESCRIPTION
If not set the power spectogram and onset strength might not align properly.

![Screenshot 2024-07-20 at 16 16 21](https://github.com/user-attachments/assets/ab89c75a-a33d-4264-9958-20a5682ea512)
