### PR TITLE
Deprecate set_fftlib, update fftpack uses

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,15 +7,16 @@ v0.11.0
 2025-02-XX
 
 Maintenance
-
     - `#1831`_ Numpy 2.0 is now supported.
     - `#1898`_ Updated codecov action. *Brian McFee*
     - `#1860`_ Updated GitHub issue templates. *Brian McFee*
 
 Enhancements
+    - `#1916`_ The default FFT backend has been changed from `numpy` to `scipy`.
     - `#1864`_ Accelerated `abs2` calculation on real-typed inputs. *Brian McFee*
 
 Bug fixes
+    - `#1916`_ Utility decorators now preserve type annotations properly. *Brian McFee*
     - `#1900`_ Fixed an error in pooch registry definition. *Brian McFee*
     - `#1897`_ Accommodate dependency resolution issues with `uv`. *David Südholt*
     - `#1878`_ Improved accuracy for `yin` and `pyin`. *David Südholt*
@@ -31,9 +32,11 @@ Documentation
     - `#1856`_ Updated documentation example for Fast Mellin Transform. *Anmol Mishra*
 
 Deprecations
+    - `#1916`_ `librosa.set_fftlib` is deprecated and will be removed in version 1.0.  Users should transition to using `scipy.fft.set_backend` instead.
     - Expired deprecation of `mono=` parameter in `util.valid_audio`.
     - `win_length` parameter in `yin` and `pyin`
 
+.. _#1916: https://github.com/librosa/librosa/pull/1916
 .. _#1831: https://github.com/librosa/librosa/pull/1831
 .. _#1898: https://github.com/librosa/librosa/pull/1898
 .. _#1860: https://github.com/librosa/librosa/pull/1860

--- a/librosa/core/convert.py
+++ b/librosa/core/convert.py
@@ -1584,7 +1584,7 @@ def tuning_to_A4(
 
 
 def fft_frequencies(*, sr: float = 22050, n_fft: int = 2048) -> np.ndarray:
-    """Alternative implementation of `np.fft.fftfreq`
+    """Alternative interface for `np.fft.rfftfreq`
 
     Parameters
     ----------

--- a/librosa/core/fft.py
+++ b/librosa/core/fft.py
@@ -1,24 +1,32 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Fast Fourier Transform (FFT) library container"""
+import scipy.fft
+
 from types import ModuleType
 from typing import Optional
+from ..util.decorators import deprecated
 
 
 __all__ = ["get_fftlib", "set_fftlib"]
 
 # Object to hold FFT interfaces
-__FFTLIB: Optional[ModuleType] = None
+__FFTLIB: Optional[ModuleType] = scipy.fft
 
 
+@deprecated(version="0.11.0", version_removed="1.0")
 def set_fftlib(lib: Optional[ModuleType] = None) -> None:
     """Set the FFT library used by librosa.
+
+    .. warning:: This functionality is deprecated in librosa 0.11 and will be
+        removed in 1.0.  To achieve the same effect, use the
+        `scipy.fft.set_backend` function.
 
     Parameters
     ----------
     lib : None or module
-        Must implement an interface compatible with `numpy.fft`.
-        If ``None``, reverts to `numpy.fft`.
+        Must implement an interface compatible with `scipy.fft`.
+        If ``None``, reverts to `scipy.fft`.
 
     Examples
     --------
@@ -27,13 +35,13 @@ def set_fftlib(lib: Optional[ModuleType] = None) -> None:
     >>> import pyfftw
     >>> librosa.set_fftlib(pyfftw.interfaces.numpy_fft)
 
-    Reset to default `numpy` implementation
+    Reset to default `scipy` implementation
 
     >>> librosa.set_fftlib()
     """
     global __FFTLIB
     if lib is None:
-        from numpy import fft
+        from scipy import fft
 
         lib = fft
 
@@ -55,7 +63,3 @@ def get_fftlib() -> ModuleType:
         assert False  # pragma: no cover
 
     return __FFTLIB
-
-
-# Set the FFT library to numpy's, by default
-set_fftlib(None)

--- a/librosa/core/fft.py
+++ b/librosa/core/fft.py
@@ -41,9 +41,7 @@ def set_fftlib(lib: Optional[ModuleType] = None) -> None:
     """
     global __FFTLIB
     if lib is None:
-        from scipy import fft
-
-        lib = fft
+        lib = scipy.fft
 
     __FFTLIB = lib
 

--- a/librosa/core/fft.py
+++ b/librosa/core/fft.py
@@ -19,8 +19,9 @@ def set_fftlib(lib: Optional[ModuleType] = None) -> None:
     """Set the FFT library used by librosa.
 
     .. warning:: This functionality is deprecated in librosa 0.11 and will be
-        removed in 1.0.  To achieve the same effect, use the
-        `scipy.fft.set_backend` function.
+        removed in 1.0.  To achieve the same effect, use either the
+        `scipy.fft.set_backend` context manager or
+        `scipy.fft.set_global_backend` function.
 
     Parameters
     ----------

--- a/librosa/feature/inverse.py
+++ b/librosa/feature/inverse.py
@@ -4,8 +4,8 @@
 
 import warnings
 import numpy as np
-import scipy.fftpack
 
+from ..core.fft import get_fftlib
 from ..util.exceptions import ParameterError
 from ..core.spectrum import griffinlim
 from ..core.spectrum import db_to_power
@@ -253,7 +253,7 @@ def mfcc_to_mel(
     --------
     librosa.feature.mfcc
     librosa.feature.melspectrogram
-    scipy.fftpack.dct
+    scipy.fft.dct
     """
     if lifter > 0:
         n_mfcc = mfcc.shape[-2]
@@ -275,7 +275,8 @@ def mfcc_to_mel(
     elif lifter != 0:
         raise ParameterError("MFCC to mel lifter must be a non-negative number.")
 
-    logmel = scipy.fftpack.idct(mfcc, axis=-2, type=dct_type, norm=norm, n=n_mels)
+    fft = get_fftlib()
+    logmel = fft.idct(mfcc, axis=-2, type=dct_type, norm=norm, n=n_mels)
     melspec: np.ndarray = db_to_power(logmel, ref=ref)
     return melspec
 
@@ -363,7 +364,7 @@ def mfcc_to_audio(
     mel_to_audio
     librosa.feature.mfcc
     librosa.griffinlim
-    scipy.fftpack.dct
+    scipy.fft.dct
     """
     mel_spec = mfcc_to_mel(
         mfcc, n_mels=n_mels, dct_type=dct_type, norm=norm, ref=ref, lifter=lifter

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -5,12 +5,12 @@
 import numpy as np
 import scipy
 import scipy.signal
-import scipy.fftpack
 
 from .. import util
 from .. import filters
 from ..util.exceptions import ParameterError
 
+from ..core.fft import get_fftlib
 from ..core.convert import fft_frequencies
 from ..core.audio import zero_crossings
 from ..core.spectrum import power_to_db, _spectrogram
@@ -1923,7 +1923,7 @@ def mfcc(
     See Also
     --------
     melspectrogram
-    scipy.fftpack.dct
+    scipy.fft.dct
 
     Examples
     --------
@@ -1992,7 +1992,8 @@ def mfcc(
         # multichannel behavior may be different due to relative noise floor differences between channels
         S = power_to_db(melspectrogram(y=y, sr=sr, norm = mel_norm, **kwargs))
 
-    M: np.ndarray = scipy.fftpack.dct(S, axis=-2, type=dct_type, norm=norm)[
+    fft = get_fftlib()
+    M: np.ndarray = fft.dct(S, axis=-2, type=dct_type, norm=norm)[
         ..., :n_mfcc, :
     ]
 

--- a/librosa/util/decorators.py
+++ b/librosa/util/decorators.py
@@ -25,7 +25,7 @@ def moved(
     Using the decorated (old) function will result in a warning.
     """
 
-    def __wrapper(func, *args: P.args, **kwargs: P.kwargs) -> R:
+    def __wrapper(func: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
         """Warn the user, and then proceed."""
         warnings.warn(
             "{:s}\n\tThis function was moved to '{:s}.{:s}' in "
@@ -50,7 +50,7 @@ def deprecated(
     Using the decorated (old) function will result in a warning.
     """
 
-    def __wrapper(func, *args: P.args, **kwargs: P.kwargs) -> R:
+    def __wrapper(func: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
         """Warn the user, and then proceed."""
         warnings.warn(
             "{:s}.{:s}\n\tDeprecated as of librosa version {:s}."

--- a/librosa/util/decorators.py
+++ b/librosa/util/decorators.py
@@ -9,19 +9,23 @@ import functools
 from decorator import decorator
 import numpy as np
 from numpy.typing import DTypeLike
+from typing_extensions import ParamSpec  # Install typing_extensions in Python 3.8
 
 __all__ = ["moved", "deprecated", "vectorize"]
+
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
 def moved(
     *, moved_from: str, version: str, version_removed: str
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """Mark functions as moved/renamed.
 
     Using the decorated (old) function will result in a warning.
     """
 
-    def __wrapper(func, *args, **kwargs):
+    def __wrapper(func, *args: P.args, **kwargs: P.kwargs) -> R:
         """Warn the user, and then proceed."""
         warnings.warn(
             "{:s}\n\tThis function was moved to '{:s}.{:s}' in "
@@ -40,13 +44,13 @@ def moved(
 
 def deprecated(
     *, version: str, version_removed: str
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """Mark a function as deprecated.
 
     Using the decorated (old) function will result in a warning.
     """
 
-    def __wrapper(func, *args, **kwargs):
+    def __wrapper(func, *args: P.args, **kwargs: P.kwargs) -> R:
         """Warn the user, and then proceed."""
         warnings.warn(
             "{:s}.{:s}\n\tDeprecated as of librosa version {:s}."

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2274,7 +2274,7 @@ def test_pcen_stream_multi(axis):
 
 
 def test_get_fftlib():
-    import numpy.fft as fft
+    import scipy.fft as fft
 
     assert librosa.get_fftlib() is fft
 
@@ -2286,7 +2286,7 @@ def test_set_fftlib():
 
 
 def test_reset_fftlib():
-    import numpy.fft as fft
+    import scipy.fft as fft
 
     librosa.set_fftlib()
     assert librosa.get_fftlib() is fft

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2280,15 +2280,18 @@ def test_get_fftlib():
 
 
 def test_set_fftlib():
-    librosa.set_fftlib("foo")  # type: ignore
+    with pytest.warns(FutureWarning):
+        librosa.set_fftlib("foo")  # type: ignore
     assert librosa.get_fftlib() == "foo"  # type: ignore
-    librosa.set_fftlib()
+    with pytest.warns(FutureWarning):
+        librosa.set_fftlib()
 
 
 def test_reset_fftlib():
     import scipy.fft as fft
 
-    librosa.set_fftlib()
+    with pytest.warns(FutureWarning):
+        librosa.set_fftlib()
     assert librosa.get_fftlib() is fft
 
 


### PR DESCRIPTION
#### Reference Issue
Fixes #1915 

#### What does this implement/fix? Explain your changes.

This PR deprecates the `set_fftlib` functionality, to be removed in 1.0.

Users are instead instructed to use scipy's fft backend selector to customize FFT computations.

#### Any other comments?

The default fftlib is now scipy instead of numpy.  Both implementations now use pocketfft under the hood, so there should be no observable difference to end users.  Switching to scipy will make the transition to a fully scipy-oriented backend selection smoother though.

I've also migrated all uses of the legacy `scipy.fftpack` to now use `scipy.fft`.  This also should have no observable impact on users, but again allows us to fully swap out backends through scipy's selection (which was independent of fftpack previously).