### PR TITLE
Variable-rate and non-iterative phase vocoding

### DIFF
--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1440,7 +1440,7 @@ def phase_vocoder(
 
     Returns
     -------
-    D_stretched : np.ndarray [shape=(..., d, t / rate), dtype=complex]
+    D_stretched : np.ndarray [shape=(..., n_bins, t / rate), dtype=complex]
         time-stretched STFT.
         For variable-rate stretching, the output will have `len(t_out)` frames.
 
@@ -1468,6 +1468,9 @@ def phase_vocoder(
 
     if (rate is None) == (t_out is None):
         raise ParameterError("Must specify exactly one of `rate` or `t_out`")
+
+    if (rate is not None) and (rate <= 0):
+        raise ParameterError(f"rate={rate} must be a positive number")
 
     if t_out is None:
         t_out = np.arange(0.0, n_frames, rate)
@@ -1509,8 +1512,8 @@ def phase_vocoder(
         copy=False,
     )
 
-    D_out: np.ndarray = util.phasor(phase, mag=mag_interp(t_out))
-    return D_out
+    D_stretched: np.ndarray = util.phasor(phase, mag=mag_interp(t_out))
+    return D_stretched
 
 
 @cache(level=20)

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1418,8 +1418,8 @@ def phase_vocoder(
         If given, `rate` must be None.
 
     kind : str
-        Interpolation kind for magnitude interpolation.
-        Passed to `scipy.interpolate.interp1d`.
+        Interpolation kind for magnitude interpolation, e.g., 'linear' or 'nearest'.
+        See `scipy.interpolate.interp1d` for a full list of supported options.
 
     hop_length : int > 0 [scalar] or None
         The number of samples between successive columns of ``D``.
@@ -1450,8 +1450,24 @@ def phase_vocoder(
     """
     n_frames = D.shape[-1]
 
+    if not isinstance(hop_length, Deprecated):
+        warnings.warn(
+            "The `hop_length` parameter is deprecated as of 1.0 and will be removed in 1.1. "
+            "It is unused in the current implementation.",
+            FutureWarning,
+            stacklevel=2,
+        )
+
+    if not isinstance(n_fft, Deprecated):
+        warnings.warn(
+            "The `n_fft` parameter is deprecated as of 1.0 and will be removed in 1.1. "
+            "It is unused in the current implementation.",
+            FutureWarning,
+            stacklevel=2,
+        )
+
     if (rate is None) == (t_out is None):
-        raise ValueError("Must specify exactly one of `rate` or `t_out`")
+        raise ParameterError("Must specify exactly one of `rate` or `t_out`")
 
     if t_out is None:
         t_out = np.arange(0.0, n_frames, rate)
@@ -1459,7 +1475,7 @@ def phase_vocoder(
     t_out = np.asarray(t_out, dtype=float)
 
     if np.any(t_out < 0) or np.any(t_out >= n_frames):
-        raise ValueError("t_out values must be in the range [0, D.shape[-1])")
+        raise ParameterError("t_out values must be in the range [0, D.shape[-1])")
 
     if np.any(np.diff(t_out) < 0):
         warnings.warn("t_out is not monotonic; phase estimation may be unstable", stacklevel=2)

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1493,8 +1493,8 @@ def phase_vocoder(
         copy=False,
     )
 
-    mags = mag_interp(t_out)
-    return util.phasor(phase, mag=mags)
+    D_out: np.ndarray = util.phasor(phase, mag=mag_interp(t_out))
+    return D_out
 
 
 @cache(level=20)

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -18,6 +18,7 @@ from .audio import resample
 from .._cache import cache
 from .. import util
 from ..util.exceptions import ParameterError
+from ..util.deprecation import Deprecated
 from ..filters import get_window, semitone_filterbank
 from ..filters import window_sumsquare
 from numpy.typing import DTypeLike
@@ -1365,9 +1366,11 @@ def magphase(D: np.ndarray, *, power: float = 1) -> Tuple[np.ndarray, np.ndarray
 def phase_vocoder(
     D: np.ndarray,
     *,
-    rate: float,
-    hop_length: Optional[int] = None,
-    n_fft: Optional[int] = None,
+    rate: Optional[float] = None,
+    t_out: Optional[np.ndarray] = None,
+    kind: str = "linear",
+    hop_length: Optional[Union[int, Deprecated]] = Deprecated(),
+    n_fft: Optional[Union[int, Deprecated]] = Deprecated(),
 ) -> np.ndarray:
     """Phase vocoder.  Given an STFT matrix D, speed up by a factor of ``rate``
 
@@ -1401,16 +1404,30 @@ def phase_vocoder(
 
     Parameters
     ----------
-    D : np.ndarray [shape=(..., d, t), dtype=complex]
+    D : np.ndarray [shape=(..., n_bins, n_frames), dtype=complex]
         STFT matrix
 
     rate : float > 0 [scalar]
         Speed-up factor: ``rate > 1`` is faster, ``rate < 1`` is slower.
+        Use this for constant-rate time-stretching.
+
+    t_out : np.ndarray [shape=(n_output,)], optional
+        Optional array of fractional input frame indices specifying the input time
+        corresponding to each output frame. Values must lie in [0, n_frames). 
+        This can be used for variable-rate time-stretching.
+        If given, `rate` must be None. 
+
+    kind : str
+        Interpolation kind for magnitude interpolation.
+        Passed to `scipy.interpolate.interp1d`.
 
     hop_length : int > 0 [scalar] or None
         The number of samples between successive columns of ``D``.
 
         If None, defaults to ``n_fft//4 = (D.shape[0]-1)//2``
+
+        .. warning:: This parameter is deprecated as of 1.0 and will
+            be removed in 1.1.  It is unused in the current implementation.
 
     n_fft : int > 0 or None
         The number of samples per frame in D.
@@ -1418,59 +1435,66 @@ def phase_vocoder(
         However, if D was constructed using an odd-length window, the correct
         frame length can be specified here.
 
+        .. warning:: This parameter is deprecated as of 1.0 and will
+            be removed in 1.1.  It is unused in the current implementation.
+
     Returns
     -------
     D_stretched : np.ndarray [shape=(..., d, t / rate), dtype=complex]
-        time-stretched STFT
+        time-stretched STFT.
+        For variable-rate stretching, the output will have `len(t_out)` frames.
 
     See Also
     --------
     pyrubberband
     """
-    if n_fft is None:
-        n_fft = 2 * (D.shape[-2] - 1)
+    n_frames = D.shape[-1]
 
-    if hop_length is None:
-        hop_length = int(n_fft // 4)
+    if (rate is None) == (t_out is None):
+        raise ValueError("Must specify exactly one of `rate` or `t_out`")
 
-    time_steps = np.arange(0, D.shape[-1], rate, dtype=np.float64)
+    if t_out is None:
+        t_out = np.arange(0.0, n_frames, rate)
 
-    # Create an empty output array
-    shape = list(D.shape)
-    shape[-1] = len(time_steps)
-    d_stretch = np.zeros_like(D, shape=shape)
+    t_out = np.asarray(t_out, dtype=float)
 
-    # Expected phase advance in each bin per frame
-    phi_advance = hop_length * convert.fft_frequencies(sr=2 * np.pi, n_fft=n_fft)
+    if np.any(t_out < 0) or np.any(t_out >= n_frames):
+        raise ValueError("t_out values must be in the range [0, D.shape[-1])")
 
-    # Phase accumulator; initialize to the first sample
-    phase_acc = np.angle(D[..., 0])
+    if np.any(np.diff(t_out) < 0):
+        warnings.warn("t_out is not monotonic; phase estimation may be unstable", stacklevel=2)
 
-    # Pad 0 columns to simplify boundary logic
-    padding = [(0, 0) for _ in D.shape]
-    padding[-1] = (0, 2)
-    D = np.pad(D, padding, mode="constant")
+    i0 = np.floor(t_out).astype(int)
+    i1 = np.minimum(i0 + 1, n_frames - 1)
 
-    for t, step in enumerate(time_steps):
-        columns = D[..., int(step) : int(step + 2)]
+    # Unwrapped phase
+    ph = np.unwrap(np.angle(D), axis=-1)
 
-        # Weighting for linear magnitude interpolation
-        alpha = np.mod(step, 1.0)
-        mag = (1.0 - alpha) * np.abs(columns[..., 0]) + alpha * np.abs(columns[..., 1])
+    # Phase differences for each output frame
+    diff = ph[..., i1] - ph[..., i0]  # (..., n_bins, n_out)
 
-        # Store to output array
-        d_stretch[..., t] = util.phasor(phase_acc, mag=mag)
+    # Initialize increments: shifted version of diff
+    phase = np.empty_like(diff)
+    # Initialize with the first output frame
+    phase[..., 0] = np.angle(D[..., i0[0]])
+    phase[..., 1:] = diff[..., :-1]
 
-        # Compute phase advance
-        dphase = np.angle(columns[..., 1]) - np.angle(columns[..., 0]) - phi_advance
+    # Cumulative phase; we can do this in-place to save a copy
+    np.cumsum(phase, axis=-1, out=phase)
 
-        # Wrap to -pi:pi range
-        dphase = dphase - 2.0 * np.pi * np.round(dphase / (2.0 * np.pi))
+    # Interpolate magnitudes
+    mag_interp = scipy.interpolate.interp1d(
+        np.arange(n_frames),
+        np.abs(D),
+        kind=kind,
+        axis=-1,
+        fill_value="extrapolate",
+        assume_sorted=True,
+        copy=False,
+    )
 
-        # Accumulate phase
-        phase_acc += phi_advance + dphase
-
-    return d_stretch
+    mags = mag_interp(t_out)
+    return util.phasor(phase, mag=mags)
 
 
 @cache(level=20)

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1468,7 +1468,7 @@ def phase_vocoder(
     i1 = np.minimum(i0 + 1, n_frames - 1)
 
     # Unwrapped phase
-    ph = np.unwrap(np.angle(D), axis=-1)
+    ph = np.angle(D)
 
     # Phase differences for each output frame
     diff = ph[..., i1] - ph[..., i0]  # (..., n_bins, n_out)

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1413,9 +1413,9 @@ def phase_vocoder(
 
     t_out : np.ndarray [shape=(n_output,)], optional
         Optional array of fractional input frame indices specifying the input time
-        corresponding to each output frame. Values must lie in [0, n_frames). 
+        corresponding to each output frame. Values must lie in [0, n_frames).
         This can be used for variable-rate time-stretching.
-        If given, `rate` must be None. 
+        If given, `rate` must be None.
 
     kind : str
         Interpolation kind for magnitude interpolation.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2794,3 +2794,9 @@ def test_phase_vocoder_nonmonotone():
     with pytest.warns(UserWarning, match="t_out is not monotonic"):
         D_stretch = librosa.phase_vocoder(D, t_out=t_out)
 
+@pytest.mark.parametrize("rate", [0, -1])
+@pytest.mark.xfail(raises=librosa.ParameterError)
+def test_phase_vocoder_negative_rate(rate):
+
+    D = np.zeros((3, 2), dtype=np.complex64)
+    librosa.phase_vocoder(D, rate=rate)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2722,3 +2722,58 @@ def test_f0_harmonics_incompat():
     harmonics = np.arange(1, 3)
 
     librosa.f0_harmonics(data, freqs=freqs, harmonics=harmonics, f0=f0)
+
+
+@pytest.mark.parametrize("rate", [0.5, 1, 3])
+def test_phase_vocoder_fixed_rate(rate, rng):
+    # Make a random complex spectrogram
+    D = rng.standard_normal(size=(257, 12)) + 1j * rng.standard_normal(size=(257, 12))
+    D_stretch = librosa.phase_vocoder(D, rate=rate)
+
+    # Check that the output has the correct shape
+    assert D_stretch.shape == (D.shape[0], int(np.ceil(D.shape[1] / rate)))
+
+    # Check that D interpolates the values properly
+    if rate >= 1:
+        assert np.allclose(np.abs(D[:, ::rate]), np.abs(D_stretch))
+    else:
+        assert np.allclose(np.abs(D), np.abs(D_stretch[:, ::int(1 / rate)]))
+
+
+def test_phase_vocoder_variable_rate(rng):
+    # Make a random complex spectrogram
+    D = rng.standard_normal(size=(257, 12)) + 1j * rng.standard_normal(size=(257, 12))
+
+    rate = 0.5
+
+    # We'll make constant rate vector, but it won't cover the whole input duration
+    # This is enough to verify the precomputed t_out code path
+    t_out = np.arange(0, D.shape[1] - 2, rate)
+
+    D_stretch = librosa.phase_vocoder(D, t_out=t_out)
+
+    assert D_stretch.shape == (D.shape[0], len(t_out))
+    assert np.allclose(np.abs(D[:, :-2]), np.abs(D_stretch[:, ::int(1 / rate)]))
+
+
+@pytest.mark.xfail(raises=librosa.ParameterError)
+def test_phase_vocoder_bad_inputs():
+    D = np.zeros((257, 12), dtype=np.complex64)
+
+    # Can only specify one of rate or t_out
+    librosa.phase_vocoder(D, rate=1.0, t_out=np.arange(6))
+
+
+def test_phase_vocoder_hop_deprecated():
+    D = np.zeros((257, 12), dtype=np.complex64)
+
+    with pytest.warns(FutureWarning, match="`hop_length` parameter is deprecated"):
+        librosa.phase_vocoder(D, rate=1.0, hop_length=64)
+
+def test_phase_vocoder_nfft_deprecated():
+    D = np.zeros((257, 12), dtype=np.complex64)
+
+    with pytest.warns(FutureWarning, match="`n_fft` parameter is deprecated"):
+        librosa.phase_vocoder(D, rate=1.0, n_fft=64)
+
+

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2770,10 +2770,27 @@ def test_phase_vocoder_hop_deprecated():
     with pytest.warns(FutureWarning, match="`hop_length` parameter is deprecated"):
         librosa.phase_vocoder(D, rate=1.0, hop_length=64)
 
+
 def test_phase_vocoder_nfft_deprecated():
     D = np.zeros((257, 12), dtype=np.complex64)
 
     with pytest.warns(FutureWarning, match="`n_fft` parameter is deprecated"):
         librosa.phase_vocoder(D, rate=1.0, n_fft=64)
 
+
+@pytest.mark.xfail(raises=librosa.ParameterError)
+def test_phase_vocoder_bad_t_out():
+    D = np.zeros((257, 12), dtype=np.complex64)
+
+    t_out = np.arange(14)
+    librosa.phase_vocoder(D, t_out=t_out)
+
+
+def test_phase_vocoder_nonmonotone():
+    D = np.zeros((257, 12), dtype=np.complex64)
+
+    t_out = np.array([1, 0, 1, 2, 3])
+
+    with pytest.warns(UserWarning, match="t_out is not monotonic"):
+        D_stretch = librosa.phase_vocoder(D, t_out=t_out)
 


### PR DESCRIPTION
#### Reference Issue
Fixes #517 
Fixes #1700
Fixes #1930 

#### What does this implement/fix? Explain your changes.
This PR is a second take at #1796 , implementing the following two changes:

1. The code is non-iterative, relying entirely on vector ops and scipy interpolators.  Results are substantially faster for slow-down (rate<1), and comparable for speedup (rate>1).
2. Variable-rate is finally supported through the `t_out` parameter.

#### Any other comments?

The `n_fft` and `hop_length` parameters are now deprecated, as they are not actually necessary to ensure correct operation.

We still need some unit tests to ensure coverage.  I'm blocking this for now until #1925 is complete so as to avoid redundant rewrites.

Meanwhile, it would be good to get an extra set of eyeballs on it, as I think the functionality is complete.