### PR TITLE
Get samplerate installing from source on windows for python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,8 @@ jobs:
           if: runner.os == 'Windows'
           shell: pwsh
           run: |
-            choco install visualstudio2022buildtools --version=17.2.4
-            choco install visualstudio2022-workload-vctools --version=17.2.4
+            choco install visualstudio2022buildtools
+            choco install visualstudio2022-workload-vctools
 
         - name: Cache conda
           uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,18 @@ jobs:
           with:
             submodules: true
 
+        - name: Create short temp directory (Windows only)
+          if: runner.os == 'Windows'
+          run: mkdir C:\tmp
+          shell: cmd
+
+        - name: Set environment variables (Windows only)
+          if: runner.os == 'Windows'
+          run: |
+            echo "TMP=C:\tmp" >> $env:GITHUB_ENV
+            echo "TEMP=C:\tmp" >> $env:GITHUB_ENV
+          shell: pwsh
+
         - name: Install OS dependencies
           shell: bash -l {0}
           run: |
@@ -79,13 +91,6 @@ jobs:
               brew install libsamplerate
               ;;
             esac
-
-        - name: Setup MSVC
-          if: runner.os == 'Windows'
-          shell: pwsh
-          run: |
-            choco install visualstudio2022buildtools
-            choco install visualstudio2022-workload-vctools
 
         - name: Cache conda
           uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,13 @@ jobs:
               ;;
             esac
 
+        - name: Setup MSVC
+          if: runner.os == 'Windows'
+          shell: pwsh
+          run: |
+            choco install visualstudio2022buildtools --version=17.2.4
+            choco install visualstudio2022-workload-vctools --version=17.2.4
+
         - name: Cache conda
           uses: actions/cache@v4
           env:


### PR DESCRIPTION

#### What does this implement/fix? Explain your changes.

CI has been failing on windows after we bumped it to the python 3.13 environment.  The issue here is that the samplerate package does not ship wheels for 3.13, and installing from source does not work with the default environment config.

This PR tries to fix the windows environment, starting from copilot suggestions on how to get a working c++ compiler (and not 3 or 4 different ones at the same time, which seems to be what is going on currently).

#### Any other comments?

No idea if this will work.  But since the python-samplerate folks are not responding to my request for a new wheel for 3.13 win, I guess it's up to us to try making source builds work.
