### PR TITLE
implemented testing with network isolation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,9 @@ If existing images need to be updated or new ones should be added:
 3. Inspect the new baseline images under tmp/
 4. If (3) looks good, copy into `tests/baseline_images/test_display/` and add to the PR.
 
+Additionally, some functions require network access to test properly.
+If you are adding tests that require network access, please mark them with `@pytest.mark.network`.
+
 Finally, once your pull request has been created and reviewed, please update the file `docs/changelog.rst`
 to briefly summarize your contribution in the section for the next release.
 If you are a first-time contributor, please add yourself to `AUTHORS.md` as well.

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -71,3 +71,20 @@ There are two ways to address this issue:
 
 Note that in librosa 0.10 and later, you may not encounter this issue when importing the library, but it may arise later when executing functions.
 The solutions above are applicable in either case.
+
+
+Testing in isolated environments
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Librosa provides a few functions that require network access to collect externally hosted data.
+While these functions are optional to use, they can be problematic for running the test suite in
+environments that restrict network access, which most commonly occurs in packaging workflows.
+To run the test suite in such restricted environments, you can specify the ``--librosa-isolation`` parameter
+on the command-line to pytest
+
+.. code-block:: shell
+
+    pytest --librosa-isolation
+
+which will skip any test functions known to require network access.  Test coverage will necessarily be reduced, but
+the remaining tests should still pass without problems.

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -1066,7 +1066,7 @@ def __lpc(
     # These two arrays hold the forward and backward prediction error. They
     # correspond to f_{M-1,k} and b_{M-1,k} in eqns 10, 11, 13 and 14 of
     # Marple. First they are used to compute the reflection coefficient at
-    # order M from M-1 then are re-used as f_{M,k} and b_{M,k} for each
+    # order M from M-1 then are used as f_{M,k} and b_{M,k} for each
     # iteration of the below loop
     fwd_pred_error = y[1:]
     bwd_pred_error = y[:-1]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,3 @@ requires = [
     "wheel >= 0.29.0",
 ]
 build-backend = 'setuptools.build_meta'
-
-[tool.pytest.ini_options]
-markers = [
-    "network: marks tests that require network access"
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,8 @@ requires = [
     "wheel >= 0.29.0",
 ]
 build-backend = 'setuptools.build_meta'
+
+[tool.pytest.ini_options]
+markers = [
+    "noisolation: marks tests to be skipped in isolation mode"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,5 +7,5 @@ build-backend = 'setuptools.build_meta'
 
 [tool.pytest.ini_options]
 markers = [
-    "noisolation: marks tests to be skipped in isolation mode"
+    "network: marks tests that require network access"
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ filterwarnings =
     ignore::DeprecationWarning:audioread.*
     ignore::DeprecationWarning:resampy.*
 
+
 [flake8]
 count = True
 statistics = True

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,6 +7,8 @@ The MATLAB script ``makeTestData.m`` generates input/output examples under the `
 
 After generating the test data, run ``pytest`` from the top-level source directory to perform tests and verify the outputs.
 
+Note: for testing in isolated environments without network access, you can use ``pytest --librosa-isolation`` to bypass any tests which depend on externally hosted data (example audio files, citation data, etc).
+
 
 Generating test data
 ====================

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+# Test configuration and customization
+
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--librosa-isolation",
+        action="store_true",
+        default=False,
+        help="Skip tests that require network access"
+    )
+    parser.addoption(
+        "--librosa-optional",
+        action="store_false",
+        default=True,
+        help="Run tests that use optional dependencies"
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    print(config.getoption("--librosa-isolation"))
+    if not config.getoption("--librosa-isolation"):
+        # User wants to run network tests, so do nothing.
+        return
+    skip_isolation = pytest.mark.skip(reason="testing in isolation mode")
+    for item in items:
+        if "noisolation" in item.keywords:
+            item.add_marker(skip_isolation)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,6 @@ def pytest_addoption(parser):
 
 
 def pytest_collection_modifyitems(config, items):
-    print(config.getoption("--librosa-isolation"))
     if not config.getoption("--librosa-isolation"):
         # User wants to run network tests, so do nothing.
         return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,12 +11,6 @@ def pytest_addoption(parser):
         default=False,
         help="Skip tests that require network access"
     )
-    parser.addoption(
-        "--librosa-optional",
-        action="store_false",
-        default=True,
-        help="Run tests that use optional dependencies"
-    )
 
 
 def pytest_collection_modifyitems(config, items):
@@ -28,3 +22,7 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if "network" in item.keywords:
             item.add_marker(skip_isolation)
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "network: mark tests that require network access.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,5 +26,5 @@ def pytest_collection_modifyitems(config, items):
         return
     skip_isolation = pytest.mark.skip(reason="testing in isolation mode")
     for item in items:
-        if "noisolation" in item.keywords:
+        if "network" in item.keywords:
             item.add_marker(skip_isolation)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -94,7 +94,7 @@ def test_load_audioread():
 def test_load_resample(res_type):
 
     sr_target = 16000
-    fn = librosa.ex("trumpet")
+    fn= os.path.join("tests", "data", "test1_44100.wav")
 
     y_native, sr = librosa.load(fn, sr=None, res_type=res_type)
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1190,6 +1190,7 @@ def test_stack_consistent(x, axis):
         assert xs.flags["C_CONTIGUOUS"]
 
 
+@pytest.mark.noisolation
 @pytest.mark.parametrize("key", ["trumpet", "brahms", "nutcracker",
     "choice", "humpback", "libri1", "libri2", "libri3", "pistachio",
     "robin", "sweetwaltz", "fishin", "vibeace"])
@@ -1205,6 +1206,7 @@ def test_example_fail():
     librosa.example("no such track")
 
 
+@pytest.mark.noisolation
 @pytest.mark.parametrize("key", ["trumpet", "brahms", "nutcracker",
     "choice", "humpback", "libri1", "libri2", "libri3", "pistachio",
     "robin", "sweetwaltz", "fishin", "vibeace"])
@@ -1385,6 +1387,7 @@ def test_phasor(dtype, angles, mag):
     assert z2.dtype == librosa.util.dtype_r2c(dtype)
 
 
+@pytest.mark.noisolation
 def test_cite_released():
     version = "0.10.1"
     doi = "https://doi.org/10.5281/zenodo.8252662"
@@ -1396,6 +1399,7 @@ def test_cite_badversion():
     librosa.cite(version="-1.5")
 
 
+@pytest.mark.noisolation
 @pytest.mark.xfail(raises=librosa.ParameterError)
 def test_cite_unreleased():
     librosa.cite("0.10.0.dev0")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1190,7 +1190,7 @@ def test_stack_consistent(x, axis):
         assert xs.flags["C_CONTIGUOUS"]
 
 
-@pytest.mark.noisolation
+@pytest.mark.network
 @pytest.mark.parametrize("key", ["trumpet", "brahms", "nutcracker",
     "choice", "humpback", "libri1", "libri2", "libri3", "pistachio",
     "robin", "sweetwaltz", "fishin", "vibeace"])
@@ -1206,7 +1206,7 @@ def test_example_fail():
     librosa.example("no such track")
 
 
-@pytest.mark.noisolation
+@pytest.mark.network
 @pytest.mark.parametrize("key", ["trumpet", "brahms", "nutcracker",
     "choice", "humpback", "libri1", "libri2", "libri3", "pistachio",
     "robin", "sweetwaltz", "fishin", "vibeace"])
@@ -1387,7 +1387,7 @@ def test_phasor(dtype, angles, mag):
     assert z2.dtype == librosa.util.dtype_r2c(dtype)
 
 
-@pytest.mark.noisolation
+@pytest.mark.network
 def test_cite_released():
     version = "0.10.1"
     doi = "https://doi.org/10.5281/zenodo.8252662"
@@ -1399,7 +1399,7 @@ def test_cite_badversion():
     librosa.cite(version="-1.5")
 
 
-@pytest.mark.noisolation
+@pytest.mark.network
 @pytest.mark.xfail(raises=librosa.ParameterError)
 def test_cite_unreleased():
     librosa.cite("0.10.0.dev0")


### PR DESCRIPTION
#### Reference Issue
Fixes #1845 


#### What does this implement/fix? Explain your changes.

Tests that require network access, notably those working with example data or citation data that are externally hosted, can now be skipped by saying `pytest --librosa-isolation`.  This should make it easier for downstream vendors to run (most of) our tests in their packaging automatic frameworks.

#### Any other comments?

I'm on the fence about doing a similar hack for optional dependencies, notably: resampy, samplerate, and matplotlib.  It will take a bit more surgery on our parameters and fixtures, and I'm not sure it's worth the effort (but I could be convinced).