### PR TITLE
Remove default quantization for note_to_hz

### DIFF
--- a/librosa/core/convert.py
+++ b/librosa/core/convert.py
@@ -706,7 +706,7 @@ def note_to_hz(
     >>> librosa.note_to_hz(['A3', 'A4', 'A5'])
     array([ 220.,  440.,  880.])
     >>> # Notes with tuning deviations
-    >>> librosa.note_to_hz(['C2-32', 'C2']))
+    >>> librosa.note_to_hz(['C2-32', 'C2'])
     array([ 64.209,  65.406])
     >>> # Or discarding tuning deviations
     >>> librosa.note_to_hz(['C2-32', 'C2'], round_midi=True)

--- a/librosa/core/convert.py
+++ b/librosa/core/convert.py
@@ -676,24 +676,24 @@ def blocks_to_time(
 
 
 @overload
-def note_to_hz(note: str, **kwargs: Any) -> np.floating[Any]:
+def note_to_hz(note: str, *, round_midi: bool) -> np.floating[Any]:
     ...
 
 
 @overload
-def note_to_hz(note: _IterableLike[str], **kwargs: Any) -> np.ndarray:
+def note_to_hz(note: _IterableLike[str], *, round_midi: bool) -> np.ndarray:
     ...
 
 
 @overload
 def note_to_hz(
-    note: Union[str, _IterableLike[str], Iterable[str]], **kwargs: Any
+    note: Union[str, _IterableLike[str], Iterable[str]], *, round_midi: bool
 ) -> Union[np.floating[Any], np.ndarray]:
     ...
 
 
 def note_to_hz(
-    note: Union[str, _IterableLike[str], Iterable[str]], **kwargs: Any
+    note: Union[str, _IterableLike[str], Iterable[str]], *, round_midi: bool = False
 ) -> Union[np.floating[Any], np.ndarray]:
     """Convert one or more note names to frequency (Hz)
 
@@ -705,16 +705,20 @@ def note_to_hz(
     >>> # Or multiple notes
     >>> librosa.note_to_hz(['A3', 'A4', 'A5'])
     array([ 220.,  440.,  880.])
-    >>> # Or notes with tuning deviations
+    >>> # Notes with tuning deviations
     >>> librosa.note_to_hz('C2-32', round_midi=False)
     array([ 64.209])
+    >>> # Or discarding tuning deviations
+    >>> librosa.note_to_hz('C2-32', round_midi=True)
+    array([ 65.406])
 
     Parameters
     ----------
     note : str or iterable of str
         One or more note names to convert
-    **kwargs : additional keyword arguments
-        Additional parameters to `note_to_midi`
+    round_midi : bool
+        If ``True``, quantize the note to the nearest MIDI pitch before conversion.
+        If ``False``, allow for cent deviations in converting to Hz.
 
     Returns
     -------
@@ -727,7 +731,7 @@ def note_to_hz(
     note_to_midi
     hz_to_note
     """
-    return midi_to_hz(note_to_midi(note, **kwargs))
+    return midi_to_hz(note_to_midi(note, round_midi=round_midi))
 
 
 @overload

--- a/librosa/core/convert.py
+++ b/librosa/core/convert.py
@@ -706,11 +706,11 @@ def note_to_hz(
     >>> librosa.note_to_hz(['A3', 'A4', 'A5'])
     array([ 220.,  440.,  880.])
     >>> # Notes with tuning deviations
-    >>> librosa.note_to_hz('C2-32', round_midi=False)
-    array([ 64.209])
+    >>> librosa.note_to_hz(['C2-32', 'C2']))
+    array([ 64.209,  65.406])
     >>> # Or discarding tuning deviations
-    >>> librosa.note_to_hz('C2-32', round_midi=True)
-    array([ 65.406])
+    >>> librosa.note_to_hz(['C2-32', 'C2'], round_midi=True)
+    array([ 65.406,  65.406])
 
     Parameters
     ----------

--- a/librosa/core/convert.py
+++ b/librosa/core/convert.py
@@ -716,7 +716,7 @@ def note_to_hz(
     ----------
     note : str or iterable of str
         One or more note names to convert
-    round_midi : bool
+    round_midi : bool (default=False)
         If ``True``, quantize the note to the nearest MIDI pitch before conversion.
         If ``False``, allow for cent deviations in converting to Hz.
 

--- a/librosa/core/convert.py
+++ b/librosa/core/convert.py
@@ -676,18 +676,18 @@ def blocks_to_time(
 
 
 @overload
-def note_to_hz(note: str, *, round_midi: bool) -> np.floating[Any]:
+def note_to_hz(note: str, *, round_midi: bool = ...) -> np.floating[Any]:
     ...
 
 
 @overload
-def note_to_hz(note: _IterableLike[str], *, round_midi: bool) -> np.ndarray:
+def note_to_hz(note: _IterableLike[str], *, round_midi: bool = ...) -> np.ndarray:
     ...
 
 
 @overload
 def note_to_hz(
-    note: Union[str, _IterableLike[str], Iterable[str]], *, round_midi: bool
+    note: Union[str, _IterableLike[str], Iterable[str]], *, round_midi: bool = ...
 ) -> Union[np.floating[Any], np.ndarray]:
     ...
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -252,6 +252,11 @@ def test_note_to_hz_badnote():
     librosa.note_to_hz("does not pass")
 
 
+def test_note_to_hz_default():
+    hz = librosa.note_to_hz("C2-30", round_midi=False)
+    assert np.isclose(hz, librosa.note_to_hz("C2-30"))
+
+
 @pytest.mark.parametrize(
     "midi_num,note,octave,cents",
     [


### PR DESCRIPTION
#### Reference Issue
Fixes #1945 

#### What does this implement/fix? Explain your changes.

This PR makes two changes:

1. The call signature of `note_to_hz` is restricted to only allow the `round_midi` pass-through parameter.  (It was the only valid parameter anyway, so now it's just explicit.)
2. The default for `note_to_hz` is to have `round_midi=False` instead of True, as per discussion in #1945. 

#### Any other comments?

I expect this change will affect very few people, but it is technically a breaking change.