### PR TITLE
Improved CMND implementation for YIN / pYIN

### DIFF
--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -762,7 +762,8 @@ def pyin(
     if fmin is None or fmax is None:
         raise ParameterError('both "fmin" and "fmax" must be provided')
 
-    __check_yin_params(
+   if not isinstance(win_length, Deprecated):
+       warnings.warn(FutureWarning, "win_length parameter is deprecated...")
         sr=sr, fmax=fmax, fmin=fmin, frame_length=frame_length, win_length=win_length
     )
 

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -963,11 +963,13 @@ def __check_yin_params(
         warnings.warn(
             f"With fmin={fmin:.3f}, sr={sr} and frame_length={frame_length}, less than two periods of fmin "
             f"fit into the frame, which can cause inaccurate pitch detection. "
-            f"Consider increasing to fmin={fmin_optimal} or frame_length={frame_length_optimal}."
+            f"Consider increasing to fmin={fmin_optimal} or frame_length={frame_length_optimal}.",
+            stacklevel=3
         )
 
     if win_length is not None:
         warnings.warn(
-            f"The win_length parameter has been depecrated in version 0.11.0 "
-            f"and has no effect. It will be removed in version 1.0.0."
+            f"The win_length parameter has been deprecated in version 0.11.0 "
+            f"and has no effect. It will be removed in version 1.0.0.",
+            stacklevel=3
         )

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -877,8 +877,7 @@ def pyin(
     t_switch = sequence.transition_loop(2, 1 - switch_prob)
     transition = np.kron(t_switch, transition)
 
-    p_init = np.zeros(2 * n_pitch_bins)
-    p_init[n_pitch_bins:] = 1 / n_pitch_bins
+    p_init = np.ones(2 * n_pitch_bins) / (2 * n_pitch_bins)
 
     states = sequence.viterbi(observation_probs, transition, p_init=p_init)
 

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -394,7 +394,7 @@ def _cumulative_mean_normalized_difference(
     k = slice(1, max_period + 1)
     yin_frames[..., 0, :] = 0
     yin_frames[..., k, :] = (
-        2 * (acf_frames[..., 0, :] - acf_frames[..., k, :]) - yin_frames[..., :k.stop-1, :]
+        2 * (acf_frames[..., 0:1, :] - acf_frames[..., k, :]) - yin_frames[..., :k.stop-1, :]
     )
 
     # Cumulative mean normalized difference function.

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -963,7 +963,7 @@ def __check_yin_params(
         warnings.warn(
             f"With fmin={fmin:.3f}, sr={sr} and frame_length={frame_length}, less than two periods of fmin "
             f"fit into the frame, which can cause inaccurate pitch detection. "
-            f"Consider increasing to fmin={fmin_optimal} or frame_length={frame_length_optimal}.",
+            f"Consider increasing to fmin={fmin_optimal:.3f} or frame_length={frame_length_optimal}.",
             stacklevel=3
         )
 

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -361,8 +361,6 @@ def piptrack(
 
 def _cumulative_mean_normalized_difference(
     y_frames: np.ndarray,
-    frame_length: int,
-    win_length: int,
     min_period: int,
     max_period: int,
 ) -> np.ndarray:
@@ -376,10 +374,6 @@ def _cumulative_mean_normalized_difference(
     ----------
     y_frames : np.ndarray [shape=(frame_length, n_frames)]
         framed audio time series.
-    frame_length : int > 0 [scalar]
-        length of the frames in samples.
-    win_length : int > 0 [scalar]
-        length of the window for calculating autocorrelation in samples.
     min_period : int > 0 [scalar]
         minimum period.
     max_period : int > 0 [scalar]
@@ -523,9 +517,6 @@ def yin(
         length of the frames in samples.
         By default, ``frame_length=2048`` corresponds to a time scale of about 93 ms at
         a sampling rate of 22050 Hz.
-    win_length : None or int > 0 [scalar]
-        length of the window for calculating autocorrelation in samples.
-        If ``None``, defaults to ``frame_length // 2``
     hop_length : None or int > 0 [scalar]
         number of audio samples between adjacent YIN predictions.
         If ``None``, defaults to ``frame_length // 4``.
@@ -543,6 +534,11 @@ def yin(
         ``y`` is padded on both sides with zeros.
         If ``center=False``,  this argument is ignored.
         .. see also:: `np.pad`
+    win_length : Deprecated
+        length of the window for calculating autocorrelation in samples.
+
+        .. warning:: This parameter is deprecated as of 0.11.0 and
+            will be removed in 1.0.
 
     Returns
     -------
@@ -568,10 +564,6 @@ def yin(
     if fmin is None or fmax is None:
         raise ParameterError('both "fmin" and "fmax" must be provided')
 
-    # Set the default window length if it is not already specified.
-    if win_length is None:
-        win_length = frame_length // 2
-
     __check_yin_params(
         sr=sr, fmax=fmax, fmin=fmin, frame_length=frame_length, win_length=win_length
     )
@@ -594,11 +586,11 @@ def yin(
 
     # Calculate minimum and maximum periods
     min_period = int(np.floor(sr / fmax))
-    max_period = min(int(np.ceil(sr / fmin)), frame_length - win_length - 1)
+    max_period = min(int(np.ceil(sr / fmin)), frame_length - 1)
 
     # Calculate cumulative mean normalized difference function.
     yin_frames = _cumulative_mean_normalized_difference(
-        y_frames, frame_length, win_length, min_period, max_period
+        y_frames, min_period, max_period
     )
 
     # Parabolic interpolation.
@@ -692,9 +684,6 @@ def pyin(
         length of the frames in samples.
         By default, ``frame_length=2048`` corresponds to a time scale of about 93 ms at
         a sampling rate of 22050 Hz.
-    win_length : None or int > 0 [scalar]
-        length of the window for calculating autocorrelation in samples.
-        If ``None``, defaults to ``frame_length // 2``
     hop_length : None or int > 0 [scalar]
         number of audio samples between adjacent pYIN predictions.
         If ``None``, defaults to ``frame_length // 4``.
@@ -729,6 +718,12 @@ def pyin(
         ``y`` is padded on both sides with zeros.
         If ``center=False``,  this argument is ignored.
         .. see also:: `np.pad`
+    win_length : Deprecated
+        length of the window for calculating autocorrelation in samples.
+
+        .. warning:: This parameter is deprecated as of 0.11.0 and
+            will be removed in 1.0.
+
 
     Returns
     -------
@@ -770,10 +765,6 @@ def pyin(
     if fmin is None or fmax is None:
         raise ParameterError('both "fmin" and "fmax" must be provided')
 
-    # Set the default window length if it is not already specified.
-    if win_length is None:
-        win_length = frame_length // 2
-
     __check_yin_params(
         sr=sr, fmax=fmax, fmin=fmin, frame_length=frame_length, win_length=win_length
     )
@@ -796,11 +787,11 @@ def pyin(
 
     # Calculate minimum and maximum periods
     min_period = int(np.floor(sr / fmax))
-    max_period = min(int(np.ceil(sr / fmin)), frame_length - win_length - 1)
+    max_period = min(int(np.ceil(sr / fmin)), frame_length - 1)
 
     # Calculate cumulative mean normalized difference function.
     yin_frames = _cumulative_mean_normalized_difference(
-        y_frames, frame_length, win_length, min_period, max_period
+        y_frames, min_period, max_period
     )
 
     # Parabolic interpolation.

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -952,7 +952,7 @@ def __check_yin_params(
         fmin_feasible = sr / (frame_length - 1)
         frame_length_feasible = int(np.ceil(sr/fmin) + 1)
         raise ParameterError(
-            f"fmin={fmin:.3f} is too small for frame_length={frame_length} and sr={sr}."
+            f"fmin={fmin:.3f} is too small for frame_length={frame_length} and sr={sr}. "
             f"Either increase to fmin={fmin_feasible:.3f} or frame_length={frame_length_feasible}"
         )
 
@@ -961,13 +961,13 @@ def __check_yin_params(
         frame_length_optimal = int(np.ceil(sr/fmin) * 2 + 1)
 
         warnings.warn(
-            f"With fmin={fmin:.3f}, sr={sr} and frame_length={frame_length}, less than two periods of fmin"
-            f"fit into the frame, which can cause inaccurate pitch detection."
+            f"With fmin={fmin:.3f}, sr={sr} and frame_length={frame_length}, less than two periods of fmin "
+            f"fit into the frame, which can cause inaccurate pitch detection. "
             f"Consider increasing to fmin={fmin_optimal} or frame_length={frame_length_optimal}."
         )
 
     if win_length is not None:
         warnings.warn(
-            f"The win_length parameter has been depecrated in version 0.11.0"
+            f"The win_length parameter has been depecrated in version 0.11.0 "
             f"and has no effect. It will be removed in version 1.0.0."
         )

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -596,6 +596,7 @@ def yin(
 
     # Find local minima.
     is_trough = util.localmin(yin_frames, axis=-2)
+    is_trough[..., 0, :] = yin_frames[..., 0, :] < yin_frames[..., 1, :]
 
     # Find minima below peak threshold.
     is_threshold_trough = np.logical_and(is_trough, yin_frames < trough_threshold)
@@ -871,6 +872,7 @@ def __pyin_helper(
         # 2. For each frame find the troughs.
         is_trough = util.localmin(yin_frame)
 
+        is_trough[0] = yin_frame[0] < yin_frame[1]
         (trough_index,) = np.nonzero(is_trough)
 
         if len(trough_index) == 0:

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -502,37 +502,46 @@ def yin(
     ----------
     y : np.ndarray [shape=(..., n)]
         audio time series. Multi-channel is supported..
+
     fmin : number > 0 [scalar]
         minimum frequency in Hertz.
         The recommended minimum is ``librosa.note_to_hz('C2')`` (~65 Hz)
         though lower values may be feasible.
+
     fmax : number > fmin, <= sr/2 [scalar]
         maximum frequency in Hertz.
         The recommended maximum is ``librosa.note_to_hz('C7')`` (~2093 Hz)
         though higher values may be feasible.
+
     sr : number > 0 [scalar]
         sampling rate of ``y`` in Hertz.
+
     frame_length : int > 0 [scalar]
         length of the frames in samples.
         By default, ``frame_length=2048`` corresponds to a time scale of about 93 ms at
         a sampling rate of 22050 Hz.
+
     hop_length : None or int > 0 [scalar]
         number of audio samples between adjacent YIN predictions.
         If ``None``, defaults to ``frame_length // 4``.
+
     trough_threshold : number > 0 [scalar]
         absolute threshold for peak estimation.
+
     center : boolean
         If ``True``, the signal `y` is padded so that frame
         ``D[:, t]`` is centered at `y[t * hop_length]`.
         If ``False``, then ``D[:, t]`` begins at ``y[t * hop_length]``.
         Defaults to ``True``,  which simplifies the alignment of ``D`` onto a
         time grid by means of ``librosa.core.frames_to_samples``.
+
     pad_mode : string or function
         If ``center=True``, this argument is passed to ``np.pad`` for padding
         the edges of the signal ``y``. By default (``pad_mode="constant"``),
         ``y`` is padded on both sides with zeros.
         If ``center=False``,  this argument is ignored.
         .. see also:: `np.pad`
+
     win_length : Deprecated
         length of the window for calculating autocorrelation in samples.
 
@@ -677,60 +686,75 @@ def pyin(
     ----------
     y : np.ndarray [shape=(..., n)]
         audio time series. Multi-channel is supported.
+
     fmin : number > 0 [scalar]
         minimum frequency in Hertz.
         The recommended minimum is ``librosa.note_to_hz('C2')`` (~65 Hz)
         though lower values may be feasible.
+
     fmax : number > fmin, <= sr/2 [scalar]
         maximum frequency in Hertz.
         The recommended maximum is ``librosa.note_to_hz('C7')`` (~2093 Hz)
         though higher values may be feasible.
+
     sr : number > 0 [scalar]
         sampling rate of ``y`` in Hertz.
+
     frame_length : int > 0 [scalar]
         length of the frames in samples.
         By default, ``frame_length=2048`` corresponds to a time scale of about 93 ms at
         a sampling rate of 22050 Hz.
+
     hop_length : None or int > 0 [scalar]
         number of audio samples between adjacent pYIN predictions.
         If ``None``, defaults to ``frame_length // 4``.
+
     n_thresholds : int > 0 [scalar]
         number of thresholds for peak estimation.
+
     beta_parameters : tuple
         shape parameters for the beta distribution prior over thresholds.
+
     boltzmann_parameter : number > 0 [scalar]
         shape parameter for the Boltzmann distribution prior over troughs.
         Larger values will assign more mass to smaller periods.
+
     resolution : float in `(0, 1)`
         Resolution of the pitch bins.
         0.01 corresponds to cents.
+
     max_transition_rate : float > 0
         maximum pitch transition rate in octaves per second.
+
     switch_prob : float in ``(0, 1)``
         probability of switching from voiced to unvoiced or vice versa.
+
     no_trough_prob : float in ``(0, 1)``
         maximum probability to add to global minimum if no trough is below threshold.
+
     fill_na : None, float, or ``np.nan``
         default value for unvoiced frames of ``f0``.
         If ``None``, the unvoiced frames will contain a best guess value.
+
     center : boolean
         If ``True``, the signal ``y`` is padded so that frame
         ``D[:, t]`` is centered at ``y[t * hop_length]``.
         If ``False``, then ``D[:, t]`` begins at ``y[t * hop_length]``.
         Defaults to ``True``,  which simplifies the alignment of ``D`` onto a
         time grid by means of ``librosa.core.frames_to_samples``.
+
     pad_mode : string or function
         If ``center=True``, this argument is passed to ``np.pad`` for padding
         the edges of the signal ``y``. By default (``pad_mode="constant"``),
         ``y`` is padded on both sides with zeros.
         If ``center=False``,  this argument is ignored.
         .. see also:: `np.pad`
+
     win_length : Deprecated
         length of the window for calculating autocorrelation in samples.
 
         .. warning:: This parameter is deprecated as of 0.11.0 and
             will be removed in 1.0.
-
 
     Returns
     -------

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -598,7 +598,6 @@ def yin(
 
     # Find local minima.
     is_trough = util.localmin(yin_frames, axis=-2)
-    is_trough[..., 0, :] = yin_frames[..., 0, :] < yin_frames[..., 1, :]
 
     # Find minima below peak threshold.
     is_threshold_trough = np.logical_and(is_trough, yin_frames < trough_threshold)
@@ -873,7 +872,6 @@ def __pyin_helper(
         # 2. For each frame find the troughs.
         is_trough = util.localmin(yin_frame)
 
-        is_trough[0] = yin_frame[0] < yin_frame[1]
         (trough_index,) = np.nonzero(is_trough)
 
         if len(trough_index) == 0:

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -14,6 +14,7 @@ from . import audio
 from .._cache import cache
 from .. import util
 from .. import sequence
+from ..util import Deprecated
 from ..util.exceptions import ParameterError
 from numpy.typing import ArrayLike
 from typing import Any, Callable, Optional, Tuple, Union
@@ -478,7 +479,7 @@ def yin(
     fmax: float,
     sr: float = 22050,
     frame_length: int = 2048,
-    win_length: Optional[int] = None,
+    win_length: Optional[Union[int, Deprecated]] = Deprecated(),
     hop_length: Optional[int] = None,
     trough_threshold: float = 0.1,
     center: bool = True,
@@ -562,8 +563,16 @@ def yin(
     if fmin is None or fmax is None:
         raise ParameterError('both "fmin" and "fmax" must be provided')
 
+    if not isinstance(win_length, Deprecated):
+        warnings.warn(
+            f"The win_length parameter has been deprecated in version 0.11.0 "
+            f"and has no effect. It will be removed in version 1.0.0.",
+            category=FutureWarning,
+            stacklevel=3,
+        )
+
     __check_yin_params(
-        sr=sr, fmax=fmax, fmin=fmin, frame_length=frame_length, win_length=win_length
+        sr=sr, fmax=fmax, fmin=fmin, frame_length=frame_length
     )
 
     # Set the default hop if it is not already specified.
@@ -637,7 +646,7 @@ def pyin(
     fmax: float,
     sr: float = 22050,
     frame_length: int = 2048,
-    win_length: Optional[int] = None,
+    win_length: Optional[Union[int, Deprecated]] = Deprecated(),
     hop_length: Optional[int] = None,
     n_thresholds: int = 100,
     beta_parameters: Tuple[float, float] = (2, 18),
@@ -763,9 +772,16 @@ def pyin(
     if fmin is None or fmax is None:
         raise ParameterError('both "fmin" and "fmax" must be provided')
 
-   if not isinstance(win_length, Deprecated):
-       warnings.warn(FutureWarning, "win_length parameter is deprecated...")
-        sr=sr, fmax=fmax, fmin=fmin, frame_length=frame_length, win_length=win_length
+    if not isinstance(win_length, Deprecated):
+        warnings.warn(
+            f"The win_length parameter has been deprecated in version 0.11.0 "
+            f"and has no effect. It will be removed in version 1.0.0.",
+            category=FutureWarning,
+            stacklevel=3,
+        )
+
+    __check_yin_params(
+        sr=sr, fmax=fmax, fmin=fmin, frame_length=frame_length
     )
 
     # Set the default hop if it is not already specified.
@@ -931,7 +947,7 @@ def __pyin_helper(
 
 
 def __check_yin_params(
-    *, sr: float, fmax: float, fmin: float, frame_length: int, win_length: int
+    *, sr: float, fmax: float, fmin: float, frame_length: int
 ):
     """Check the feasibility of yin/pyin parameters against
     the following conditions:
@@ -965,12 +981,5 @@ def __check_yin_params(
             f"With fmin={fmin:.3f}, sr={sr} and frame_length={frame_length}, less than two periods of fmin "
             f"fit into the frame, which can cause inaccurate pitch detection. "
             f"Consider increasing to fmin={fmin_optimal:.3f} or frame_length={frame_length_optimal}.",
-            stacklevel=3,
-        )
-
-    if win_length is not None:
-        warnings.warn(
-            f"The win_length parameter has been deprecated in version 0.11.0 "
-            f"and has no effect. It will be removed in version 1.0.0.",
             stacklevel=3,
         )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1219,6 +1219,16 @@ def test_yin_fail(fmin, fmax, frame_length):
         y, fmin=fmin, fmax=fmax, frame_length=frame_length
     )
 
+def test_yin_warn():
+    y = librosa.tone(110, duration=1.0)
+
+    # win_length is deprecated
+    with pytest.warns(FutureWarning, match="deprecated"):
+        librosa.yin(y, fmin=110, fmax=1000, win_length=1024)
+
+    # sr / fmin >= frame_length // 2
+    with pytest.warns(UserWarning, match="two periods"):
+        librosa.yin(y, fmin=20, fmax=1000)
 
 @pytest.mark.parametrize("freq", [110, 220, 440, 880])
 def test_pyin_tone(freq):
@@ -1344,6 +1354,13 @@ def test_pyin_fail(fmin, fmax, frame_length):
     librosa.pyin(
         y, fmin=fmin, fmax=fmax, frame_length=frame_length
     )
+
+def test_pyin_warn():
+    y = librosa.tone(110, duration=1.0)
+
+    # win_length is deprecated
+    with pytest.warns(FutureWarning, match="deprecated"):
+        librosa.pyin(y, fmin=110, fmax=1000, win_length=1024)
 
 
 @pytest.mark.parametrize("freq", [110, 220, 440, 880])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1328,16 +1328,18 @@ def test_pyin_chirp_instant():
 
     # test if correct frames are voiced
     assert np.array_equal(voiced_flag, target_f0 > 0)
-    # test voiced frames are within one cent of the target
-    atol = 1e-2 * np.ones(np.count_nonzero(voiced_flag))
 
-    # higher tolerance for the first and last frames, accounting for abrupt start / end
-    atol[0] = 1e-1
-    atol[-1] = 1e-1
+    # test voiced frames are within one cent of the target
+    cents = np.log2(f0[voiced_flag])
+    target_cents = np.log2(target_f0[target_f0 > 0])
 
     assert np.allclose(
-        np.log2(f0[voiced_flag]), np.log2(target_f0[target_f0 > 0]), rtol=0, atol=atol
+        np.log2(cents[1:-1]), np.log2(target_cents[1:-1]), rtol=0, atol=1e-2
     )
+
+    # higher tolerance for the first and last frames, accounting for abrupt start / end
+    assert np.abs(cents[0] - target_cents[0]) <= 1e-1
+    assert np.abs(cents[-1] - target_cents[-1]) <= 1e-1
 
 
 @pytest.mark.xfail(raises=librosa.ParameterError)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1238,7 +1238,7 @@ def test_pyin_tone(freq):
 
 
 def test_pyin_multi():
-    y = np.stack([librosa.tone(440, duration=0.1), librosa.tone(560, duration=0.1)])
+    y = np.stack([librosa.tone(440, duration=1.0), librosa.tone(560, duration=1.0)])
 
     # Taper the signal
     h = librosa.filters.get_window("triangle", y.shape[-1])


### PR DESCRIPTION
**TL;DR**: We can noticeably improve the accuracy of the YIN implementation by getting rid of the `win_length` parameter entirely and simply calculating the autocorrelation function (ACF) over the entire frame. Mathematical reasoning and some benchmarks provided below.

Apologies in advance for the wall of text. The devil is very much in the details with this one and I wanted to document it thoroughly.

## ACF Calculation

The main point of this pull request is to replace the calculation of the ACF: https://github.com/librosa/librosa/blob/d5aa7e1ae443c917fa53bef31055ed2613d63133/librosa/core/pitch.py#L393-L395 with a call to librosa's existing implementation: 

```python
acf_frames = audio.autocorrelate(y_frames, max_size=max_period+1, axis=-2)
``` 

Looking at this [discussion](https://github.com/librosa/librosa/pull/1063#discussion_r435547835), I believe the intention behind the current implementation is to calculate a type I ACF with a constant window size. Given window length $N$, this is defined as

$$r(k) = \sum_{n=0}^{N-1}x[n]x[n + k]$$

By contrast, the type II ACF uses an integration window that shrinks as the lag increases:

$$r'(k) = \sum_{n=0}^{N-1-k}x[n]x[n + k]$$

I'll go into some detail as to why I believe that 

1. the current implementation does not actually correctly calculate the type I ACF
2. the librosa implementation should use the type II ACF anyway (as implemented in `librosa.core.autocorrelate`)

It's true that the authors of the original YIN paper recommend to use the type I ACF, because the type II ACF implicitly tapers to 0 as $k \rightarrow N$. However, in the formulation of the type I ACF, the $n + k$ index will exceed the window size. This is not an issue discussed in the paper, since the authors consider the signal in its entirety, rather than on a frame-by-frame basis, so they can essentially "look into the future". 

As I understand it, the current implementation addresses this by making a distinction between `frame_length` $N$ and `win_length` $W < N$, where `win_length` essentially places an upper bound on the calculated lags. Mathematically,

$$r(k) = \sum_{n=0}^{W-1}x[n]x[n+k] \text{ for } 0\leq k < N - W$$

However, due to the `win_length:0:-1` indexing, the current code instead calculates:

$$r(k) = \sum_{n=0}^{W-1}x[n]x[n+k+1] \text{ for } 0\leq k < N - W$$

This off-by-one error was introduced [here](https://github.com/librosa/librosa/issues/1425). I think the reason that this change actually improved accuracy at the time is that it might have cancelled out another off-by-one error in the following calculation of the cumulative mean normalized difference (CMND) function, which this PR also fixes (see next section).

But this brings me to the second point of the argument: rather than fixing this calculation, I propose to drop the `win_length` parameter entirely and simply use `librosa.core.audio.autocorrelate` to calculate the type II ACF over the entire frame. This has several benefits:

- it simplifies the function call interface by removing a parameter
- using the type II ACF is standard in frame-by-frame implementations of YIN, in e.g. [aubio](https://github.com/aubio/aubio/blob/master/src/pitch/pitchyin.c) and also in the [original pYIN implementation](https://code.soundsoftware.ac.uk/projects/pyin/repository/entry/YinUtil.cpp#L57), so it aligns librosa with expected behavior.

As an example, the different ACFs are illustrated below for a 2048-sample frame from track 2 of the vocadito dataset. The highest peak of the type II ACF (excluding 0 lag) is at the correct period, while the type I ACF's peak at the correct period is slightly lower than the peak at double the period.

![ACF comparison](https://github.com/user-attachments/assets/eab25b47-8c1b-4927-b188-d31e1ef8054f)


## CMND Calculation

The next step in the YIN algorithm is to calculate the difference function. As mentioned before, the current implementation makes another off-by-one error here: https://github.com/librosa/librosa/blob/d5aa7e1ae443c917fa53bef31055ed2613d63133/librosa/core/pitch.py#L398-L406

Translating line 401 into mathematical notation, we see that the `energy_frame` $E$ is calculated as

$$\begin{align}
E(k) &= \sum_{n=0}^{W + k}x[n]^2 - \sum_{n=0}^{k}x[n]^2\\
&= \sum_{n=k+1}^{W + k}x[n]^2\\
&= \sum_{n=0}^{W - 1}x[n + k + 1]^2
\end{align}$$

Meaning that we end up with the same off-by-one error as seen before in the ACF correlation, which seem to cancel each other out to a degree.

The calculation needs to be adapted in any case to account for switching to the type II ACF $r'(k)$. We'll define 

$$\begin{align}E(k) &= \sum_{n=k}^{N-1}x[n]^2\\
&= \sum_{n=0}^{N-1}x[n]^2 - \sum_{n=0}^{k-1}x[n]^2\\
&= r'(0) - \sum_{n=0}^{k-1}x[n]^2
\end{align}$$

Following the logic of equation (7) from the YIN paper, the difference function can be calculated as

$$\begin{align}
d(k) &= r'(0) + E(k) - 2r'(k)\\
&= r'(0) + \left(r'(0) - \sum_{n=0}^{k-1}x[n]^2\right) - 2r'(k)\\
&= 2\left(r'(0) - r'(k)\right) - \sum_{n=0}^{k-1}x[n]^2
\end{align}$$

And going back from maths to code:

```python
yin_frames = np.cumsum(np.square(y_frames), axis=-2)

# Difference function: d(k) = 2 * (ACF(0) - ACF(k)) - sum_{m=0}^{k-1} y(m)^2
k = slice(1, max_period + 1)
yin_frames[..., 0, :] = 0
yin_frames[..., k, :] = (
    2 * (acf_frames[..., 0, :] - acf_frames[..., k, :]) - yin_frames[..., :k.stop-1, :]
)
``` 

The remaining steps (cumulative mean normalization, peak picking etc) are correct in the current implementation as far as I can tell.

## Benchmarks

I've run some comparisons using `mir_eval` that hopefully show that all this mathematical pedantry was worth it. The full numbers are contained [this Google sheet](https://docs.google.com/spreadsheets/d/15_eYfSo3drQSCM-cWmeYEokGsPsMtqqpg4E5PhnP5bs/edit?gid=0#gid=0), but I'll summarize the highlights here.


Using `fmin=80`, `fmax=800`, `sr=44100` and leaving all other values at their default, the new implementation improves the raw pitch accuracy of YIN (using a tolerance of 50 cents) on the [vocadito](https://zenodo.org/records/5578807) dataset significantly:

- from 95% to 98% using `frame_length=1024`
- from 92% to 98% using `frame_length=2048`

pYIN results also show clear improvements both for raw pitch accuracy and overall accuracy (taking into account V/UV decisions). 

The drawback is an increase in computational cost. The FFT is $O(N\log(N))$, and we've replaced 3 FFT operations with length $N/2$ with 2 operations of length $N$. That means at $N=2048$, we'd expect to take roughly 1.5x longer, which indeed matches the measurements for YIN. However, due to the more costly Viterbi decoding, this does not seem to have the same effect on pYIN running times.

## Additional changes

- I removed this line in both YIN and pYIN which marks $d'(0)$ as a trough if $d'(0) < d'(1)$: https://github.com/librosa/librosa/blob/d5aa7e1ae443c917fa53bef31055ed2613d63133/librosa/core/pitch.py#L612 This check is unnecessary since $d'(0) = 1$ by definition (equation 8 in the YIN paper), and a lag of 0 should never be selected as the period anyway.
- `__check_yin_parameters`
  - Since `win_length` is unused now, I've added a deprecation warning if it is called with any value other than `None`
  - It previously included this check: https://github.com/librosa/librosa/blob/d5aa7e1ae443c917fa53bef31055ed2613d63133/librosa/core/pitch.py#L967 I believe this is an error and should use `fmin`? As I understand it, the intention is an upper bound on the largest possible period, which corresponds to the lowest frequency, not the highest. I've changed this check to throw an error if the largest period `sr / fmin` exceeds `frame_length`.
  - Additionally there's a "softer" check (warning instead of error) for `sr / fmin >= frame_length // 2`, since ideally the frame should fit two periods of the lowest frequency for accurate f0 detection.