### PR TITLE
Freq convert nan

### DIFF
--- a/librosa/core/convert.py
+++ b/librosa/core/convert.py
@@ -760,7 +760,10 @@ def note_to_midi(
 
     The leading note name is case-insensitive.
 
+    The empty string ``""`` maps to `np.nan`.
+
     Sharps are indicated with ``#``, flats may be indicated with ``!`` or ``b``.
+
 
     Parameters
     ----------
@@ -813,6 +816,9 @@ def note_to_midi(
     """
     if not isinstance(note, str):
         return np.array([note_to_midi(n, round_midi=round_midi) for n in note])
+
+    if note == "":
+        return np.nan
 
     pitch_map: Dict[str, int] = {
         "C": 0,
@@ -912,6 +918,8 @@ def midi_to_note(
 
     MIDI numbers will be rounded to the nearest integer.
 
+    Non-finite values (NaN, inf, -inf) will return an empty string.
+
     Notes will be of the format 'C0', 'C♯0', 'D0', ...
 
     Examples
@@ -983,6 +991,9 @@ def midi_to_note(
     """
     if cents and not octave:
         raise ParameterError("Cannot encode cents without octave information.")
+
+    if not np.isfinite(midi):
+        return ""
 
     note_map = notation.key_to_notes(key=key, unicode=unicode)
 
@@ -2446,6 +2457,8 @@ def midi_to_svara_h(
 ) -> Union[str, np.ndarray]:
     """Convert MIDI numbers to Hindustani svara
 
+    Non-finite midi numbers (e.g., NaN, inf) will return an empty string.
+
     Parameters
     ----------
     midi : numeric or np.ndarray
@@ -2510,6 +2523,9 @@ def midi_to_svara_h(
     >>> librosa.midi_to_svara_h([72, 73, 74], Sa=60, abbr=False)
     array(['Ṡa', 'ṙe', 'Ṙe'], dtype='<U3')
     """
+    if not np.isfinite(midi):
+        return ""
+
     SVARA_MAP = [
         "Sa",
         "re",
@@ -2801,6 +2817,8 @@ def midi_to_svara_c(
 ) -> Union[str, np.ndarray]:
     """Convert MIDI numbers to Carnatic svara within a given melakarta raga
 
+    Non-finite midi numbers (e.g., NaN, inf) will return an empty string.
+
     Parameters
     ----------
     midi : numeric
@@ -2843,6 +2861,10 @@ def midi_to_svara_c(
     mela_to_svara
     list_mela
     """
+
+    if not np.isfinite(midi):
+        return ""
+
     svara_num = int(np.round(midi - Sa))
 
     svara_map = notation.mela_to_svara(mela, abbr=abbr, unicode=unicode)

--- a/librosa/core/convert.py
+++ b/librosa/core/convert.py
@@ -2461,7 +2461,7 @@ def midi_to_svara_h(
     >>> librosa.midi_to_svara_h([72, 73, 74], Sa=60, abbr=False)
     array(['Ṡa', 'ṙe', 'Ṙe'], dtype='<U3')
     """
-    if not np.isfinite(midi):  # type: ignore
+    if not np.isfinite(midi):
         return ""
 
     SVARA_MAP = [
@@ -2790,7 +2790,7 @@ def midi_to_svara_c(
     mela_to_svara
     list_mela
     """
-    if not np.isfinite(midi):  # type: ignore
+    if not np.isfinite(midi):
         return ""
 
     svara_num = int(np.round(midi - Sa))

--- a/librosa/core/convert.py
+++ b/librosa/core/convert.py
@@ -956,7 +956,7 @@ def midi_to_note(
     if cents and not octave:
         raise ParameterError("Cannot encode cents without octave information.")
 
-    if not np.isfinite(midi):
+    if not np.isfinite(midi):  # type: ignore
         return ""
 
     note_map = notation.key_to_notes(key=key, unicode=unicode)
@@ -2461,7 +2461,7 @@ def midi_to_svara_h(
     >>> librosa.midi_to_svara_h([72, 73, 74], Sa=60, abbr=False)
     array(['Ṡa', 'ṙe', 'Ṙe'], dtype='<U3')
     """
-    if not np.isfinite(midi):
+    if not np.isfinite(midi):  # type: ignore
         return ""
 
     SVARA_MAP = [
@@ -2790,7 +2790,7 @@ def midi_to_svara_c(
     mela_to_svara
     list_mela
     """
-    if not np.isfinite(midi):
+    if not np.isfinite(midi):  # type: ignore
         return ""
 
     svara_num = int(np.round(midi - Sa))

--- a/librosa/core/convert.py
+++ b/librosa/core/convert.py
@@ -64,8 +64,7 @@ __all__ = [
 @overload
 def frames_to_samples(
     frames: _IntLike_co, *, hop_length: int = 512, n_fft: Optional[int] = None
-) -> np.integer[Any]:
-    ...
+) -> np.integer[Any]: ...
 
 
 @overload
@@ -74,8 +73,7 @@ def frames_to_samples(
     *,
     hop_length: int = 512,
     n_fft: Optional[int] = None,
-) -> np.ndarray:
-    ...
+) -> np.ndarray: ...
 
 
 def frames_to_samples(
@@ -125,8 +123,7 @@ def frames_to_samples(
 @overload
 def samples_to_frames(
     samples: _IntLike_co, *, hop_length: int = ..., n_fft: Optional[int] = ...
-) -> np.integer[Any]:
-    ...
+) -> np.integer[Any]: ...
 
 
 @overload
@@ -135,8 +132,7 @@ def samples_to_frames(
     *,
     hop_length: int = ...,
     n_fft: Optional[int] = ...,
-) -> np.ndarray:
-    ...
+) -> np.ndarray: ...
 
 
 @overload
@@ -145,8 +141,7 @@ def samples_to_frames(
     *,
     hop_length: int = ...,
     n_fft: Optional[int] = ...,
-) -> Union[np.integer[Any], np.ndarray]:
-    ...
+) -> Union[np.integer[Any], np.ndarray]: ...
 
 
 def samples_to_frames(
@@ -211,8 +206,7 @@ def frames_to_time(
     sr: float = ...,
     hop_length: int = ...,
     n_fft: Optional[int] = ...,
-) -> np.floating[Any]:
-    ...
+) -> np.floating[Any]: ...
 
 
 @overload
@@ -222,8 +216,7 @@ def frames_to_time(
     sr: float = ...,
     hop_length: int = ...,
     n_fft: Optional[int] = ...,
-) -> np.ndarray:
-    ...
+) -> np.ndarray: ...
 
 
 @overload
@@ -233,8 +226,7 @@ def frames_to_time(
     sr: float = ...,
     hop_length: int = ...,
     n_fft: Optional[int] = ...,
-) -> Union[np.floating[Any], np.ndarray]:
-    ...
+) -> Union[np.floating[Any], np.ndarray]: ...
 
 
 def frames_to_time(
@@ -289,8 +281,7 @@ def time_to_frames(
     sr: float = ...,
     hop_length: int = ...,
     n_fft: Optional[int] = ...,
-) -> np.integer[Any]:
-    ...
+) -> np.integer[Any]: ...
 
 
 @overload
@@ -300,8 +291,7 @@ def time_to_frames(
     sr: float = ...,
     hop_length: int = ...,
     n_fft: Optional[int] = ...,
-) -> np.ndarray:
-    ...
+) -> np.ndarray: ...
 
 
 @overload
@@ -311,8 +301,7 @@ def time_to_frames(
     sr: float = ...,
     hop_length: int = ...,
     n_fft: Optional[int] = ...,
-) -> Union[np.integer[Any], np.ndarray]:
-    ...
+) -> Union[np.integer[Any], np.ndarray]: ...
 
 
 def time_to_frames(
@@ -368,22 +357,19 @@ def time_to_frames(
 
 
 @overload
-def time_to_samples(times: _FloatLike_co, *, sr: float = ...) -> np.integer[Any]:
-    ...
+def time_to_samples(times: _FloatLike_co, *, sr: float = ...) -> np.integer[Any]: ...
 
 
 @overload
 def time_to_samples(
     times: _SequenceLike[_FloatLike_co], *, sr: float = ...
-) -> np.ndarray:
-    ...
+) -> np.ndarray: ...
 
 
 @overload
 def time_to_samples(
     times: _ScalarOrSequence[_FloatLike_co], *, sr: float = ...
-) -> Union[np.integer[Any], np.ndarray]:
-    ...
+) -> Union[np.integer[Any], np.ndarray]: ...
 
 
 def time_to_samples(
@@ -418,22 +404,19 @@ def time_to_samples(
 
 
 @overload
-def samples_to_time(samples: _IntLike_co, *, sr: float = ...) -> np.floating[Any]:
-    ...
+def samples_to_time(samples: _IntLike_co, *, sr: float = ...) -> np.floating[Any]: ...
 
 
 @overload
 def samples_to_time(
     samples: _SequenceLike[_IntLike_co], *, sr: float = ...
-) -> np.ndarray:
-    ...
+) -> np.ndarray: ...
 
 
 @overload
 def samples_to_time(
     samples: _ScalarOrSequence[_IntLike_co], *, sr: float = ...
-) -> Union[np.floating[Any], np.ndarray]:
-    ...
+) -> Union[np.floating[Any], np.ndarray]: ...
 
 
 def samples_to_time(
@@ -475,22 +458,19 @@ def samples_to_time(
 
 
 @overload
-def blocks_to_frames(blocks: _IntLike_co, *, block_length: int) -> np.integer[Any]:
-    ...
+def blocks_to_frames(blocks: _IntLike_co, *, block_length: int) -> np.integer[Any]: ...
 
 
 @overload
 def blocks_to_frames(
     blocks: _SequenceLike[_IntLike_co], *, block_length: int
-) -> np.ndarray:
-    ...
+) -> np.ndarray: ...
 
 
 @overload
 def blocks_to_frames(
     blocks: _ScalarOrSequence[_IntLike_co], *, block_length: int
-) -> Union[np.integer[Any], np.ndarray]:
-    ...
+) -> Union[np.integer[Any], np.ndarray]: ...
 
 
 def blocks_to_frames(
@@ -534,22 +514,19 @@ def blocks_to_frames(
 @overload
 def blocks_to_samples(
     blocks: _IntLike_co, *, block_length: int, hop_length: int
-) -> np.integer[Any]:
-    ...
+) -> np.integer[Any]: ...
 
 
 @overload
 def blocks_to_samples(
     blocks: _SequenceLike[_IntLike_co], *, block_length: int, hop_length: int
-) -> np.ndarray:
-    ...
+) -> np.ndarray: ...
 
 
 @overload
 def blocks_to_samples(
     blocks: _ScalarOrSequence[_IntLike_co], *, block_length: int, hop_length: int
-) -> Union[np.integer[Any], np.ndarray]:
-    ...
+) -> Union[np.integer[Any], np.ndarray]: ...
 
 
 def blocks_to_samples(
@@ -600,15 +577,13 @@ def blocks_to_samples(
 @overload
 def blocks_to_time(
     blocks: _IntLike_co, *, block_length: int, hop_length: int, sr: float
-) -> np.floating[Any]:
-    ...
+) -> np.floating[Any]: ...
 
 
 @overload
 def blocks_to_time(
     blocks: _SequenceLike[_IntLike_co], *, block_length: int, hop_length: int, sr: float
-) -> np.ndarray:
-    ...
+) -> np.ndarray: ...
 
 
 @overload
@@ -618,8 +593,7 @@ def blocks_to_time(
     block_length: int,
     hop_length: int,
     sr: float,
-) -> Union[np.floating[Any], np.ndarray]:
-    ...
+) -> Union[np.floating[Any], np.ndarray]: ...
 
 
 def blocks_to_time(
@@ -676,20 +650,17 @@ def blocks_to_time(
 
 
 @overload
-def note_to_hz(note: str, *, round_midi: bool = ...) -> np.floating[Any]:
-    ...
+def note_to_hz(note: str, *, round_midi: bool = ...) -> np.floating[Any]: ...
 
 
 @overload
-def note_to_hz(note: _IterableLike[str], *, round_midi: bool = ...) -> np.ndarray:
-    ...
+def note_to_hz(note: _IterableLike[str], *, round_midi: bool = ...) -> np.ndarray: ...
 
 
 @overload
 def note_to_hz(
     note: Union[str, _IterableLike[str], Iterable[str]], *, round_midi: bool = ...
-) -> Union[np.floating[Any], np.ndarray]:
-    ...
+) -> Union[np.floating[Any], np.ndarray]: ...
 
 
 def note_to_hz(
@@ -735,20 +706,17 @@ def note_to_hz(
 
 
 @overload
-def note_to_midi(note: str, *, round_midi: bool = ...) -> Union[float, int]:
-    ...
+def note_to_midi(note: str, *, round_midi: bool = ...) -> Union[float, int]: ...
 
 
 @overload
-def note_to_midi(note: _IterableLike[str], *, round_midi: bool = ...) -> np.ndarray:
-    ...
+def note_to_midi(note: _IterableLike[str], *, round_midi: bool = ...) -> np.ndarray: ...
 
 
 @overload
 def note_to_midi(
     note: Union[str, _IterableLike[str], Iterable[str]], *, round_midi: bool = ...
-) -> Union[float, int, np.ndarray]:
-    ...
+) -> Union[float, int, np.ndarray]: ...
 
 
 def note_to_midi(
@@ -763,7 +731,6 @@ def note_to_midi(
     The empty string ``""`` maps to `np.nan`.
 
     Sharps are indicated with ``#``, flats may be indicated with ``!`` or ``b``.
-
 
     Parameters
     ----------
@@ -877,8 +844,7 @@ def midi_to_note(
     cents: bool = ...,
     key: str = ...,
     unicode: bool = ...,
-) -> str:
-    ...
+) -> str: ...
 
 
 @overload
@@ -889,8 +855,7 @@ def midi_to_note(
     cents: bool = ...,
     key: str = ...,
     unicode: bool = ...,
-) -> np.ndarray:
-    ...
+) -> np.ndarray: ...
 
 
 @overload
@@ -901,8 +866,7 @@ def midi_to_note(
     cents: bool = ...,
     key: str = ...,
     unicode: bool = ...,
-) -> Union[str, np.ndarray]:
-    ...
+) -> Union[str, np.ndarray]: ...
 
 
 @vectorize(excluded=["octave", "cents", "key", "unicode"])
@@ -1012,20 +976,17 @@ def midi_to_note(
 
 
 @overload
-def midi_to_hz(notes: _FloatLike_co) -> np.floating[Any]:
-    ...
+def midi_to_hz(notes: _FloatLike_co) -> np.floating[Any]: ...
 
 
 @overload
-def midi_to_hz(notes: _SequenceLike[_FloatLike_co]) -> np.ndarray:
-    ...
+def midi_to_hz(notes: _SequenceLike[_FloatLike_co]) -> np.ndarray: ...
 
 
 @overload
 def midi_to_hz(
     notes: _ScalarOrSequence[_FloatLike_co],
-) -> Union[np.ndarray, np.floating[Any]]:
-    ...
+) -> Union[np.ndarray, np.floating[Any]]: ...
 
 
 def midi_to_hz(
@@ -1062,20 +1023,17 @@ def midi_to_hz(
 
 
 @overload
-def hz_to_midi(frequencies: _FloatLike_co) -> np.floating[Any]:
-    ...
+def hz_to_midi(frequencies: _FloatLike_co) -> np.floating[Any]: ...
 
 
 @overload
-def hz_to_midi(frequencies: _SequenceLike[_FloatLike_co]) -> np.ndarray:
-    ...
+def hz_to_midi(frequencies: _SequenceLike[_FloatLike_co]) -> np.ndarray: ...
 
 
 @overload
 def hz_to_midi(
     frequencies: _ScalarOrSequence[_FloatLike_co],
-) -> Union[np.ndarray, np.floating[Any]]:
-    ...
+) -> Union[np.ndarray, np.floating[Any]]: ...
 
 
 def hz_to_midi(
@@ -1111,20 +1069,19 @@ def hz_to_midi(
 
 
 @overload
-def hz_to_note(frequencies: _FloatLike_co, **kwargs: Any) -> str:
-    ...
+def hz_to_note(frequencies: _FloatLike_co, **kwargs: Any) -> str: ...
 
 
 @overload
-def hz_to_note(frequencies: _SequenceLike[_FloatLike_co], **kwargs: Any) -> np.ndarray:
-    ...
+def hz_to_note(
+    frequencies: _SequenceLike[_FloatLike_co], **kwargs: Any
+) -> np.ndarray: ...
 
 
 @overload
 def hz_to_note(
     frequencies: _ScalarOrSequence[_FloatLike_co], **kwargs: Any
-) -> Union[str, np.ndarray]:
-    ...
+) -> Union[str, np.ndarray]: ...
 
 
 def hz_to_note(
@@ -1174,22 +1131,19 @@ def hz_to_note(
 
 
 @overload
-def hz_to_mel(frequencies: _FloatLike_co, *, htk: bool = ...) -> np.floating[Any]:
-    ...
+def hz_to_mel(frequencies: _FloatLike_co, *, htk: bool = ...) -> np.floating[Any]: ...
 
 
 @overload
 def hz_to_mel(
     frequencies: _SequenceLike[_FloatLike_co], *, htk: bool = ...
-) -> np.ndarray:
-    ...
+) -> np.ndarray: ...
 
 
 @overload
 def hz_to_mel(
     frequencies: _ScalarOrSequence[_FloatLike_co], *, htk: bool = ...
-) -> Union[np.floating[Any], np.ndarray]:
-    ...
+) -> Union[np.floating[Any], np.ndarray]: ...
 
 
 def hz_to_mel(
@@ -1250,20 +1204,17 @@ def hz_to_mel(
 
 
 @overload
-def mel_to_hz(mels: _FloatLike_co, *, htk: bool = ...) -> np.floating[Any]:
-    ...
+def mel_to_hz(mels: _FloatLike_co, *, htk: bool = ...) -> np.floating[Any]: ...
 
 
 @overload
-def mel_to_hz(mels: _SequenceLike[_FloatLike_co], *, htk: bool = ...) -> np.ndarray:
-    ...
+def mel_to_hz(mels: _SequenceLike[_FloatLike_co], *, htk: bool = ...) -> np.ndarray: ...
 
 
 @overload
 def mel_to_hz(
     mels: _ScalarOrSequence[_FloatLike_co], *, htk: bool = ...
-) -> Union[np.floating[Any], np.ndarray]:
-    ...
+) -> Union[np.floating[Any], np.ndarray]: ...
 
 
 def mel_to_hz(
@@ -1324,8 +1275,7 @@ def mel_to_hz(
 @overload
 def hz_to_octs(
     frequencies: _FloatLike_co, *, tuning: float = ..., bins_per_octave: int = ...
-) -> np.floating[Any]:
-    ...
+) -> np.floating[Any]: ...
 
 
 @overload
@@ -1334,8 +1284,7 @@ def hz_to_octs(
     *,
     tuning: float = ...,
     bins_per_octave: int = ...,
-) -> np.ndarray:
-    ...
+) -> np.ndarray: ...
 
 
 @overload
@@ -1344,8 +1293,7 @@ def hz_to_octs(
     *,
     tuning: float = ...,
     bins_per_octave: int = ...,
-) -> Union[np.floating[Any], np.ndarray]:
-    ...
+) -> Union[np.floating[Any], np.ndarray]: ...
 
 
 def hz_to_octs(
@@ -1390,8 +1338,7 @@ def hz_to_octs(
 @overload
 def octs_to_hz(
     octs: _FloatLike_co, *, tuning: float = ..., bins_per_octave: int = ...
-) -> np.floating[Any]:
-    ...
+) -> np.floating[Any]: ...
 
 
 @overload
@@ -1400,8 +1347,7 @@ def octs_to_hz(
     *,
     tuning: float = ...,
     bins_per_octave: int = ...,
-) -> np.ndarray:
-    ...
+) -> np.ndarray: ...
 
 
 @overload
@@ -1410,8 +1356,7 @@ def octs_to_hz(
     *,
     tuning: float = ...,
     bins_per_octave: int = ...,
-) -> Union[np.floating[Any], np.ndarray]:
-    ...
+) -> Union[np.floating[Any], np.ndarray]: ...
 
 
 def octs_to_hz(
@@ -1455,22 +1400,21 @@ def octs_to_hz(
 
 
 @overload
-def A4_to_tuning(A4: _FloatLike_co, *, bins_per_octave: int = ...) -> np.floating[Any]:
-    ...
+def A4_to_tuning(
+    A4: _FloatLike_co, *, bins_per_octave: int = ...
+) -> np.floating[Any]: ...
 
 
 @overload
 def A4_to_tuning(
     A4: _SequenceLike[_FloatLike_co], *, bins_per_octave: int = ...
-) -> np.ndarray:
-    ...
+) -> np.ndarray: ...
 
 
 @overload
 def A4_to_tuning(
     A4: _ScalarOrSequence[_FloatLike_co], *, bins_per_octave: int = ...
-) -> Union[np.floating[Any], np.ndarray]:
-    ...
+) -> Union[np.floating[Any], np.ndarray]: ...
 
 
 def A4_to_tuning(
@@ -1528,22 +1472,19 @@ def A4_to_tuning(
 @overload
 def tuning_to_A4(
     tuning: _FloatLike_co, *, bins_per_octave: int = ...
-) -> np.floating[Any]:
-    ...
+) -> np.floating[Any]: ...
 
 
 @overload
 def tuning_to_A4(
     tuning: _SequenceLike[_FloatLike_co], *, bins_per_octave: int = ...
-) -> np.ndarray:
-    ...
+) -> np.ndarray: ...
 
 
 @overload
 def tuning_to_A4(
     tuning: _ScalarOrSequence[_FloatLike_co], *, bins_per_octave: int = ...
-) -> Union[np.floating[Any], np.ndarray]:
-    ...
+) -> Union[np.floating[Any], np.ndarray]: ...
 
 
 def tuning_to_A4(
@@ -2418,8 +2359,7 @@ def midi_to_svara_h(
     abbr: bool = ...,
     octave: bool = ...,
     unicode: bool = ...,
-) -> str:
-    ...
+) -> str: ...
 
 
 @overload
@@ -2430,8 +2370,7 @@ def midi_to_svara_h(
     abbr: bool = ...,
     octave: bool = ...,
     unicode: bool = ...,
-) -> np.ndarray:
-    ...
+) -> np.ndarray: ...
 
 
 @overload
@@ -2442,8 +2381,7 @@ def midi_to_svara_h(
     abbr: bool = ...,
     octave: bool = ...,
     unicode: bool = ...,
-) -> Union[str, np.ndarray]:
-    ...
+) -> Union[str, np.ndarray]: ...
 
 
 @vectorize(excluded=["Sa", "abbr", "octave", "unicode"])
@@ -2574,8 +2512,7 @@ def hz_to_svara_h(
     abbr: bool = ...,
     octave: bool = ...,
     unicode: bool = ...,
-) -> str:
-    ...
+) -> str: ...
 
 
 @overload
@@ -2586,8 +2523,7 @@ def hz_to_svara_h(
     abbr: bool = ...,
     octave: bool = ...,
     unicode: bool = ...,
-) -> np.ndarray:
-    ...
+) -> np.ndarray: ...
 
 
 @overload
@@ -2598,8 +2534,7 @@ def hz_to_svara_h(
     abbr: bool = ...,
     octave: bool = ...,
     unicode: bool = ...,
-) -> Union[str, np.ndarray]:
-    ...
+) -> Union[str, np.ndarray]: ...
 
 
 def hz_to_svara_h(
@@ -2673,8 +2608,7 @@ def hz_to_svara_h(
 @overload
 def note_to_svara_h(
     notes: str, *, Sa: str, abbr: bool = ..., octave: bool = ..., unicode: bool = ...
-) -> str:
-    ...
+) -> str: ...
 
 
 @overload
@@ -2685,8 +2619,7 @@ def note_to_svara_h(
     abbr: bool = ...,
     octave: bool = ...,
     unicode: bool = ...,
-) -> np.ndarray:
-    ...
+) -> np.ndarray: ...
 
 
 @overload
@@ -2697,8 +2630,7 @@ def note_to_svara_h(
     abbr: bool = ...,
     octave: bool = ...,
     unicode: bool = ...,
-) -> Union[str, np.ndarray]:
-    ...
+) -> Union[str, np.ndarray]: ...
 
 
 def note_to_svara_h(
@@ -2775,8 +2707,7 @@ def midi_to_svara_c(
     abbr: bool = ...,
     octave: bool = ...,
     unicode: bool = ...,
-) -> str:
-    ...
+) -> str: ...
 
 
 @overload
@@ -2788,8 +2719,7 @@ def midi_to_svara_c(
     abbr: bool = ...,
     octave: bool = ...,
     unicode: bool = ...,
-) -> np.ndarray:
-    ...
+) -> np.ndarray: ...
 
 
 @overload
@@ -2801,8 +2731,7 @@ def midi_to_svara_c(
     abbr: bool = ...,
     octave: bool = ...,
     unicode: bool = ...,
-) -> Union[str, np.ndarray]:
-    ...
+) -> Union[str, np.ndarray]: ...
 
 
 @vectorize(excluded=["Sa", "mela", "abbr", "octave", "unicode"])  # type: ignore
@@ -2895,8 +2824,7 @@ def hz_to_svara_c(
     abbr: bool = ...,
     octave: bool = ...,
     unicode: bool = ...,
-) -> str:
-    ...
+) -> str: ...
 
 
 @overload
@@ -2908,8 +2836,7 @@ def hz_to_svara_c(
     abbr: bool = ...,
     octave: bool = ...,
     unicode: bool = ...,
-) -> np.ndarray:
-    ...
+) -> np.ndarray: ...
 
 
 @overload
@@ -2921,8 +2848,7 @@ def hz_to_svara_c(
     abbr: bool = ...,
     octave: bool = ...,
     unicode: bool = ...,
-) -> Union[str, np.ndarray]:
-    ...
+) -> Union[str, np.ndarray]: ...
 
 
 def hz_to_svara_c(
@@ -3007,8 +2933,7 @@ def note_to_svara_c(
     abbr: bool = ...,
     octave: bool = ...,
     unicode: bool = ...,
-) -> str:
-    ...
+) -> str: ...
 
 
 @overload
@@ -3020,8 +2945,7 @@ def note_to_svara_c(
     abbr: bool = ...,
     octave: bool = ...,
     unicode: bool = ...,
-) -> np.ndarray:
-    ...
+) -> np.ndarray: ...
 
 
 @overload
@@ -3033,8 +2957,7 @@ def note_to_svara_c(
     abbr: bool = ...,
     octave: bool = ...,
     unicode: bool = ...,
-) -> Union[str, np.ndarray]:
-    ...
+) -> Union[str, np.ndarray]: ...
 
 
 def note_to_svara_c(
@@ -3114,8 +3037,7 @@ def hz_to_fjs(
     fmin: Optional[float] = ...,
     unison: Optional[str] = ...,
     unicode: bool = ...,
-) -> str:
-    ...
+) -> str: ...
 
 
 @overload
@@ -3125,8 +3047,7 @@ def hz_to_fjs(
     fmin: Optional[float] = ...,
     unison: Optional[str] = ...,
     unicode: bool = ...,
-) -> np.ndarray:
-    ...
+) -> np.ndarray: ...
 
 
 def hz_to_fjs(

--- a/librosa/core/convert.py
+++ b/librosa/core/convert.py
@@ -2790,7 +2790,6 @@ def midi_to_svara_c(
     mela_to_svara
     list_mela
     """
-
     if not np.isfinite(midi):
         return ""
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -752,12 +752,12 @@ def test_midi_to_note_empty(value):
 
 
 @pytest.mark.parametrize("value", [np.inf, -np.inf, np.nan])
-def test_midi_to_svara_h(value):
+def test_midi_to_svara_h_empty(value):
     assert librosa.midi_to_svara_h(value, Sa=60) == ""
 
 
 @pytest.mark.parametrize("value", [np.inf, -np.inf, np.nan])
-def test_midi_to_svara_c(value):
+def test_midi_to_svara_c_empty(value):
     assert librosa.midi_to_svara_c(value, Sa=60, mela=22) == ""
 
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -750,9 +750,11 @@ def test_note_to_svara_c(note, Sa, mela, abbr, octave, unicode, result):
 def test_midi_to_note_empty(value):
     assert librosa.midi_to_note(value) == ""
 
+
 @pytest.mark.parametrize("value", [np.inf, -np.inf, np.nan])
 def test_midi_to_svara_h(value):
     assert librosa.midi_to_svara_h(value, Sa=60) == ""
+
 
 @pytest.mark.parametrize("value", [np.inf, -np.inf, np.nan])
 def test_midi_to_svara_c(value):

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -744,3 +744,20 @@ def test_note_to_svara_c(note, Sa, mela, abbr, octave, unicode, result):
         note, Sa=Sa, mela=mela, abbr=abbr, octave=octave, unicode=unicode
     )
     assert s == result
+
+
+@pytest.mark.parametrize("value", [np.inf, -np.inf, np.nan])
+def test_midi_to_note_empty(value):
+    assert librosa.midi_to_note(value) == ""
+
+@pytest.mark.parametrize("value", [np.inf, -np.inf, np.nan])
+def test_midi_to_svara_h(value):
+    assert librosa.midi_to_svara_h(value, Sa=60) == ""
+
+@pytest.mark.parametrize("value", [np.inf, -np.inf, np.nan])
+def test_midi_to_svara_c(value):
+    assert librosa.midi_to_svara_c(value, Sa=60, mela=22) == ""
+
+
+def test_note_to_midi_empty():
+    assert np.isnan(librosa.note_to_midi(""))


### PR DESCRIPTION
#### Reference Issue
Fixes #1944 


#### What does this implement/fix? Explain your changes.

This PR implements #1944, adding support for nan or inf <-> empty string in note and svara converters.

#### Any other comments?

I did not implement nan support in FJS conversion, since it would amount to a slightly more invasive set of changes to the interval calculations.  I'm okay with not supporting nan/empty string in FJS anyway.

Tests are implemented, so I think as long as this passes CI it should be good to merge.