### PR TITLE
allow skipping linkchecks on ~dpwe

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -412,3 +412,4 @@ smv_prefer_remote_refs = True
 
 
 linkcheck_allow_unauthorized = True
+linkcheck_ignore = ['https://www.ee.columbia.edu/~dpwe/resources/.*']


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR adds a `linkcheck_ignore` directive to allow doc CI to pass around 403 errors from @dpwe 's resources pages.

#### Any other comments?

The links still work fine, eg https://www.ee.columbia.edu/~dpwe/resources/matlab/pvoc/ , though the web server appears to have some overly restrictive permissioning that causes sphinx linkcheck to fail.