### PR TITLE
Allow alternative viterbi implementations for pyin

### DIFF
--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -668,6 +668,7 @@ def pyin(
     fill_na: Optional[float] = np.nan,
     center: bool = True,
     pad_mode: _PadMode = "constant",
+    viterbi_function: Callable = sequence.viterbi,
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Fundamental frequency (F0) estimation using probabilistic YIN (pYIN).
 
@@ -750,6 +751,10 @@ def pyin(
         ``y`` is padded on both sides with zeros.
         If ``center=False``,  this argument is ignored.
         .. see also:: `np.pad`
+
+    viterbi_function : Callable
+        Function to use for Viterbi decoding.
+        Defaults to ``librosa.sequence.viterbi``.
 
     win_length : Deprecated
         length of the window for calculating autocorrelation in samples.
@@ -880,7 +885,7 @@ def pyin(
 
     p_init = np.ones(2 * n_pitch_bins) / (2 * n_pitch_bins)
 
-    states = sequence.viterbi(observation_probs, transition, p_init=p_init)
+    states = viterbi_function(observation_probs, transition, p_init=p_init)
 
     # Find f0 corresponding to each decoded pitch bin.
     freqs = fmin * 2 ** (np.arange(n_pitch_bins) / (12 * n_bins_per_semitone))


### PR DESCRIPTION
#### Reference Issue
Partially addresses #1798

#### What does this implement/fix? Explain your changes.

As noted in the above issue, viterbi decoding is the slowest operation for f0 tracking with pyin.

This commit is a fairly minimal change which moves the `sequence.viterbi` call to a parameter, allowing for the possibility of alternative viterbi decoding methods. The intended use case for this at the moment is [torbi](https://github.com/maxrmorrison/torbi) which is a new viterbi implementation optimised for GPU and multithreading.

#### Any other comments?

Example benchmark:

[Example audio: deantown.mp3](https://www.dropbox.com/scl/fi/kruyvp9lbhvg0yda4ekxo/deantown.mp3?rlkey=hzvd73o7vwrb0a74y384bcl1p&st=sedda7rc&dl=0)

```
# clone this repo and branch and cd into librosa folder
uv venv --python 3.11
uv pip install -e .
uv pip install git+https://github.com/maxrmorrison/torbi.git matplotlib
```

```python
import librosa
import timeit
from matplotlib import pyplot as plt
import torch
import torbi
import numpy as np

def torbi_single_thread(observation_probs, transition, p_init):
    return torbi.from_probabilities(torch.from_numpy(observation_probs.transpose(0, 2, 1).astype(np.float32)), 
        transition=torch.from_numpy(transition.astype(np.float32)), 
        initial=torch.from_numpy(p_init.astype(np.float32)),
        num_threads=1,
        log_probs=False).numpy()

def torbi_multithreaded(observation_probs, transition, p_init):
    return torbi.from_probabilities(torch.from_numpy(observation_probs.transpose(0, 2, 1).astype(np.float32)), 
        transition=torch.from_numpy(transition.astype(np.float32)), 
        initial=torch.from_numpy(p_init.astype(np.float32)),
        num_threads=16,
        log_probs=False).numpy()

def torbi_gpu(observation_probs, transition, p_init):
    if not torch.cuda.is_available():
        raise ValueError("CUDA is not available")
    
    device = torch.device("cuda:0")
    return torbi.from_probabilities(
        torch.from_numpy(observation_probs.transpose(0, 2, 1).astype(np.float32)).to(device), 
        transition=torch.from_numpy(transition.astype(np.float32)).to(device), 
        initial=torch.from_numpy(p_init.astype(np.float32)).to(device),
        gpu=0,
        log_probs=False).cpu().numpy()

n_fft = 2048
hop_length = 512

durations = [10, 30, 60, 120, 240]
methods = [librosa.sequence.viterbi, torbi_single_thread, torbi_multithreaded, torbi_gpu]

for method in methods:
    timings = []

    for duration in durations:
        y, sr = librosa.load('deantown.mp3', duration=duration)
        pyin_time = timeit.timeit(
            lambda: librosa.pyin(
                y,
                fmin=librosa.note_to_hz('E0'),
                fmax=librosa.note_to_hz('C6'),
                frame_length=n_fft,
                hop_length=hop_length,
                viterbi_function=method
            ),
            number=1  # Run once for this benchmark
        )
        timings.append(pyin_time)
        print(f"{method.__name__} timeit result for {duration} seconds: {pyin_time:.4f} seconds")
    
    plt.plot(durations, timings, label=method.__name__)

plt.legend()
plt.xlabel('Input Duration (s)')
plt.ylabel('Execution Time (s)')
plt.title('pyin timing comparison')
plt.savefig('pyin_timing_comparison.png')
plt.show()
```

<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/25e4e95b-f239-4a3e-853e-24c72e38203e" />

| Method | 10s | 30s | 60s | 120s | 240s |
|--------|-----|-----|-----|------|------|
| **librosa.sequence.viterbi** | 2.9153 | 8.2866 | 15.9120 | 32.8650 | 71.5760 |
| **torbi_single_thread** | 3.9254 | 11.7587 | 23.3271 | 46.8374 | 85.3265 |
| **torbi_multithreaded (num_threads=16)** | 0.9531 | 2.7089 | 5.2896 | 10.6621 | 19.3450 |
| **torbi_gpu** | 0.7770 | 0.7975 | 1.5992 | 3.2255 | 6.0070 |

The speed up with GPU is quite dramatic (~10x), but even with CPU and multithreading its a lot faster (70s -> 20s,  3.5x).
