### PR TITLE
Fix time stretch round error

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -108,7 +108,8 @@ Contributors
 * Jize Guo <https://github.com/alumkal>
 * Phillip S.M. Skelton <https://github.com/psmskelton>
 * Matt Pitkin <https://github.com/mattpitkin>
-
+* Orkun Kınay <https://github.com/orkunkinay>
+  
 Some feature extraction code was based on <https://github.com/ronw/frontend> by Ron Weiss.
 
 Large portions of librosa were ported from MATLAB code by Dan Ellis <http://www.ee.columbia.edu/~dpwe/resources/matlab/>.

--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -392,7 +392,7 @@ def time_stretch(y: np.ndarray, *, rate: float, **kwargs: Any) -> np.ndarray:
     )
 
     # Predict the length of y_stretch
-    len_stretch = int(round(y.shape[-1] / rate))
+    len_stretch = int(np.round(y.shape[-1] / rate))
 
     # Invert the STFT
     y_stretch = core.istft(stft_stretch, dtype=y.dtype, length=len_stretch, **kwargs)


### PR DESCRIPTION
This PR fixes a TypeError in the `time_stretch` function where `round()` was applied to an ndarray inappropriately. The fix replaces `round()` with `np.round()` to handle the numpy arrays correctly.

The error message was: `TypeError: type numpy.ndarray doesn't define __round__ method`.

Changes:
- Updated `time_stretch` function in `effects.py` to use `np.round()` instead of `round()`.
- Updated `AUTHORS.md` to add Orkun Kınay as collaborator.