### PR TITLE
Fixing figures clumped up at the end of page

### DIFF
--- a/librosa/beat.py
+++ b/librosa/beat.py
@@ -372,6 +372,7 @@ def plp(
     ...          label='Predominant local pulse (PLP)')
     >>> ax[2].set(title='Log-normal tempo prior, mean=120', xlim=[5, 20])
     >>> ax[2].legend()
+    >>> plt.show()
 
     PLP local maxima can be used as estimates of beat positions.
 
@@ -396,6 +397,7 @@ def plp(
     >>> ax[1].legend()
     >>> ax[1].set(title='librosa.beat.plp', xlim=[5, 20])
     >>> ax[1].xaxis.set_major_formatter(librosa.display.TimeFormatter())
+    >>> plt.show()
     """
     # Step 1: get the onset envelope
     if onset_envelope is None:

--- a/librosa/core/harmonic.py
+++ b/librosa/core/harmonic.py
@@ -208,6 +208,7 @@ def interp_harmonics(
     >>> ax.set(yticks=np.arange(len(harmonics)),
     ...        yticklabels=['{:.3g}'.format(_) for _ in harmonics],
     ...        ylabel='Harmonic', xlabel='Tempo (BPM)')
+    >>> plt.show()
 
     We can also compute frequency harmonics for spectrograms.
     To calculate sub-harmonic energy, use values < 1.
@@ -229,6 +230,7 @@ def interp_harmonics(
     ...     ax.flat[i].set(title='h={:.3g}'.format(harmonics[i]))
     ...     ax.flat[i].label_outer()
     >>> librosa.display.colorbar_db(img, ax=ax)
+    >>> plt.show()
     """
     if freqs.ndim == 1 and len(freqs) == x.shape[axis]:
         # Build the 1-D interpolator.

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -2248,6 +2248,7 @@ def fmt(
     >>> ax[1].semilogy(np.abs(scale2), linestyle='--', label='Stretched')
     >>> ax[1].set(xlabel='scale coefficients', title='Scale transform magnitude')
     >>> ax[1].legend()
+    >>> plt.show()
 
     >>> # Plot the scale transform of an onset strength autocorrelation
     >>> y, sr = librosa.load(librosa.ex('choice'))
@@ -2259,13 +2260,14 @@ def fmt(
     >>> # Compute the scale transform
     >>> odf_ac_scale = librosa.fmt(odf_ac_norm, n_fmt=512)
     >>> # Plot the results
-    >>> fig, ax = plt.subplots(nrows=3)
+    >>> fig, ax = plt.subplots(nrows=3, layout='compressed')
     >>> ax[0].plot(odf, label='Onset strength')
     >>> ax[0].set(xlabel='Time (frames)', title='Onset strength')
     >>> ax[1].plot(odf_ac_norm, label='Onset autocorrelation')
     >>> ax[1].set(xlabel='Lag (frames)', title='Onset autocorrelation')
     >>> ax[2].semilogy(np.abs(odf_ac_scale), label='Scale transform magnitude')
     >>> ax[2].set(xlabel='scale coefficients')
+    >>> plt.show()
     """
     n = y.shape[axis]
 
@@ -2573,6 +2575,7 @@ def pcen(
     >>> ax[1].set(title='Per-channel energy normalization')
     >>> librosa.display.colorbar_db(img, ax=ax[0])
     >>> fig.colorbar(imgpcen, ax=ax[1])
+    >>> plt.show()
 
     Compare PCEN with and without max-filtering
 
@@ -2584,6 +2587,7 @@ def pcen(
     >>> img = librosa.display.specshow(pcen_max, x_axis='time', y_axis='mel', ax=ax[1])
     >>> ax[1].set(title='Per-channel energy normalization (max_size=3)')
     >>> fig.colorbar(img, ax=ax)
+    >>> plt.show()
     """
     if power < 0:
         raise ParameterError(f"power={power} must be nonnegative")

--- a/librosa/display.py
+++ b/librosa/display.py
@@ -191,6 +191,7 @@ class TimeFormatter(mplticker.Formatter):
     >>> ax.plot(times, values)
     >>> ax.xaxis.set_major_formatter(librosa.display.TimeFormatter())
     >>> ax.set(xlabel='Time')
+    >>> plt.show()
 
     Manually set the physical time unit of the x-axis to milliseconds
 
@@ -200,6 +201,7 @@ class TimeFormatter(mplticker.Formatter):
     >>> ax.plot(times, values)
     >>> ax.xaxis.set_major_formatter(librosa.display.TimeFormatter(unit='ms'))
     >>> ax.set(xlabel='Time (ms)')
+    >>> plt.show()
 
     For lag plots
 
@@ -209,6 +211,7 @@ class TimeFormatter(mplticker.Formatter):
     >>> ax.plot(times, values)
     >>> ax.xaxis.set_major_formatter(librosa.display.TimeFormatter(lag=True))
     >>> ax.set(xlabel='Lag')
+    >>> plt.show()
     """
 
     def __init__(self, lag: bool = False, unit: Optional[str] = None):
@@ -2392,6 +2395,7 @@ def waveshow(
     >>> librosa.display.waveshow(y_perc, sr=sr, color='r', alpha=0.5, ax=ax[2], label='Percussive')
     >>> ax[2].set(title='Multiple waveforms')
     >>> ax[2].legend()
+    >>> plt.show()
 
     Zooming in on a plot to show raw sample values
 
@@ -2403,10 +2407,11 @@ def waveshow(
     >>> ax.label_outer()
     >>> ax.legend()
     >>> ax2.legend()
+    >>> plt.show()
 
     Plotting a transposed wave along with a self-similarity matrix
 
-    >>> fig, ax = plt.subplot_mosaic("hSSS;hSSS;hSSS;.vvv")
+    >>> fig, ax = plt.subplot_mosaic("hSSS;hSSS;hSSS;.vvv", layout='compressed')
     >>> y, sr = librosa.load(librosa.ex('trumpet'))
     >>> chroma = librosa.feature.chroma_cqt(y=y, sr=sr)
     >>> sim = librosa.segment.recurrence_matrix(chroma, mode='affinity')
@@ -2423,6 +2428,7 @@ def waveshow(
     >>> librosa.display.waveshow(y, ax=ax['h'], transpose=True)
     >>> ax['h'].label_outer()
     >>> ax['h'].set(title='transpose=True')
+    >>> plt.show()
     """
     util.valid_audio(y)
 
@@ -2762,6 +2768,7 @@ def colorbar_phase(
     >>> fig, ax = plt.subplots()
     >>> im = librosa.display.specshow(S, ax=ax, y_axis='log', x_axis='time', vscale='phase')
     >>> librosa.display.colorbar_phase(im)
+    >>> plt.show()
 
     Attach a colorbar to one subplot axes, and show as multiples of π/3.
 
@@ -2771,6 +2778,7 @@ def colorbar_phase(
     >>> im_ph = librosa.display.specshow(S, ax=ax[1], y_axis='log', x_axis='time', vscale='dphase')
     >>> cbar = librosa.display.colorbar_phase(im_ph, ax=ax[1], numticks=7)
     >>> ax[0].label_outer()
+    >>> plt.show()
     """
     if fig is None:
         fig = im.figure
@@ -2840,6 +2848,7 @@ def colorbar_db(
     >>> fig, ax = plt.subplots()
     >>> im = librosa.display.specshow(S, ax=ax, y_axis='log', x_axis='time', vscale='dB')
     >>> librosa.display.colorbar_db(im)
+    >>> plt.show()
 
     Attach a colorbar to one subplot axes.  We can also set a label for the colorbar.
 
@@ -2849,6 +2858,7 @@ def colorbar_db(
     >>> im_ph = librosa.display.specshow(S, ax=ax[1], y_axis='log', x_axis='time', vscale='dphase')
     >>> cbar = librosa.display.colorbar_phase(im_ph, ax=ax[1])
     >>> ax[0].label_outer()
+    >>> plt.show()
     """
     if fig is None:
         fig = im.figure

--- a/librosa/feature/rhythm.py
+++ b/librosa/feature/rhythm.py
@@ -391,6 +391,7 @@ def tempo(
     >>> ax.set(xlabel='Tempo (BPM)', title='Static tempo estimation')
     >>> ax.grid(True)
     >>> ax.legend()
+    >>> plt.show()
 
     Plot dynamic tempo estimates over a tempogram
 
@@ -405,6 +406,7 @@ def tempo(
     ...          label='Tempo estimate (lognorm prior)')
     >>> ax.set(title='Dynamic tempo estimation')
     >>> ax.legend()
+    >>> plt.show()
     """
     if start_bpm <= 0:
         raise ParameterError("start_bpm must be strictly positive")

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -1973,18 +1973,20 @@ def mfcc(
     >>> img = librosa.display.specshow(mfccs, x_axis='time', ax=ax[1])
     >>> fig.colorbar(img, ax=[ax[1]])
     >>> ax[1].set(title='MFCC')
+    >>> plt.show()
 
     Compare different DCT bases
 
     >>> m_slaney = librosa.feature.mfcc(y=y, sr=sr, dct_type=2)
     >>> m_htk = librosa.feature.mfcc(y=y, sr=sr, dct_type=3)
-    >>> fig, ax = plt.subplots(nrows=2, sharex=True, sharey=True)
+    >>> fig, ax = plt.subplots(nrows=2, sharex=True, sharey=True, layout='compressed')
     >>> img1 = librosa.display.specshow(m_slaney, x_axis='time', ax=ax[0])
     >>> ax[0].set(title='RASTAMAT / Auditory toolbox (dct_type=2)')
     >>> fig.colorbar(img, ax=[ax[0]])
     >>> img2 = librosa.display.specshow(m_htk, x_axis='time', ax=ax[1])
     >>> ax[1].set(title='HTK-style (dct_type=3)')
     >>> fig.colorbar(img2, ax=[ax[1]])
+    >>> plt.show()
     """
     if S is None:
         # multichannel behavior may be different due to relative noise floor differences between channels

--- a/librosa/sequence.py
+++ b/librosa/sequence.py
@@ -855,6 +855,7 @@ def rqa(
     >>> ax[1].plot(L_path[:, 1], L_path[:, 0], label='Optimal path', color='c')
     >>> ax[1].legend()
     >>> ax[1].label_outer()
+    >>> plt.show()
 
     Full alignment using gaps and knight moves
 
@@ -868,6 +869,7 @@ def rqa(
     >>> ax[1].plot(path[:, 1], path[:, 0], label='Optimal path', color='c')
     >>> ax[1].legend()
     >>> ax[1].label_outer()
+    >>> plt.show()
     """
     if gap_onset < 0:
         raise ParameterError("gap_onset={} must be strictly positive")
@@ -1554,6 +1556,7 @@ def viterbi_discriminative(
     >>> librosa.display.specshow(chroma, x_axis='time', y_axis='chroma', ax=ax[0])
     >>> librosa.display.specshow(weights, x_axis='chroma', ax=ax[1])
     >>> ax[1].set(yticks=np.arange(25) + 0.5, yticklabels=labels, ylabel='Chord')
+    >>> plt.show()
 
     >>> # And plot the results
     >>> fig, ax = plt.subplots()
@@ -1567,6 +1570,7 @@ def viterbi_discriminative(
     >>> ax.set(yticks=np.unique(chords_vit),
     ...        yticklabels=[labels[i] for i in np.unique(chords_vit)])
     >>> ax.legend()
+    >>> plt.show()
     """
     n_states, n_steps = prob.shape[-2:]
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/main/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
<!-- Example: Fixes #123 -->
Fixes #1974 

#### What does this implement/fix? Explain your changes.

- This adds `plt.show()` at the end of code blocks to prevent figures from clumping at the end of the documentation page.
- Added `layout='compressed'` to stop figures from overlapping 

This covers the following:

- librosa.beat.plp
- librosa.display.colorbar_db
- librosa.display.colorbar_phase
- librosa.display.TimeFormatter
- librosa.display.waveshow
- librosa.feature.mfcc
- librosa.feature.tempo
- librosa.fmt
- librosa.interp_harmonics
- librosa.pcen
- librosa.sequence.rqa
- librosa.sequence.viterbi_discriminative

#### Any other comments?

