### PR TITLE
SPEC07 compliant rng parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A python package for music and audio analysis.
 [![CI](https://github.com/librosa/librosa/actions/workflows/ci.yml/badge.svg)](https://github.com/librosa/librosa/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/librosa/librosa/branch/main/graph/badge.svg?token=ULWnUHaIJC)](https://codecov.io/gh/librosa/librosa)
 [![Docs](https://github.com/librosa/librosa/actions/workflows/docs.yml/badge.svg)](https://librosa.org/doc/latest/index.html)
-
+[![Scientific Python Ecosystem Coordination](https://img.shields.io/badge/SPEC-7-green?labelColor=%23004811&color=%235CA038)](https://scientific-python.org/specs/)
 #  Table of Contents
 
 - [Documentation](#Documentation)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A python package for music and audio analysis.
 [![CI](https://github.com/librosa/librosa/actions/workflows/ci.yml/badge.svg)](https://github.com/librosa/librosa/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/librosa/librosa/branch/main/graph/badge.svg?token=ULWnUHaIJC)](https://codecov.io/gh/librosa/librosa)
 [![Docs](https://github.com/librosa/librosa/actions/workflows/docs.yml/badge.svg)](https://librosa.org/doc/latest/index.html)
-[![Scientific Python Ecosystem Coordination](https://img.shields.io/badge/SPEC-7-green?labelColor=%23004811&color=%235CA038)](https://scientific-python.org/specs/)
+[![Scientific Python Ecosystem Coordination](https://img.shields.io/badge/SPEC-1,7-green?labelColor=%23004811&color=%235CA038)](https://scientific-python.org/specs/)
 #  Table of Contents
 
 - [Documentation](#Documentation)

--- a/librosa/_typing.py
+++ b/librosa/_typing.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Callable, Generator, List, TypeVar, Union, Tuple, Any, Sequence
 from typing_extensions import Literal, Never
 import numpy as np
 from numpy.typing import ArrayLike
 import scipy.sparse as sp
+
+
+# RNG types
+SeedLike = int | np.integer | Sequence[int] | np.random.SeedSequence
+RNGLike = np.random.Generator | np.random.BitGenerator
 
 
 _WindowSpec = Union[str, Tuple[Any, ...], float, Callable[[int], np.ndarray], ArrayLike]

--- a/librosa/_typing.py
+++ b/librosa/_typing.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Callable, Generator, List, TypeVar, Union, Tuple, Any, Sequence
+from typing import Callable, Generator, List, TypeVar, Union, Tuple, Any
 from typing_extensions import Literal, Never
 import numpy as np
 from numpy.typing import ArrayLike

--- a/librosa/_typing.py
+++ b/librosa/_typing.py
@@ -9,8 +9,8 @@ import scipy.sparse as sp
 
 
 # RNG types
-SeedLike = int | np.integer | Sequence[int] | np.random.SeedSequence
-RNGLike = np.random.Generator | np.random.BitGenerator
+SeedLike = Union[int, np.integer, Sequence[int], np.random.SeedSequence]
+RNGLike = Union[np.random.Generator, np.random.BitGenerator]
 
 
 _WindowSpec = Union[str, Tuple[Any, ...], float, Callable[[int], np.ndarray], ArrayLike]

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -15,9 +15,17 @@ from .._cache import cache
 from .. import filters
 from .. import util
 from ..util.exceptions import ParameterError
+from ..util.deprecation import rename_kw, Deprecated
 from numpy.typing import DTypeLike
 from typing import Optional, Union, Collection, List
-from .._typing import _WindowSpec, _PadMode, _FloatLike_co, _ensure_not_reachable
+from .._typing import (
+    _WindowSpec,
+    _PadMode,
+    _FloatLike_co,
+    _ensure_not_reachable,
+    RNGLike,
+    SeedLike,
+)
 
 __all__ = ["cqt", "hybrid_cqt", "pseudo_cqt", "icqt", "griffinlim_cqt", "vqt"]
 
@@ -1226,9 +1234,10 @@ def griffinlim_cqt(
     length: Optional[int] = None,
     momentum: float = 0.99,
     init: Optional[str] = "random",
+    rng: Optional[Union[RNGLike, SeedLike]] = None,
     random_state: Optional[
-        Union[int, np.random.RandomState, np.random.Generator]
-    ] = None,
+        Union[int, np.random.RandomState, np.random.Generator, Deprecated]
+    ] = Deprecated(),
 ) -> np.ndarray:
     """Approximate constant-Q magnitude spectrogram inversion using the "fast" Griffin-Lim
     algorithm.
@@ -1331,13 +1340,23 @@ def griffinlim_cqt(
         an initial guess for phase can be provided, or when you want to resume
         Griffin-Lim from a previous output.
 
+    rng : None, int, sequence of int, np.random.Generator, or np.random.RandomState
+        Pseudorandom number generator state. When `rng` is None, a new
+        `numpy.random.Generator` is created using entropy from the
+        operating system. Types other than `numpy.random.Generator` are
+        passed to `numpy.random.default_rng` to instantiate a ``Generator``.
+
     random_state : None, int, np.random.RandomState, or np.random.Generator
+        .. warning:: This parameter is deprecated in 1.0.0 and will be removed in 1.2.0.
+
         If int, random_state is the seed used by the random number generator
         for phase initialization.
 
         If `np.random.RandomState` or `np.random.Generator` instance, the random number generator itself.
 
         If ``None``, defaults to the `np.random.default_rng()` object.
+
+        An exception is raised if both `rng` and `random_state` are provided.
 
     Returns
     -------
@@ -1380,15 +1399,25 @@ def griffinlim_cqt(
     if fmin is None:
         fmin = note_to_hz("C1")
 
-    if random_state is None:
-        rng = np.random.default_rng()
-    elif isinstance(random_state, int):
-        rng = np.random.RandomState(seed=random_state)  # type: ignore
-    elif isinstance(random_state, (np.random.RandomState, np.random.Generator)):
-        rng = random_state  # type: ignore
-    else:
-        _ensure_not_reachable(random_state)
-        raise ParameterError(f"Unsupported random_state={random_state!r}")
+    if not isinstance(random_state, Deprecated):
+        if rng is not None:
+            raise ParameterError(
+                f"Both random_state={random_state!r} and rng={rng!r} were provided. "
+                "Please use only the rng parameter."
+            )
+
+        # Otherwise transfer the state object and throw a deprecation warning
+        rng = rename_kw(
+            old_name="random_state",
+            old_value=random_state,
+            new_name="rng",
+            new_value=rng,
+            version_deprecated="1.0.0",
+            version_removed="1.2.0",
+        )
+
+    # Coerce the various input types to a proper Generator
+    rng = np.random.default_rng(rng)
 
     if momentum > 1:
         warnings.warn(

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -1417,7 +1417,9 @@ def griffinlim_cqt(
         )
 
     # Coerce the various input types to a proper Generator
-    rng = np.random.default_rng(rng)
+    # This branch is necessary until we bump to numpy 2.2
+    if not isinstance(rng, np.random.RandomState):
+        rng = np.random.default_rng(rng)
 
     if momentum > 1:
         warnings.warn(

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -1387,13 +1387,13 @@ def griffinlim_cqt(
 
     >>> import matplotlib.pyplot as plt
     >>> fig, ax = plt.subplots(nrows=3, sharex=True, sharey=True)
-    >>> librosa.display.waveshow(y, sr=sr, color='b', ax=ax[0])
+    >>> librosa.display.waveshow(y, sr=sr, color='C0', ax=ax[0])
     >>> ax[0].set(title='Original', xlabel=None)
     >>> ax[0].label_outer()
-    >>> librosa.display.waveshow(y_inv, sr=sr, color='g', ax=ax[1])
+    >>> librosa.display.waveshow(y_inv, sr=sr, color='C1', ax=ax[1])
     >>> ax[1].set(title='Griffin-Lim reconstruction', xlabel=None)
     >>> ax[1].label_outer()
-    >>> librosa.display.waveshow(y_icqt, sr=sr, color='r', ax=ax[2])
+    >>> librosa.display.waveshow(y_icqt, sr=sr, color='C2', ax=ax[2])
     >>> ax[2].set(title='Magnitude-only icqt reconstruction')
     """
     if fmin is None:

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -2847,7 +2847,9 @@ def griffinlim(
         )
 
     # Coerce the various input types to a proper Generator
-    rng = np.random.default_rng(rng)
+    # This branch is necessary until we bump to numpy 2.2
+    if not isinstance(rng, np.random.RandomState):
+        rng = np.random.default_rng(rng)
 
     if momentum > 1:
         warnings.warn(

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -2820,13 +2820,13 @@ def griffinlim(
 
     >>> import matplotlib.pyplot as plt
     >>> fig, ax = plt.subplots(nrows=3, sharex=True, sharey=True)
-    >>> librosa.display.waveshow(y, sr=sr, color='b', ax=ax[0])
+    >>> librosa.display.waveshow(y, sr=sr, color='C0', ax=ax[0])
     >>> ax[0].set(title='Original', xlabel=None)
     >>> ax[0].label_outer()
-    >>> librosa.display.waveshow(y_inv, sr=sr, color='g', ax=ax[1])
+    >>> librosa.display.waveshow(y_inv, sr=sr, color='C1', ax=ax[1])
     >>> ax[1].set(title='Griffin-Lim reconstruction', xlabel=None)
     >>> ax[1].label_outer()
-    >>> librosa.display.waveshow(y_istft, sr=sr, color='r', ax=ax[2])
+    >>> librosa.display.waveshow(y_istft, sr=sr, color='C2', ax=ax[2])
     >>> ax[2].set_title('Magnitude-only istft reconstruction')
     """
     if not isinstance(random_state, Deprecated):

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -18,7 +18,7 @@ from .audio import resample
 from .._cache import cache
 from .. import util
 from ..util.exceptions import ParameterError
-from ..util.deprecation import Deprecated
+from ..util.deprecation import Deprecated, rename_kw
 from ..filters import get_window, semitone_filterbank
 from ..filters import window_sumsquare
 from numpy.typing import DTypeLike
@@ -32,7 +32,9 @@ from .._typing import (
     _SequenceLike,
     _ScalarOrSequence,
     _ComplexLike_co,
-    _FloatLike_co
+    _FloatLike_co,
+    SeedLike,
+    RNGLike,
 )
 
 __all__ = [
@@ -1481,7 +1483,9 @@ def phase_vocoder(
         raise ParameterError("t_out values must be in the range [0, D.shape[-1])")
 
     if np.any(np.diff(t_out) < 0):
-        warnings.warn("t_out is not monotonic; phase estimation may be unstable", stacklevel=2)
+        warnings.warn(
+            "t_out is not monotonic; phase estimation may be unstable", stacklevel=2
+        )
 
     i0 = np.floor(t_out).astype(int)
     i1 = np.minimum(i0 + 1, n_frames - 1)
@@ -1715,8 +1719,8 @@ def power_to_db(
     ref: Union[float, Callable] = ...,
     amin: float = ...,
     top_db: Optional[float] = ...,
-) -> np.floating[Any]:
-    ...
+) -> np.floating[Any]: ...
+
 
 @overload
 def power_to_db(
@@ -1725,8 +1729,8 @@ def power_to_db(
     ref: Union[float, Callable] = ...,
     amin: float = ...,
     top_db: Optional[float] = ...,
-) -> np.ndarray:
-    ...
+) -> np.ndarray: ...
+
 
 @overload
 def power_to_db(
@@ -1735,8 +1739,8 @@ def power_to_db(
     ref: Union[float, Callable] = ...,
     amin: float = ...,
     top_db: Optional[float] = ...,
-) -> Union[np.floating[Any], np.ndarray]:
-    ...
+) -> Union[np.floating[Any], np.ndarray]: ...
+
 
 @cache(level=30)
 def power_to_db(
@@ -1871,27 +1875,29 @@ def db_to_power(
     S_db: _FloatLike_co,
     *,
     ref: float = ...,
-) -> np.floating[Any]:
-    ...
+) -> np.floating[Any]: ...
+
 
 @overload
 def db_to_power(
-        S_db: np.ndarray,
+    S_db: np.ndarray,
     *,
     ref: float = ...,
-) -> np.ndarray:
-    ...
+) -> np.ndarray: ...
+
 
 @overload
 def db_to_power(
     S_db: Union[_FloatLike_co, np.ndarray],
     *,
     ref: float = ...,
-) -> Union[np.floating[Any], np.ndarray]:
-    ...
+) -> Union[np.floating[Any], np.ndarray]: ...
+
 
 @cache(level=30)
-def db_to_power(S_db: Union[_FloatLike_co, np.ndarray], *, ref: float = 1.0) -> Union[np.floating[Any], np.ndarray]:
+def db_to_power(
+    S_db: Union[_FloatLike_co, np.ndarray], *, ref: float = 1.0
+) -> Union[np.floating[Any], np.ndarray]:
     """Convert dB-scale values to a power values.
 
     This effectively inverts ``power_to_db``::
@@ -1924,8 +1930,8 @@ def amplitude_to_db(
     ref: Union[float, Callable] = ...,
     amin: float = ...,
     top_db: Optional[float] = ...,
-) -> np.floating[Any]:
-    ...
+) -> np.floating[Any]: ...
+
 
 @overload
 def amplitude_to_db(
@@ -1934,8 +1940,8 @@ def amplitude_to_db(
     ref: Union[float, Callable] = ...,
     amin: float = ...,
     top_db: Optional[float] = ...,
-) -> np.ndarray:
-    ...
+) -> np.ndarray: ...
+
 
 @overload
 def amplitude_to_db(
@@ -1944,8 +1950,8 @@ def amplitude_to_db(
     ref: Union[float, Callable] = ...,
     amin: float = ...,
     top_db: Optional[float] = ...,
-) -> Union[np.floating[Any], np.ndarray]:
-    ...
+) -> Union[np.floating[Any], np.ndarray]: ...
+
 
 @cache(level=30)
 def amplitude_to_db(
@@ -2022,27 +2028,29 @@ def db_to_amplitude(
     S_db: _FloatLike_co,
     *,
     ref: float = ...,
-) -> np.floating[Any]:
-    ...
+) -> np.floating[Any]: ...
+
 
 @overload
 def db_to_amplitude(
     S_db: np.ndarray,
     *,
     ref: float = ...,
-) -> np.ndarray:
-    ...
+) -> np.ndarray: ...
+
 
 @overload
 def db_to_amplitude(
     S_db: Union[_FloatLike_co, np.ndarray],
     *,
     ref: float = ...,
-) -> Union[np.floating[Any], np.ndarray]:
-    ...
+) -> Union[np.floating[Any], np.ndarray]: ...
+
 
 @cache(level=30)
-def db_to_amplitude(S_db: Union[_FloatLike_co, np.ndarray], *, ref: float = 1.0) -> Union[np.floating[Any], np.ndarray]:
+def db_to_amplitude(
+    S_db: Union[_FloatLike_co, np.ndarray], *, ref: float = 1.0
+) -> Union[np.floating[Any], np.ndarray]:
     """Convert a dB-scaled spectrogram to an amplitude spectrogram.
 
     This effectively inverts `amplitude_to_db`::
@@ -2358,8 +2366,7 @@ def pcen(
     max_axis: Optional[int] = ...,
     zi: Optional[np.ndarray] = ...,
     return_zf: Literal[False] = ...,
-) -> np.ndarray:
-    ...
+) -> np.ndarray: ...
 
 
 @overload
@@ -2380,8 +2387,7 @@ def pcen(
     max_axis: Optional[int] = ...,
     zi: Optional[np.ndarray] = ...,
     return_zf: Literal[True],
-) -> Tuple[np.ndarray, np.ndarray]:
-    ...
+) -> Tuple[np.ndarray, np.ndarray]: ...
 
 
 @overload
@@ -2402,8 +2408,7 @@ def pcen(
     max_axis: Optional[int] = ...,
     zi: Optional[np.ndarray] = ...,
     return_zf: bool = ...,
-) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
-    ...
+) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]: ...
 
 
 @cache(level=30)
@@ -2689,9 +2694,10 @@ def griffinlim(
     pad_mode: _PadModeSTFT = "constant",
     momentum: float = 0.99,
     init: Optional[str] = "random",
+    rng: Optional[Union[RNGLike, SeedLike]] = None,
     random_state: Optional[
-        Union[int, np.random.RandomState, np.random.Generator]
-    ] = None,
+        Union[int, np.random.RandomState, np.random.Generator, Deprecated]
+    ] = Deprecated(),
 ) -> np.ndarray:
     """Approximate magnitude spectrogram inversion using the "fast" Griffin-Lim algorithm.
 
@@ -2767,7 +2773,15 @@ def griffinlim(
         an initial guess for phase can be provided, or when you want to resume
         Griffin-Lim from a previous output.
 
+    rng : None, int, sequence of int, np.random.Generator, or np.random.RandomState
+        Pseudorandom number generator state. When `rng` is None, a new
+        `numpy.random.Generator` is created using entropy from the
+        operating system. Types other than `numpy.random.Generator` are
+        passed to `numpy.random.default_rng` to instantiate a ``Generator``.
+
     random_state : None, int, np.random.RandomState, or np.random.Generator
+        .. warning:: This parameter is deprecated in 1.0.0 and will be removed in 1.2.0.
+
         If int, random_state is the seed used by the random number generator
         for phase initialization.
 
@@ -2775,6 +2789,8 @@ def griffinlim(
         generator itself.
 
         If `None`, defaults to the `np.random.default_rng()` object.
+
+        An exception is raised if both `rng` and `random_state` are provided.
 
     Returns
     -------
@@ -2813,14 +2829,25 @@ def griffinlim(
     >>> librosa.display.waveshow(y_istft, sr=sr, color='r', ax=ax[2])
     >>> ax[2].set_title('Magnitude-only istft reconstruction')
     """
-    if random_state is None:
-        rng = np.random.default_rng()
-    elif isinstance(random_state, int):
-        rng = np.random.RandomState(seed=random_state)  # type: ignore
-    elif isinstance(random_state, (np.random.RandomState, np.random.Generator)):
-        rng = random_state  # type: ignore
-    else:
-        raise ParameterError(f"Unsupported random_state={random_state!r}")
+    if not isinstance(random_state, Deprecated):
+        if rng is not None:
+            raise ParameterError(
+                f"Both random_state={random_state!r} and rng={rng!r} were provided. "
+                "Please use only one of these parameters."
+            )
+
+        # Otherwise transfer the state object and throw a deprecation warning
+        rng = rename_kw(
+            old_name="random_state",
+            old_value=random_state,
+            new_name="rng",
+            new_value=rng,
+            version_deprecated="1.0.0",
+            version_removed="1.2.0",
+        )
+
+    # Coerce the various input types to a proper Generator
+    rng = np.random.default_rng(rng)
 
     if momentum > 1:
         warnings.warn(

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -2833,7 +2833,7 @@ def griffinlim(
         if rng is not None:
             raise ParameterError(
                 f"Both random_state={random_state!r} and rng={rng!r} were provided. "
-                "Please use only one of these parameters."
+                "Please use only the rng parameter."
             )
 
         # Otherwise transfer the state object and throw a deprecation warning

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -640,7 +640,7 @@ def y_chirp():
 @pytest.mark.parametrize("pad_mode", ["reflect"])
 @pytest.mark.parametrize("scale", [False, True])
 @pytest.mark.parametrize("momentum", [0.99])
-@pytest.mark.parametrize("random_state", [0])
+@pytest.mark.parametrize("rng", [0])
 @pytest.mark.parametrize("fmin", [40.0])
 @pytest.mark.parametrize("dtype", [np.float32])
 @pytest.mark.parametrize("init", [None])
@@ -657,7 +657,7 @@ def test_griffinlim_cqt(
     scale,
     momentum,
     init,
-    random_state,
+    rng,
     dtype,
 ):
 
@@ -695,7 +695,7 @@ def test_griffinlim_cqt(
         pad_mode=pad_mode,
         n_iter=1,
         momentum=momentum,
-        random_state=random_state,
+        rng=rng,
         length=length,
         res_type=res_type,
         init=init,
@@ -744,20 +744,20 @@ def test_griffinlim_cqt_momentum(y_chirp, momentum):
     assert np.all(np.isfinite(y_rec))
 
 
-@pytest.mark.parametrize("random_state", [None, 0, np.random.RandomState()])
+@pytest.mark.parametrize("rng", [None, 0, np.random.RandomState()])
 @pytest.mark.filterwarnings("ignore:n_fft=.*is too large")
-def test_griffinlim_cqt_rng(y_chirp, random_state):
+def test_griffinlim_cqt_rng(y_chirp, rng):
 
     C = librosa.cqt(y=y_chirp, sr=22050, res_type="polyphase")
     y_rec = librosa.griffinlim_cqt(
-        np.abs(C), sr=22050, n_iter=2, random_state=random_state, res_type="polyphase"
+        np.abs(C), sr=22050, n_iter=2, rng=rng, res_type="polyphase"
     )
 
     y_rec2 = librosa.griffinlim_cqt(
-        np.abs(C), sr=22050, n_iter=2, random_state=random_state, res_type="polyphase"
+        np.abs(C), sr=22050, n_iter=2, rng=rng, res_type="polyphase"
     )
 
-    if not isinstance(random_state, np.random.RandomState) and random_state is not None:
+    if not isinstance(rng, np.random.RandomState) and rng is not None:
         assert np.allclose(y_rec, y_rec2)
 
 
@@ -779,11 +779,11 @@ def test_griffinlim_cqt_badinit():
     librosa.griffinlim_cqt(x, init="garbage")
 
 
-@pytest.mark.xfail(raises=librosa.ParameterError)
+@pytest.mark.xfail(raises=TypeError)
 @pytest.mark.filterwarnings("ignore:n_fft=.*is too large")
 def test_griffinlim_cqt_badrng():
     x = np.zeros((33, 3))
-    librosa.griffinlim_cqt(x, random_state="garbage")  # type: ignore
+    librosa.griffinlim_cqt(x, rng="garbage")  # type: ignore
 
 
 @pytest.mark.xfail(raises=librosa.ParameterError)
@@ -796,6 +796,35 @@ def test_griffinlim_cqt_momentum_warn():
     x = np.zeros((33, 3))
     with pytest.warns(UserWarning):
         librosa.griffinlim_cqt(x, momentum=2)
+
+
+def test_griffinlim_cqt_deprecated_randomstate(y_chirp):
+    # Test that the deprecated random_state argument raises a warning
+    C = librosa.cqt(y=y_chirp, sr=22050, res_type="polyphase")
+    with pytest.warns(FutureWarning, match="renamed to 'rng'"):
+        y1 = librosa.griffinlim_cqt(
+            np.abs(C),
+            sr=22050,
+            n_iter=2,
+            random_state=np.random.RandomState(5),
+            res_type="polyphase",
+        )
+    # And verify that it produces the same output as the new rng argument
+    y2 = librosa.griffinlim_cqt(
+        np.abs(C),
+        sr=22050,
+        n_iter=2,
+        rng=np.random.RandomState(5),
+        res_type="polyphase",
+    )
+    assert np.allclose(y1, y2)
+
+
+@pytest.mark.xfail(raises=librosa.ParameterError)
+def test_griffinlim_cqt_oldrng():
+    x = np.zeros((33, 3))
+    # We can't have both parameters set
+    librosa.griffinlim_cqt(x, rng=0, random_state=0)
 
 
 @pytest.mark.parametrize("dtype", [np.complex64, np.complex128])

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -806,16 +806,15 @@ def test_griffinlim_cqt_deprecated_randomstate(y_chirp):
             np.abs(C),
             sr=22050,
             n_iter=2,
-            random_state=np.random.RandomState(5),
+            random_state=5,
             res_type="polyphase",
         )
     # And verify that it produces the same output as the new rng argument
-    # We'll ignore type safety here
     y2 = librosa.griffinlim_cqt(
         np.abs(C),
         sr=22050,
         n_iter=2,
-        rng=np.random.RandomState(5),  # type: ignore
+        rng=5,
         res_type="polyphase",
     )
     assert np.allclose(y1, y2)

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -810,11 +810,12 @@ def test_griffinlim_cqt_deprecated_randomstate(y_chirp):
             res_type="polyphase",
         )
     # And verify that it produces the same output as the new rng argument
+    # We'll ignore type safety here
     y2 = librosa.griffinlim_cqt(
         np.abs(C),
         sr=22050,
         n_iter=2,
-        rng=np.random.RandomState(5),
+        rng=np.random.RandomState(5),  # type: ignore
         res_type="polyphase",
     )
     assert np.allclose(y1, y2)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2347,11 +2347,10 @@ def test_griffinlim_deprecated_randomstate(y_chirp):
     D = librosa.stft(y=y_chirp)
     with pytest.warns(FutureWarning, match="renamed to 'rng'"):
         y1 = librosa.griffinlim(
-            np.abs(D), n_iter=2, random_state=np.random.RandomState(5)
+            np.abs(D), n_iter=2, random_state=5,
         )
     # And verify that it produces the same output as the new rng argument
-    # we'll ignore type safety here
-    y2 = librosa.griffinlim(np.abs(D), n_iter=2, rng=np.random.RandomState(5))  # type: ignore
+    y2 = librosa.griffinlim(np.abs(D), n_iter=2, rng=5)
     assert np.allclose(y1, y2)
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2311,15 +2311,15 @@ def test_griffinlim_momentum(y_chirp, momentum):
     # No value tests here, just ensuring that it passes cleanly
 
 
-@pytest.mark.parametrize("random_state", [None, 0, np.random.RandomState()])
-def test_griffinlim_state(y_chirp, random_state):
+@pytest.mark.parametrize("rng", [None, 0, np.random.RandomState()])
+def test_griffinlim_state(y_chirp, rng):
     D = librosa.stft(y_chirp)
-    y_rec = librosa.griffinlim(np.abs(D), random_state=random_state, n_iter=1)
+    y_rec = librosa.griffinlim(np.abs(D), rng=rng, n_iter=1)
 
-    y_rec2 = librosa.griffinlim(np.abs(D), random_state=random_state, n_iter=1)
+    y_rec2 = librosa.griffinlim(np.abs(D), rng=rng, n_iter=1)
 
     # Ensure that seeding with a constant gives us consistent values
-    if not isinstance(random_state, np.random.RandomState) and random_state is not None:
+    if not isinstance(rng, np.random.RandomState) and rng is not None:
         assert np.allclose(y_rec, y_rec2)
 
 
@@ -2329,10 +2329,29 @@ def test_griffinlim_badinit():
     librosa.griffinlim(x, init="garbage")
 
 
-@pytest.mark.xfail(raises=librosa.ParameterError)
+@pytest.mark.xfail(raises=TypeError)
 def test_griffinlim_badrng():
     x = np.zeros((33, 3))
-    librosa.griffinlim(x, random_state="garbage")  # type: ignore
+    librosa.griffinlim(x, rng="garbage")  # type: ignore
+
+
+@pytest.mark.xfail(raises=librosa.ParameterError)
+def test_griffinlim_cqt_oldrng():
+    x = np.zeros((33, 3))
+    # We can't have both parameters set
+    librosa.griffinlim(x, rng=0, random_state=0)
+
+
+def test_griffinlim_deprecated_randomstate(y_chirp):
+    # Test that the deprecated random_state argument raises a warning
+    D = librosa.stft(y=y_chirp)
+    with pytest.warns(FutureWarning, match="renamed to 'rng'"):
+        y1 = librosa.griffinlim(
+            np.abs(D), n_iter=2, random_state=np.random.RandomState(5)
+        )
+    # And verify that it produces the same output as the new rng argument
+    y2 = librosa.griffinlim(np.abs(D), n_iter=2, rng=np.random.RandomState(5))
+    assert np.allclose(y1, y2)
 
 
 @pytest.mark.xfail(raises=librosa.ParameterError)
@@ -2737,7 +2756,7 @@ def test_phase_vocoder_fixed_rate(rate, rng):
     if rate >= 1:
         assert np.allclose(np.abs(D[:, ::rate]), np.abs(D_stretch))
     else:
-        assert np.allclose(np.abs(D), np.abs(D_stretch[:, ::int(1 / rate)]))
+        assert np.allclose(np.abs(D), np.abs(D_stretch[:, :: int(1 / rate)]))
 
 
 def test_phase_vocoder_variable_rate(rng):
@@ -2753,7 +2772,7 @@ def test_phase_vocoder_variable_rate(rng):
     D_stretch = librosa.phase_vocoder(D, t_out=t_out)
 
     assert D_stretch.shape == (D.shape[0], len(t_out))
-    assert np.allclose(np.abs(D[:, :-2]), np.abs(D_stretch[:, ::int(1 / rate)]))
+    assert np.allclose(np.abs(D[:, :-2]), np.abs(D_stretch[:, :: int(1 / rate)]))
 
 
 @pytest.mark.xfail(raises=librosa.ParameterError)
@@ -2793,6 +2812,7 @@ def test_phase_vocoder_nonmonotone():
 
     with pytest.warns(UserWarning, match="t_out is not monotonic"):
         D_stretch = librosa.phase_vocoder(D, t_out=t_out)
+
 
 @pytest.mark.parametrize("rate", [0, -1])
 @pytest.mark.xfail(raises=librosa.ParameterError)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2350,7 +2350,8 @@ def test_griffinlim_deprecated_randomstate(y_chirp):
             np.abs(D), n_iter=2, random_state=np.random.RandomState(5)
         )
     # And verify that it produces the same output as the new rng argument
-    y2 = librosa.griffinlim(np.abs(D), n_iter=2, rng=np.random.RandomState(5))
+    # we'll ignore type safety here
+    y2 = librosa.griffinlim(np.abs(D), n_iter=2, rng=np.random.RandomState(5))  # type: ignore
     assert np.allclose(y1, y2)
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2336,7 +2336,7 @@ def test_griffinlim_badrng():
 
 
 @pytest.mark.xfail(raises=librosa.ParameterError)
-def test_griffinlim_cqt_oldrng():
+def test_griffinlim_oldrng():
     x = np.zeros((33, 3))
     # We can't have both parameters set
     librosa.griffinlim(x, rng=0, random_state=0)


### PR DESCRIPTION
#### Reference Issue

Partially implements #1935 

#### What does this implement/fix? Explain your changes.

This PR deprecates the `random_state=` parameters of griffinlim and griffinlim_cqt to a standardized `rng=` parameter as described by SPEC07.

These are the only functions in the library that depend on randomness, so having implemented this, we can endorse SPEC07.

#### Any other comments?

The deprecation is set to expire in librosa 1.2.0.