### PR TITLE
Refactor Viterbi step to avoid intermediate matrix

### DIFF
--- a/librosa/sequence.py
+++ b/librosa/sequence.py
@@ -1132,22 +1132,18 @@ def _viterbi(
     value[0] = log_prob[0] + log_p_init
 
     for t in range(1, n_steps):
-        # Want V[t, j] <- p[t, j] * max_k V[t-1, k] * A[k, j]
-        #    assume at time t-1 we were in state k
-        #    transition k -> j
-
-        # Broadcast over rows:
-        #    Tout[k, j] = V[t-1, k] * A[k, j]
-        #    then take the max over columns
-        # We'll do this in log-space for stability
-
-        trans_out = value[t - 1] + log_trans.T
-
-        # Unroll the max/argmax loop to enable numba support
+        # Avoid materializing an intermediate (n_states x n_states) matrix.
         for j in range(n_states):
-            ptr[t, j] = np.argmax(trans_out[j])
-            # value[t, j] = log_prob[t, j] + np.max(trans_out[j])
-            value[t, j] = log_prob[t, j] + trans_out[j, ptr[t][j]]
+            best_idx = 0
+            best_val = value[t - 1, 0] + log_trans[0, j]
+            for k in range(1, n_states):
+                candidate = value[t - 1, k] + log_trans[k, j]
+                if candidate > best_val:
+                    best_val = candidate
+                    best_idx = k
+
+            ptr[t, j] = best_idx
+            value[t, j] = log_prob[t, j] + best_val
 
     # Now roll backward
 


### PR DESCRIPTION
#### What does this implement
Optimized the Viterbi dynamic-programming core used by pyin by removing a large per-step intermediate matrix allocation and computing max/argmax in-place. 

**Before**: _viterbi built a large temporary n_states x n_states matrix at every time step, then took max/argmax from it.
**After**: the temporary matrix is removed; max/argmax is computed directly in loops.
**Why**: this avoids repeated allocations and extra memory traffic, which is costly for large state spaces (as in pyin).

#### My Env
macOS-26.3-arm64
Python 3.13.5
NumPy 2.4.2
SciPy 1.17.0
librosa 0.11.0

#### Results
Outputs stay the same: the Viterbi math and logic are unchanged; only the way max_k(...) is computed was refactored.
Speedup:
viterbi: about **1.6x–1.8x** faster
end-to-end pyin: about **1.4x–1.6x** faster

#### Tests
I tested the data for the original function and the modified one, and the test was successful.



#### Benchmark 
[test.py](https://github.com/user-attachments/files/25495629/test.py)
Repeats: 3 runs per file

| file | size | sr | samples | Old mean(s) | New mean(s) | Speedup |
|---|---|---|--|---|---|---|
| 1min.wav  | 5.3 MiB | 44100 | 2646000 | 10.37 | 7.09 | 1.46x |
| 5min.wav  | 26.5 MiB | 44100 | 13230000 | 52.72 | 37.32 | 1.41x |
| 15min.wav  | 79.4 MiB | 44100 | 39690000 | 161.64 | 114.53 | 1.41x |