### PR TITLE
0.11.0 final

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 
 v0.11.0
 -------
-2025-03-XX
+2025-03-11
 
 Maintenance
     - `#1831`_ Numpy 2.0 is now supported.

--- a/librosa/version.py
+++ b/librosa/version.py
@@ -6,7 +6,7 @@ import sys
 import importlib
 
 short_version = "0.11"
-version = "0.11.0rc1"
+version = "0.11.0"
 
 
 def __get_mod_version(modname):


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Final release management for 0.11.0.

#### Any other comments?

We have verified that samplerate does build properly on python 3.13 (CI failures were environment-related, not package-related).

Since audioread is lagging on merging the soft failure for legacy codecs, we'll tack them on as hard dependencies here to unstick the release.

If audioread does merge my fix at some point, we can do a post-release that ups the audioread min version and drops the hard dependencies on legacy codecs from our side.

Once CI passes, I'll cut the release.
