### PR TITLE
Optimize pyin with sparse Viterbi

### DIFF
--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -3,6 +3,7 @@
 """Pitch-tracking and tuning estimation"""
 
 import warnings
+from functools import lru_cache
 import numpy as np
 import scipy
 import numba
@@ -21,6 +22,118 @@ from typing import Any, Callable, Optional, Tuple, Union
 from .._typing import _WindowSpec, _PadMode, _PadModeSTFT
 
 __all__ = ["estimate_tuning", "pitch_tuning", "piptrack", "yin", "pyin"]
+
+
+@numba.jit(nopython=True, cache=True)  # type: ignore
+def __viterbi_sparse_numba(
+    log_prob_t: np.ndarray,
+    offsets: np.ndarray,
+    src_idx: np.ndarray,
+    src_logp: np.ndarray,
+    log_p_init: np.ndarray,
+) -> np.ndarray:
+    """Sparse-column Viterbi for fixed transition sparsity."""
+    n_steps, n_states = log_prob_t.shape
+
+    state = np.zeros(n_steps, dtype=np.uint16)
+    value = np.zeros((n_steps, n_states), dtype=np.float64)
+    ptr = np.zeros((n_steps, n_states), dtype=np.uint16)
+
+    value[0] = log_prob_t[0] + log_p_init
+
+    for t in range(1, n_steps):
+        for j in range(n_states):
+            start = offsets[j]
+            end = offsets[j + 1]
+
+            k0 = src_idx[start]
+            best_idx = k0
+            best_val = value[t - 1, k0] + src_logp[start]
+
+            for p in range(start + 1, end):
+                k = src_idx[p]
+                candidate = value[t - 1, k] + src_logp[p]
+                if candidate > best_val:
+                    best_val = candidate
+                    best_idx = k
+
+            ptr[t, j] = best_idx
+            value[t, j] = log_prob_t[t, j] + best_val
+
+    state[-1] = np.argmax(value[-1])
+    for t in range(n_steps - 2, -1, -1):
+        state[t] = ptr[t + 1, state[t + 1]]
+
+    return state
+
+
+@lru_cache(maxsize=32)
+def __pyin_sparse_transition(
+    n_pitch_bins: int, transition_width: int, switch_prob: float
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Build sparse transition representation for pYIN Viterbi decoding."""
+    transition = sequence.transition_local(
+        n_pitch_bins, transition_width, window="triangle", wrap=False
+    )
+    t_switch = sequence.transition_loop(2, 1 - switch_prob)
+    transition = np.kron(t_switch, transition)
+
+    n_states = transition.shape[0]
+    offsets = np.zeros(n_states + 1, dtype=np.int64)
+    src_blocks = []
+    logp_blocks = []
+    pos = 0
+
+    for j in range(n_states):
+        src = np.flatnonzero(transition[:, j] > 0)
+        src_blocks.append(src.astype(np.int64))
+        logp_blocks.append(np.log(transition[src, j]))
+        pos += src.size
+        offsets[j + 1] = pos
+
+    src_idx = np.concatenate(src_blocks)
+    src_logp = np.concatenate(logp_blocks)
+    return offsets, src_idx, src_logp
+
+
+def __pyin_viterbi(
+    observation_probs: np.ndarray, *, n_pitch_bins: int, transition_width: int, switch_prob: float
+) -> np.ndarray:
+    """Decode pYIN observation probabilities with sparse Viterbi."""
+    n_states = observation_probs.shape[-2]
+    if n_states != 2 * n_pitch_bins:
+        raise ParameterError(
+            f"Invalid pYIN state count: {n_states} (expected {2 * n_pitch_bins})"
+        )
+    if n_states > np.iinfo(np.uint16).max + 1:
+        raise ParameterError(
+            f"pYIN state count {n_states} exceeds uint16 decoding capacity "
+            f"({np.iinfo(np.uint16).max + 1})"
+        )
+
+    offsets, src_idx, src_logp = __pyin_sparse_transition(
+        n_pitch_bins, transition_width, switch_prob
+    )
+    if not np.all(np.diff(offsets) > 0):
+        raise ParameterError(
+            "Invalid pYIN sparse transition: at least one state has no incoming transitions."
+        )
+
+    p_init = np.ones(n_states, dtype=np.float64) / n_states
+    log_p_init = np.log(p_init + util.tiny(p_init))
+
+    batch_shape = observation_probs.shape[:-2]
+    n_steps = observation_probs.shape[-1]
+    batched_probs = observation_probs.reshape((-1, n_states, n_steps))
+    batched_states = np.empty((batched_probs.shape[0], n_steps), dtype=np.uint16)
+
+    for i in range(batched_probs.shape[0]):
+        log_prob_t = np.log(batched_probs[i].T + util.tiny(batched_probs[i]))
+        batched_states[i] = __viterbi_sparse_numba(
+            log_prob_t, offsets, src_idx, src_logp, log_p_init
+        )
+
+    return batched_states.reshape(batch_shape + (n_steps,))
 
 
 def estimate_tuning(
@@ -808,21 +921,15 @@ def pyin(
     helper = np.vectorize(_helper, signature="(f,t),(k,t)->(1,d,t),(j,t)")
     observation_probs, voiced_prob = helper(yin_frames, parabolic_shifts)
 
-    # Construct transition matrix.
+    # Decode using sparse Viterbi transition structure.
     max_semitones_per_frame = round(max_transition_rate * 12 * hop_length / sr)
     transition_width = max_semitones_per_frame * n_bins_per_semitone + 1
-    # Construct the within voicing transition probabilities
-    transition = sequence.transition_local(
-        n_pitch_bins, transition_width, window="triangle", wrap=False
+    states = __pyin_viterbi(
+        observation_probs,
+        n_pitch_bins=n_pitch_bins,
+        transition_width=transition_width,
+        switch_prob=switch_prob,
     )
-
-    # Include across voicing transition probabilities
-    t_switch = sequence.transition_loop(2, 1 - switch_prob)
-    transition = np.kron(t_switch, transition)
-
-    p_init = np.ones(2 * n_pitch_bins) / (2 * n_pitch_bins)
-
-    states = sequence.viterbi(observation_probs, transition, p_init=p_init)
 
     # Find f0 corresponding to each decoded pitch bin.
     freqs = fmin * 2 ** (np.arange(n_pitch_bins) / (12 * n_bins_per_semitone))

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -24,22 +24,22 @@ from .._typing import _WindowSpec, _PadMode, _PadModeSTFT
 __all__ = ["estimate_tuning", "pitch_tuning", "piptrack", "yin", "pyin"]
 
 
-@numba.jit(nopython=True, cache=True)  # type: ignore
+@numba.jit(nopython=True, cache=True, fastmath=True)  # type: ignore
 def __viterbi_sparse_numba(
     log_prob_t: np.ndarray,
     offsets: np.ndarray,
     src_idx: np.ndarray,
     src_logp: np.ndarray,
-    log_p_init: np.ndarray,
 ) -> np.ndarray:
     """Sparse-column Viterbi for fixed transition sparsity."""
     n_steps, n_states = log_prob_t.shape
 
-    state = np.zeros(n_steps, dtype=np.uint16)
-    value = np.zeros((n_steps, n_states), dtype=np.float64)
-    ptr = np.zeros((n_steps, n_states), dtype=np.uint16)
+    state = np.empty(n_steps, dtype=np.uint16)
+    ptr = np.empty((n_steps, n_states), dtype=np.uint16)
+    value_prev = np.empty(n_states, dtype=np.float64)
+    value_curr = np.empty(n_states, dtype=np.float64)
 
-    value[0] = log_prob_t[0] + log_p_init
+    value_prev[:] = log_prob_t[0]
 
     for t in range(1, n_steps):
         for j in range(n_states):
@@ -48,19 +48,21 @@ def __viterbi_sparse_numba(
 
             k0 = src_idx[start]
             best_idx = k0
-            best_val = value[t - 1, k0] + src_logp[start]
+            best_val = value_prev[k0] + src_logp[start]
 
             for p in range(start + 1, end):
                 k = src_idx[p]
-                candidate = value[t - 1, k] + src_logp[p]
+                candidate = value_prev[k] + src_logp[p]
                 if candidate > best_val:
                     best_val = candidate
                     best_idx = k
 
             ptr[t, j] = best_idx
-            value[t, j] = log_prob_t[t, j] + best_val
+            value_curr[j] = log_prob_t[t, j] + best_val
 
-    state[-1] = np.argmax(value[-1])
+        value_prev, value_curr = value_curr, value_prev
+
+    state[-1] = np.argmax(value_prev)
     for t in range(n_steps - 2, -1, -1):
         state[t] = ptr[t + 1, state[t + 1]]
 
@@ -86,7 +88,7 @@ def __pyin_sparse_transition(
 
     for j in range(n_states):
         src = np.flatnonzero(transition[:, j] > 0)
-        src_blocks.append(src.astype(np.int64))
+        src_blocks.append(src.astype(np.uint16))
         logp_blocks.append(np.log(transition[src, j]))
         pos += src.size
         offsets[j + 1] = pos
@@ -119,21 +121,94 @@ def __pyin_viterbi(
             "Invalid pYIN sparse transition: at least one state has no incoming transitions."
         )
 
-    p_init = np.ones(n_states, dtype=np.float64) / n_states
-    log_p_init = np.log(p_init + util.tiny(p_init))
-
     batch_shape = observation_probs.shape[:-2]
     n_steps = observation_probs.shape[-1]
     batched_probs = observation_probs.reshape((-1, n_states, n_steps))
     batched_states = np.empty((batched_probs.shape[0], n_steps), dtype=np.uint16)
+    epsilon = util.tiny(observation_probs)
+    log_prob_t = np.empty((n_steps, n_states), dtype=np.float64)
 
     for i in range(batched_probs.shape[0]):
-        log_prob_t = np.log(batched_probs[i].T + util.tiny(batched_probs[i]))
-        batched_states[i] = __viterbi_sparse_numba(
-            log_prob_t, offsets, src_idx, src_logp, log_p_init
-        )
+        np.copyto(log_prob_t, batched_probs[i].T)
+        log_prob_t += epsilon
+        np.log(log_prob_t, out=log_prob_t)
+        batched_states[i] = __viterbi_sparse_numba(log_prob_t, offsets, src_idx, src_logp)
 
     return batched_states.reshape(batch_shape + (n_steps,))
+
+
+@numba.jit(nopython=True, cache=True, fastmath=True)  # type: ignore
+def __pyin_helper_probabilities(
+    yin_frames: np.ndarray,
+    threshold_values: np.ndarray,
+    boltzmann_decay: np.ndarray,
+    beta_probs: np.ndarray,
+    no_trough_prob: float,
+) -> np.ndarray:
+    """Compute pYIN trough probabilities for a single framed observation."""
+    n_periods, n_frames = yin_frames.shape
+    yin_probs = np.zeros((n_periods, n_frames), dtype=yin_frames.dtype)
+    base_scale = 1.0 - boltzmann_decay[1]
+
+    for i in range(n_frames):
+        trough_index = np.empty(n_periods, dtype=np.int64)
+        trough_count = 0
+
+        if yin_frames[0, i] < yin_frames[1, i]:
+            trough_index[trough_count] = 0
+            trough_count += 1
+
+        for p in range(1, n_periods - 1):
+            v = yin_frames[p, i]
+            if v < yin_frames[p - 1, i] and v <= yin_frames[p + 1, i]:
+                trough_index[trough_count] = p
+                trough_count += 1
+
+        if yin_frames[n_periods - 1, i] < yin_frames[n_periods - 2, i]:
+            trough_index[trough_count] = n_periods - 1
+            trough_count += 1
+
+        if trough_count == 0:
+            continue
+
+        trough_heights = np.empty(trough_count, dtype=np.float64)
+        positions = np.empty(trough_count, dtype=np.int64)
+        probs = np.zeros(trough_count, dtype=np.float64)
+        global_min = 0
+        global_min_value = yin_frames[trough_index[0], i]
+
+        for r in range(trough_count):
+            val = yin_frames[trough_index[r], i]
+            trough_heights[r] = val
+            if val < global_min_value:
+                global_min_value = val
+                global_min = r
+
+        for m in range(threshold_values.shape[0]):
+            threshold = threshold_values[m]
+            n_troughs = 0
+
+            for r in range(trough_count):
+                if trough_heights[r] < threshold:
+                    positions[r] = n_troughs
+                    n_troughs += 1
+                else:
+                    positions[r] = -1
+
+            if n_troughs > 0:
+                scale = beta_probs[m] * base_scale / (1.0 - boltzmann_decay[n_troughs])
+                for r in range(trough_count):
+                    pos = positions[r]
+                    if pos >= 0:
+                        probs[r] += scale * boltzmann_decay[pos]
+
+            if trough_heights[global_min] >= threshold:
+                probs[global_min] += no_trough_prob * beta_probs[m]
+
+        for r in range(trough_count):
+            yin_probs[trough_index[r], i] = probs[r]
+
+    return yin_probs
 
 
 def estimate_tuning(
@@ -955,46 +1030,13 @@ def __pyin_helper(
     n_pitch_bins,
     n_bins_per_semitone,
 ):
-    yin_probs = np.zeros_like(yin_frames)
-
-    for i, yin_frame in enumerate(yin_frames.T):
-        # 2. For each frame find the troughs.
-        is_trough = util.localmin(yin_frame)
-
-        is_trough[0] = yin_frame[0] < yin_frame[1]
-        (trough_index,) = np.nonzero(is_trough)
-
-        if len(trough_index) == 0:
-            continue
-
-        # 3. Find the troughs below each threshold.
-        # these are the local minima of the frame, could get them directly without the trough index
-        trough_heights = yin_frame[trough_index]
-        trough_thresholds = np.less.outer(trough_heights, thresholds[1:])
-
-        # 4. Define the prior over the troughs.
-        # Smaller periods are weighted more.
-        trough_positions = np.cumsum(trough_thresholds, axis=0) - 1
-        n_troughs = np.count_nonzero(trough_thresholds, axis=0)
-
-        trough_prior = scipy.stats.boltzmann.pmf(
-            trough_positions, boltzmann_parameter, n_troughs
-        )
-
-        trough_prior[~trough_thresholds] = 0
-
-        # 5. For each threshold add probability to global minimum if no trough is below threshold,
-        # else add probability to each trough below threshold biased by prior.
-
-        probs = trough_prior.dot(beta_probs)
-
-        global_min = np.argmin(trough_heights)
-        n_thresholds_below_min = np.count_nonzero(~trough_thresholds[global_min, :])
-        probs[global_min] += no_trough_prob * np.sum(
-            beta_probs[:n_thresholds_below_min]
-        )
-
-        yin_probs[trough_index, i] = probs
+    threshold_values = thresholds[1:]
+    boltzmann_decay = np.exp(
+        -boltzmann_parameter * np.arange(yin_frames.shape[0] + 1, dtype=np.float64)
+    )
+    yin_probs = __pyin_helper_probabilities(
+        yin_frames, threshold_values, boltzmann_decay, beta_probs, no_trough_prob
+    )
 
     yin_period, frame_index = np.nonzero(yin_probs)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -17,6 +17,7 @@ import sys
 import soundfile
 import librosa
 import librosa.core
+import librosa.core.pitch
 import librosa.core.spectrum
 import glob
 import numpy as np
@@ -1483,6 +1484,90 @@ def test_pyin_chirp_instant():
     assert np.abs(cents[-1] - target_cents[-1]) <= 1e-1
 
 
+def test_pyin_helper_matches_reference():
+    rng = np.random.default_rng(1234)
+
+    yin_frames = rng.random((48, 9))
+    parabolic_shifts = rng.uniform(-0.5, 0.5, size=yin_frames.shape)
+
+    sr = 22050
+    thresholds = np.linspace(0, 1, 11)
+    beta_probs = np.diff(scipy.stats.beta.cdf(thresholds, 2, 18))
+    boltzmann_parameter = 2
+    no_trough_prob = 0.01
+    min_period = 16
+    fmin = 65.0
+    n_pitch_bins = 96
+    n_bins_per_semitone = 10
+
+    def _reference_helper():
+        yin_probs = np.zeros_like(yin_frames)
+
+        for i, yin_frame in enumerate(yin_frames.T):
+            is_trough = librosa.util.localmin(yin_frame)
+            is_trough[0] = yin_frame[0] < yin_frame[1]
+            (trough_index,) = np.nonzero(is_trough)
+
+            if len(trough_index) == 0:
+                continue
+
+            trough_heights = yin_frame[trough_index]
+            trough_thresholds = np.less.outer(trough_heights, thresholds[1:])
+            trough_positions = np.cumsum(trough_thresholds, axis=0) - 1
+            n_troughs = np.count_nonzero(trough_thresholds, axis=0)
+
+            trough_prior = scipy.stats.boltzmann.pmf(
+                trough_positions, boltzmann_parameter, n_troughs
+            )
+            trough_prior[~trough_thresholds] = 0
+
+            probs = trough_prior.dot(beta_probs)
+
+            global_min = np.argmin(trough_heights)
+            n_thresholds_below_min = np.count_nonzero(~trough_thresholds[global_min, :])
+            probs[global_min] += no_trough_prob * np.sum(
+                beta_probs[:n_thresholds_below_min]
+            )
+
+            yin_probs[trough_index, i] = probs
+
+        yin_period, frame_index = np.nonzero(yin_probs)
+        period_candidates = min_period + yin_period
+        period_candidates = period_candidates + parabolic_shifts[yin_period, frame_index]
+        f0_candidates = sr / period_candidates
+
+        bin_index = 12 * n_bins_per_semitone * np.log2(f0_candidates / fmin)
+        bin_index = np.clip(np.round(bin_index), 0, n_pitch_bins).astype(int)
+
+        observation_probs = np.zeros((2 * n_pitch_bins, yin_frames.shape[1]))
+        observation_probs[bin_index, frame_index] = yin_probs[yin_period, frame_index]
+
+        voiced_prob = np.clip(
+            np.sum(observation_probs[:n_pitch_bins, :], axis=0, keepdims=True), 0, 1
+        )
+        observation_probs[n_pitch_bins:, :] = (1 - voiced_prob) / n_pitch_bins
+
+        return observation_probs[np.newaxis], voiced_prob
+
+    observation_probs, voiced_prob = librosa.core.pitch.__pyin_helper(
+        yin_frames,
+        parabolic_shifts,
+        sr,
+        thresholds,
+        boltzmann_parameter,
+        beta_probs,
+        no_trough_prob,
+        min_period,
+        fmin,
+        n_pitch_bins,
+        n_bins_per_semitone,
+    )
+    ref_observation_probs, ref_voiced_prob = _reference_helper()
+
+    assert np.allclose(observation_probs, ref_observation_probs)
+    assert np.allclose(voiced_prob, ref_voiced_prob)
+
+
 def test_pyin_sparse_transition_cache():
     sparse_transition = librosa.core.pitch.__pyin_sparse_transition
     sparse_transition.cache_clear()
@@ -1562,6 +1647,18 @@ def test_pyin_viterbi_fail_uint16_capacity():
         librosa.core.pitch.__pyin_viterbi(
             observation_probs,
             n_pitch_bins=n_states // 2,
+            transition_width=1,
+            switch_prob=0.01,
+        )
+
+
+def test_pyin_viterbi_fail_invalid_state_count():
+    observation_probs = np.ones((3, 4), dtype=np.float64) / 3
+
+    with pytest.raises(librosa.ParameterError, match="Invalid pYIN state count"):
+        librosa.core.pitch.__pyin_viterbi(
+            observation_probs,
+            n_pitch_bins=1,
             transition_width=1,
             switch_prob=0.01,
         )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1483,6 +1483,112 @@ def test_pyin_chirp_instant():
     assert np.abs(cents[-1] - target_cents[-1]) <= 1e-1
 
 
+def test_pyin_sparse_transition_cache():
+    sparse_transition = librosa.core.pitch.__pyin_sparse_transition
+    sparse_transition.cache_clear()
+
+    n_pitch_bins = 24
+    transition_width = 5
+    switch_prob = 0.01
+
+    offsets_a, src_idx_a, src_logp_a = sparse_transition(
+        n_pitch_bins, transition_width, switch_prob
+    )
+    info_a = sparse_transition.cache_info()
+
+    offsets_b, src_idx_b, src_logp_b = sparse_transition(
+        n_pitch_bins, transition_width, switch_prob
+    )
+    info_b = sparse_transition.cache_info()
+
+    n_states = 2 * n_pitch_bins
+    assert offsets_a.shape == (n_states + 1,)
+    assert src_idx_a.ndim == 1
+    assert src_logp_a.ndim == 1
+    assert src_idx_a.shape == src_logp_a.shape
+    assert np.all(np.diff(offsets_a) > 0)
+
+    # Same call should hit cache and return the exact same objects.
+    assert offsets_a is offsets_b
+    assert src_idx_a is src_idx_b
+    assert src_logp_a is src_logp_b
+    assert info_a.misses == 1
+    assert info_a.hits == 0
+    assert info_b.misses == 1
+    assert info_b.hits == 1
+
+
+@pytest.mark.parametrize("batch_shape", [(), (3,), (2, 2)])
+def test_pyin_viterbi_matches_sequence_viterbi(batch_shape):
+    rng = np.random.default_rng(1234)
+
+    n_pitch_bins = 24
+    n_states = 2 * n_pitch_bins
+    n_steps = 32
+    transition_width = 5
+    switch_prob = 0.01
+
+    obs_shape = batch_shape + (n_states, n_steps)
+    observation_probs = rng.random(obs_shape) + 1e-8
+    observation_probs /= observation_probs.sum(axis=-2, keepdims=True)
+
+    transition = librosa.sequence.transition_local(
+        n_pitch_bins, transition_width, window="triangle", wrap=False
+    )
+    t_switch = librosa.sequence.transition_loop(2, 1 - switch_prob)
+    transition = np.kron(t_switch, transition)
+    p_init = np.ones(n_states, dtype=np.float64) / n_states
+
+    states_dense = librosa.sequence.viterbi(
+        observation_probs, transition, p_init=p_init
+    )
+    states_sparse = librosa.core.pitch.__pyin_viterbi(
+        observation_probs,
+        n_pitch_bins=n_pitch_bins,
+        transition_width=transition_width,
+        switch_prob=switch_prob,
+    )
+
+    assert states_sparse.shape == states_dense.shape
+    assert np.array_equal(states_sparse, states_dense)
+
+
+def test_pyin_viterbi_fail_uint16_capacity():
+    n_states = np.iinfo(np.uint16).max + 3
+    n_steps = 1
+    observation_probs = np.ones((n_states, n_steps), dtype=np.float64) / n_states
+
+    with pytest.raises(librosa.ParameterError, match="exceeds uint16 decoding capacity"):
+        librosa.core.pitch.__pyin_viterbi(
+            observation_probs,
+            n_pitch_bins=n_states // 2,
+            transition_width=1,
+            switch_prob=0.01,
+        )
+
+
+def test_pyin_viterbi_fail_empty_transition_column():
+    observation_probs = np.ones((2, 4), dtype=np.float64) / 2
+    bad_offsets = np.array([0, 1, 1], dtype=np.int64)
+    src_idx = np.array([0], dtype=np.int64)
+    src_logp = np.array([0.0], dtype=np.float64)
+
+    with mock.patch.object(
+        librosa.core.pitch,
+        "__pyin_sparse_transition",
+        return_value=(bad_offsets, src_idx, src_logp),
+    ):
+        with pytest.raises(
+            librosa.ParameterError, match="at least one state has no incoming transitions"
+        ):
+            librosa.core.pitch.__pyin_viterbi(
+                observation_probs,
+                n_pitch_bins=1,
+                transition_width=1,
+                switch_prob=0.01,
+            )
+
+
 @pytest.mark.xfail(raises=librosa.ParameterError)
 @pytest.mark.parametrize(
     "fmin,fmax,frame_length",


### PR DESCRIPTION
I hope this implementation addresses one of the most significant performance bottlenecks in the library by optimizing the Viterbi decoding step in pyin.

#### What does this implement/fix? Explain your changes.
**Before**: pyin built a dense transition matrix and decoded with the generic sequence.viterbi.
**After**: pyin now uses a specialized sparse Viterbi path (__pyin_viterbi + __viterbi_sparse_numba) with cached transition structure (@lru_cache).

**Coverage**: added tests for sparse vs dense decoding equivalence, batched shapes, transition-cache behavior, and new guard branches; tests/test_core.py passes.

Why these functions are in pitch.py (not sequence.py):
This is really a pyin optimization, not a generic Viterbi feature.
sequence.py is used as the shared decoding module, so I didn’t want to put pyin-specific assumptions there.
Keeping it in pitch.py makes the scope clear: we speed up pyin only, and we don’t risk changing behavior for other code paths that rely on sequence.viterbi.

#### Environment 
macOS-26.3-arm64
Python 3.13.5
NumPy 2.4.2
SciPy 1.17.1
librosa 1.0.0dev

#### Profiling Comparison (60s audio)
Test file: test_1min.wav
Sample rate: 44.1 kHz
Duration: 60 seconds
Profiler: cProfile

| Component | Dense (s) | Optimized (s) | Speedup |
| --- | --- | --- | --- |
| Total pyin | 11.797 | 1.230 | **9.6×** :fire: |
| Viterbi core | 11.164 | 0.570 | **19.6×** :fire: |
| numpy.vectorize | 11.567 | 0.488 | **23.7×** :fire: |
| __pyin_helper | 0.420 | 0.487 | ~1.0× |
| YIN CMND | 0.191 | 0.167 | ~1.1× |
| Autocorrelate | 0.129 | 0.115 | ~1.1× |

#### Benchmark Comparison
[benchmark.py](https://github.com/user-attachments/files/25659606/benchmark.py)

Repeats: 3 runs per file with cache warm-up.
| File  | sr | Samples | OLD mean (s) | NEW mean (s) | Speedup |
| --- | --- | --- | --- | --- | --- |
| `test_1min.wav`  | 44100 | 2,646,000 | 11.70 | 1.02 | **11.4×** |
| `test_5min.wav` | 44100 | 13,230,000 | 58.65 | 5.09 | **11.5×** |
| `test_15min.wav` | 44100 | 39,690,000 | 175.72 | 16.81 | **10.4×** |

#### tests
I performed a validation test comparing the new implementation against the previous dense version, and no discrepancies were observed.

INPUT
file: /bench/test_1min.wav
sr: 44100
samples: 2646000
duration_sec: 60.00

DIFF (new vs old)
state_sequence_equal: True
state_sequence_mismatch_frames: 0
f0_exact_equal: True
voiced_flag_equal: True
voiced_prob_exact_equal: True
voiced_prob_allclose: True
shared_voiced_frames: 5164
shared_voiced_nonempty: True
f0_abs_diff_mean_hz: 0.000000000000
f0_abs_diff_max_hz: 0.000000000000
voiced_prob_abs_diff_mean: 0.000000000000
voiced_prob_abs_diff_max: 0.000000000000

