### PR TITLE
Trying a new environment cache setup in CI

### DIFF
--- a/.github/environment-docs.yml
+++ b/.github/environment-docs.yml
@@ -20,7 +20,7 @@ dependencies:
   - pooch>=1.1.0,<1.7
   - packaging>=20.0
   - matplotlib>=3.5
-  - sphinx>=5.1.0
+  - sphinx>=5.1.0,<8.0
   - msgpack-python>=1.0
   - sphinx-gallery>=0.10.1
   - sphinx_rtd_theme>=1.2.0

--- a/.github/environment-docs.yml
+++ b/.github/environment-docs.yml
@@ -20,7 +20,7 @@ dependencies:
   - pooch>=1.1.0,<1.7
   - packaging>=20.0
   - matplotlib>=3.5
-  - sphinx>=5.1.0,<8.0
+  - sphinx>=5.1.0
   - msgpack-python>=1.0
   - sphinx-gallery>=0.10.1
   - sphinx_rtd_theme>=1.2.0

--- a/.github/environment-docs.yml
+++ b/.github/environment-docs.yml
@@ -7,7 +7,7 @@ dependencies:
   - pip
   - audioread>=2.1.9
   - numpy>=1.22.3,<1.24.0
-  - scipy>=1.6.0
+  - scipy>=1.6.0,<1.13.0  # older versions of librosa need scipy<1.13.0 
   - scikit-learn>=1.2.0
   - joblib>=1.0.0
   - decorator>=4.3.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,27 +96,6 @@ jobs:
               ;;
             esac
 
-        # - name: Cache conda
-        #   uses: actions/cache@v4
-        #   env:
-        #     # Increase this value to reset cache if etc/example-environment.yml has not changed
-        #     CACHE_NUMBER: 0
-        #   with:
-        #     path: ~/conda_pkgs_dir
-        #     key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.python-version }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles( matrix.envfile ) }}
-        #
-        # - name: Install Conda environment
-        #   uses: conda-incubator/setup-miniconda@v3
-        #   with:
-        #     auto-update-conda: true
-        #     python-version: ${{ matrix.python-version }}
-        #     add-pip-as-python-dependency: true
-        #     auto-activate-base: false
-        #     activate-environment: test
-        #     channel-priority: ${{ matrix.channel-priority }}
-        #     environment-file: ${{ matrix.envfile }}
-        #     use-only-tar-bz2: false # IMPORTANT: This needs to be set for caching to work properly!
-
         - name: Setup Miniforge
           uses: conda-incubator/setup-miniconda@v3
           with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,26 +96,54 @@ jobs:
               ;;
             esac
 
-        - name: Cache conda
-          uses: actions/cache@v4
-          env:
-            # Increase this value to reset cache if etc/example-environment.yml has not changed
-            CACHE_NUMBER: 0
-          with:
-            path: ~/conda_pkgs_dir
-            key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.python-version }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles( matrix.envfile ) }}
+        # - name: Cache conda
+        #   uses: actions/cache@v4
+        #   env:
+        #     # Increase this value to reset cache if etc/example-environment.yml has not changed
+        #     CACHE_NUMBER: 0
+        #   with:
+        #     path: ~/conda_pkgs_dir
+        #     key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.python-version }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles( matrix.envfile ) }}
+        #
+        # - name: Install Conda environment
+        #   uses: conda-incubator/setup-miniconda@v3
+        #   with:
+        #     auto-update-conda: true
+        #     python-version: ${{ matrix.python-version }}
+        #     add-pip-as-python-dependency: true
+        #     auto-activate-base: false
+        #     activate-environment: test
+        #     channel-priority: ${{ matrix.channel-priority }}
+        #     environment-file: ${{ matrix.envfile }}
+        #     use-only-tar-bz2: false # IMPORTANT: This needs to be set for caching to work properly!
 
-        - name: Install Conda environment
+        - name: Setup Miniforge
           uses: conda-incubator/setup-miniconda@v3
           with:
-            auto-update-conda: true
-            python-version: ${{ matrix.python-version }}
-            add-pip-as-python-dependency: true
-            auto-activate-base: false
+            miniforge-version: latest
             activate-environment: test
-            channel-priority: ${{ matrix.channel-priority }}
-            environment-file: ${{ matrix.envfile }}
-            use-only-tar-bz2: false # IMPORTANT: This needs to be set for caching to work properly!
+
+        - name: Get Date
+          id: get-date
+          run: echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
+          shell: bash
+
+        - name: Cache Conda env
+          uses: actions/cache@v4
+          with:
+            path: ${{ env.CONDA }}/envs
+            key:
+              conda-${{ runner.os }}--${{ runner.arch }}--${{
+              steps.get-date.outputs.today }}-${{ env.CACHE_NUMBER
+              }}-${{ matrix.python-version }}-${{ hashFiles( matrix.envfile ) }}
+          env:
+            CACHE_NUMBER: 0
+          id: cache
+
+        - name: Update environment
+          run:
+            mamba env update -n test -f ${{ matrix.envfile }} 
+          if: steps.cache.outputs.cache-hit != 'true'
 
         - name: Conda info
           shell: bash -l {0}

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -35,26 +35,33 @@ jobs:
           with:
             fetch-depth: 0
 
-        - name: Cache conda
-          uses: actions/cache@v4
-          env:
-            # Increase this value to reset cache if etc/example-environment.yml has not changed
-            CACHE_NUMBER: 0
-          with:
-            path: ~/conda_pkgs_dir
-            key: ${{ runner.os }}-${{ matrix.python-version }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles( matrix.envfile ) }}
-
-        - name: Install Conda environment
+        - name: Setup Miniforge
           uses: conda-incubator/setup-miniconda@v3
           with:
-            auto-update-conda: false
-            python-version: ${{ matrix.python-version }}
-            add-pip-as-python-dependency: true
-            auto-activate-base: false
+            miniforge-version: latest
             activate-environment: docs
-            channel-priority: ${{ matrix.channel-priority }}
-            environment-file: ${{ matrix.envfile }}
-            use-only-tar-bz2: false # IMPORTANT: This needs to be set for caching to work properly!
+
+        - name: Get Date
+          id: get-date
+          run: echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
+          shell: bash
+
+        - name: Cache Conda env
+          uses: actions/cache@v4
+          with:
+            path: ${{ env.CONDA }}/envs
+            key:
+              conda-${{ runner.os }}--${{ runner.arch }}--${{
+              steps.get-date.outputs.today }}-${{ env.CACHE_NUMBER
+              }}-${{ matrix.python-version }}-${{ hashFiles( matrix.envfile ) }}
+          env:
+            CACHE_NUMBER: 0
+          id: cache
+
+        - name: Update environment
+          run:
+            mamba env update -n docs -f ${{ matrix.envfile }} 
+          if: steps.cache.outputs.cache-hit != 'true'
 
         - name: Conda info
           shell: bash -l {0}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -404,7 +404,7 @@ smv_branch_whitelist = (
     r"^main$"  # build main branch, and anything relating to documentation
 )
 smv_tag_whitelist = (
-    r"^((0\.10\.2)|(0\.11\.\d+)|(1\.0\.\d+)$"  # use this for final builds
+    r"^((0\.10\.2)|(0\.11\.\d+)|(1\.0\.\d+))$"  # use this for final builds
 )
 smv_released_pattern = r".*tags.*"
 smv_remote_whitelist = r"^origin$"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -404,7 +404,7 @@ smv_branch_whitelist = (
     r"^main$"  # build main branch, and anything relating to documentation
 )
 smv_tag_whitelist = (
-    r"^((0\.9\.2)|(0\.10\.2)|(0\.11\.\d+))$"  # use this for final builds
+    r"^((0\.10\.2)|(0\.11\.\d+)|(1\.0\.\d+)$"  # use this for final builds
 )
 smv_released_pattern = r".*tags.*"
 smv_remote_whitelist = r"^origin$"


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR updates the CI workflow to cache the conda environments instead of the downloaded packages.

With any luck, this should bring down our CI time substantially for repeated runs in short succession.