### PR TITLE
declare numba requirement before numpy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -63,12 +63,12 @@ packages = find:
 include_package_data = True
 install_requires =
     audioread >= 2.1.9
+    numba >= 0.51.0
     numpy >= 1.20.3, != 1.22.0, != 1.22.1, != 1.22.2
     scipy >= 1.2.0
     scikit-learn >= 0.20.0
     joblib >= 0.14
     decorator >= 4.3.0
-    numba >= 0.51.0
     soundfile >= 0.12.1
     pooch >= 1.1
     soxr >= 0.3.2


### PR DESCRIPTION
Fixes #1896


#### What does this implement/fix? Explain your changes.

As mentioned in the issue, the following will currently fail:

```
> uv venv -p 3.12
> uv pip install librosa

error: Failed to prepare distributions
  Caused by: Failed to download and build `llvmlite==0.36.0`
  Caused by: Build backend failed to determine requirements with `build_wheel()` (exit status: 1)

[...]
```

I've run into this issue before and used the workaround of installing `numba` explicilty before librosa, which seems to fix the issue for some reason:

```
> uv venv -p 3.12
> uv pip install numba
> uv pip install librosa
# works
```

I have no idea whether the actual issue lies with `numba`, `llvmlite`, or `uv` itself. But `uv` is becoming very popular very quickly and it would be easy for `librosa` could incorporate this workaround by simply declaring `numba` as a dependency before `numpy`.

