### PR TITLE
Fix: .gitignore syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,61 +1,66 @@
+# Python bytecode files
 *.py[co]
 __pycache__
 
-__pycache__
-
 # Packages
+.installed.cfg
 *.egg
 *.egg-info
-dist
-build
-eggs
-parts
-bin
-var
-sdist
-develop-eggs
-.installed.cfg
+bin/
+build/
+develop-eggs/
+dist/
+eggs/
+parts/
+sdist/
+var/
 
 # Installer logs
 pip-log.txt
 
 # Unit test / coverage reports
 .coverage
-.tox
+.tox/
 tests/result_images/
 
-#Translations
+# Translations
 *.mo
 
-#Mr Developer
+# Mr Developer
 .mr.developer.cfg
 
 # Data files
-*/data/*
+data/
 *.mat
 
 # Mac OS X cruft
+._*
 .DS_Store
 .DS_Store?
-._*
 .Spotlight-V100
 .Trashes
 ehthumbs.db
 Thumbs.db
 
 # Sphinx stuff
-docs/generated/
-docs/_build/
-docs/auto_examples/
+/docs/_build/
+/docs/auto_examples/
+/docs/generated/
 
 # Vim
 *.swp
 
 # Testing and checkpoints
-.ipynb_checkpoints
 .coverage.*
+.ipynb_checkpoints/
 coverage.xml
 
-#IDE
+# IDE
 .idea/
-.vscode
+.vscode/
+*.code-workspace
+
+# py -m venv
+pyvenv.cfg
+/Lib/site-packages/
+/scripts/


### PR DESCRIPTION
Many of the current statements will have unintended effects. https://git-scm.com/docs/gitignore

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/main/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
<!-- Example: Fixes #123 -->

#### What does this implement/fix? Explain your changes.
`parts`, for example, will match any file or directory in any part of the tree named `parts`
The result of `*/data/*` is not defined, but `data/` will match any directory (but not file) named `data` in any part of the tree.


#### Any other comments?
There are templates here, https://github.com/github/gitignore, but my perception is that they are overloaded with old formats and lacking more recent formats. On the other hand, they are far superior to the few other templates I've found. 