### PR TITLE
Update effects.py

### DIFF
--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -98,7 +98,7 @@ def hpss(
     power
     mask
     margin
-        See `librosa.deocmpose.hpss`
+        See `librosa.decompose.hpss`
     n_fft
     hop_length
     win_length
@@ -195,7 +195,7 @@ def harmonic(
     power
     mask
     margin
-        See `librosa.deocmpose.hpss`
+        See `librosa.decompose.hpss`
     n_fft
     hop_length
     win_length
@@ -281,7 +281,7 @@ def percussive(
     power
     mask
     margin
-        See `librosa.deocmpose.hpss`
+        See `librosa.decompose.hpss`
     n_fft
     hop_length
     win_length


### PR DESCRIPTION
decompose was mis-spelled as "deocmpose" in three places

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/main/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
<!-- Example: Fixes #123 -->
Just correcting a typo I caught while reading the docs

#### What does this implement/fix? Explain your changes.
s/deocmpose/decompose/g

#### Any other comments?
hope it's helpful rather than annoying
