### PR TITLE
Faster abs2 on real inputs

### DIFF
--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -2498,7 +2498,7 @@ def abs2(x: _NumberOrArray, dtype: Optional[DTypeLike] = None) -> _NumberOrArray
             return y.astype(dtype)  # type: ignore
     else:
         # suppress type check, mypy doesn't know this is real
-        return np.power(x, 2, dtype=dtype)  # type: ignore
+        return np.square(x, dtype=dtype)  # type: ignore
 
 
 @numba.vectorize(


### PR DESCRIPTION
#### Reference Issue
Fixes #1863 


#### What does this implement/fix? Explain your changes.

This PR replaces a call to `np.power(x, 2)` with `np.square(x)`, which is considerably faster.  Main use-case is to speed up rms, but it will benefit many other places as well.

#### Any other comments?

This should pass cleanly.