### PR TITLE
Add a pYIN-specific exact structured Viterbi backend

### DIFF
--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -22,6 +22,8 @@ from .._typing import _WindowSpec, _PadMode, _PadModeSTFT
 
 __all__ = ["estimate_tuning", "pitch_tuning", "piptrack", "yin", "pyin"]
 
+_PYIN_VITERBI_IMPLS = ("legacy", "fast")
+
 
 def estimate_tuning(
     *,
@@ -666,6 +668,7 @@ def pyin(
     switch_prob: float = 0.01,
     no_trough_prob: float = 0.01,
     fill_na: Optional[float] = np.nan,
+    viterbi_impl: str = "legacy",
     center: bool = True,
     pad_mode: _PadMode = "constant",
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
@@ -737,6 +740,10 @@ def pyin(
         default value for unvoiced frames of ``f0``.
         If ``None``, the unvoiced frames will contain a best guess value.
 
+    viterbi_impl : str
+        Viterbi backend used for the pYIN HMM smoothing stage.
+        One of ``"legacy"`` or ``"fast"``.
+
     center : boolean
         If ``True``, the signal ``y`` is padded so that frame
         ``D[:, t]`` is centered at ``y[t * hop_length]``.
@@ -796,6 +803,12 @@ def pyin(
     """
     if fmin is None or fmax is None:
         raise ParameterError('both "fmin" and "fmax" must be provided')
+
+    if viterbi_impl not in _PYIN_VITERBI_IMPLS:
+        raise ParameterError(
+            f'Invalid pyin viterbi_impl="{viterbi_impl}". '
+            f"Expected one of {_PYIN_VITERBI_IMPLS}."
+        )
 
     if not isinstance(win_length, Deprecated):
         warnings.warn(
@@ -880,7 +893,12 @@ def pyin(
 
     p_init = np.ones(2 * n_pitch_bins) / (2 * n_pitch_bins)
 
-    states = sequence.viterbi(observation_probs, transition, p_init=p_init)
+    states = __pyin_viterbi(
+        observation_probs,
+        transition,
+        p_init=p_init,
+        viterbi_impl=viterbi_impl,
+    )
 
     # Find f0 corresponding to each decoded pitch bin.
     freqs = fmin * 2 ** (np.arange(n_pitch_bins) / (12 * n_bins_per_semitone))
@@ -891,6 +909,109 @@ def pyin(
         f0[~voiced_flag] = fill_na
 
     return f0[..., 0, :], voiced_flag[..., 0, :], voiced_prob[..., 0, :]
+
+
+@numba.jit(nopython=True, cache=True)  # type: ignore
+def __pyin_transition_structure(
+    transition: np.ndarray,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:  # pragma: no cover
+    n_states = transition.shape[0]
+    max_width = 0
+    for target in range(n_states):
+        count = 0
+        for source in range(n_states):
+            if transition[source, target] > 0:
+                count += 1
+        if count > max_width:
+            max_width = count
+
+    source_idx = np.zeros((n_states, max_width), dtype=np.uint16)
+    log_trans = np.full((n_states, max_width), -np.inf, dtype=np.float64)
+    counts = np.zeros(n_states, dtype=np.uint16)
+
+    for target in range(n_states):
+        count = 0
+        for source in range(n_states):
+            value = transition[source, target]
+            if value > 0:
+                source_idx[target, count] = source
+                log_trans[target, count] = np.log(value)
+                count += 1
+        counts[target] = count
+
+    return source_idx, log_trans, counts
+
+
+@numba.jit(nopython=True, cache=True)  # type: ignore
+def __pyin_viterbi_sparse(
+    log_prob: np.ndarray,
+    source_idx: np.ndarray,
+    log_trans: np.ndarray,
+    counts: np.ndarray,
+    log_p_init: np.ndarray,
+) -> Tuple[np.ndarray, np.ndarray]:  # pragma: no cover
+    n_steps, n_states = log_prob.shape
+    state = np.zeros(n_steps, dtype=np.uint16)
+    value = np.zeros((n_steps, n_states), dtype=np.float64)
+    ptr = np.zeros((n_steps, n_states), dtype=np.uint16)
+
+    value[0] = log_prob[0] + log_p_init
+
+    for t in range(1, n_steps):
+        prev = value[t - 1]
+        for target in range(n_states):
+            best_source = 0
+            best_val = -np.inf
+            count = counts[target]
+            for k in range(count):
+                source = source_idx[target, k]
+                candidate = prev[source] + log_trans[target, k]
+                if candidate > best_val:
+                    best_val = candidate
+                    best_source = source
+            ptr[t, target] = best_source
+            value[t, target] = log_prob[t, target] + best_val
+
+    state[-1] = np.argmax(value[-1])
+
+    for t in range(n_steps - 2, -1, -1):
+        state[t] = ptr[t + 1, state[t + 1]]
+
+    logp = value[-1:, state[-1]]
+    return state, logp
+
+
+def __pyin_viterbi(
+    prob: np.ndarray,
+    transition: np.ndarray,
+    *,
+    p_init: np.ndarray,
+    viterbi_impl: str,
+) -> np.ndarray:
+    if viterbi_impl == "legacy":
+        return sequence.viterbi(prob, transition, p_init=p_init)
+
+    n_states, _ = prob.shape[-2:]
+    epsilon = util.tiny(prob)
+    log_prob = np.log(prob + epsilon)
+    log_p_init = np.log(p_init + epsilon)
+    source_idx, log_trans, counts = __pyin_transition_structure(transition)
+
+    def _helper(lp):
+        state, _ = __pyin_viterbi_sparse(
+            lp.T,
+            source_idx,
+            log_trans,
+            counts,
+            log_p_init,
+        )
+        return state.T
+
+    if log_prob.ndim == 2:
+        return _helper(log_prob)
+
+    __viterbi = np.vectorize(_helper, otypes=[np.uint16], signature="(s,t)->(t)")
+    return __viterbi(log_prob)
 
 
 def __pyin_helper(

--- a/scripts/benchmark_pyin_viterbi.py
+++ b/scripts/benchmark_pyin_viterbi.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python
+import argparse
+import importlib
+import json
+import pathlib
+import sys
+import time
+
+import numpy as np
+import scipy
+
+# Ensure the local checkout is imported rather than any site-packages install.
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import librosa
+
+pitch_mod = importlib.import_module("librosa.core.pitch")
+PYIN_VITERBI = getattr(pitch_mod, "__pyin_viterbi")
+PYIN_HELPER = getattr(pitch_mod, "__pyin_helper")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--duration", type=float, default=4.0)
+    parser.add_argument("--repeat-audio", type=int, default=1)
+    parser.add_argument("--sr", type=int, default=22050)
+    parser.add_argument("--warmup", type=int, default=1)
+    parser.add_argument("--iters", type=int, default=3)
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args()
+
+
+def synth_audio(duration: float, sr: int, repeat_audio: int) -> np.ndarray:
+    y = librosa.chirp(fmin=220, fmax=640, sr=sr, duration=duration, linear=False)
+    y = np.pad(y, (sr,))
+    if repeat_audio > 1:
+        y = np.tile(y, repeat_audio)
+    return y.astype(np.float64, copy=False)
+
+
+def time_call(fn, *, warmup: int, iters: int) -> float:
+    for _ in range(warmup):
+        fn()
+    durations_ms = []
+    for _ in range(iters):
+        start = time.perf_counter()
+        fn()
+        durations_ms.append((time.perf_counter() - start) * 1000.0)
+    durations_ms.sort()
+    return durations_ms[len(durations_ms) // 2]
+
+
+def prepare_pyin_state(
+    y: np.ndarray,
+    sr: int,
+    frame_length: int = 2048,
+    hop_length: int = 512,
+    fmin: float = 110.0,
+    fmax: float = 880.0,
+    n_thresholds: int = 100,
+    beta_parameters=(2, 18),
+    boltzmann_parameter: float = 2.0,
+    resolution: float = 0.1,
+    max_transition_rate: float = 35.92,
+    switch_prob: float = 0.01,
+    no_trough_prob: float = 0.01,
+):
+    min_period = int(np.floor(sr / fmax))
+    max_period = min(int(np.ceil(sr / fmin)), frame_length - 1)
+    y_frames = librosa.util.frame(y, frame_length=frame_length, hop_length=hop_length)
+    yin_frames = pitch_mod._cumulative_mean_normalized_difference(
+        y_frames, min_period, max_period
+    )
+    parabolic_shifts = pitch_mod._parabolic_interpolation(yin_frames)
+
+    thresholds = np.linspace(0, 1, n_thresholds + 1)
+    beta_cdf = scipy.stats.beta.cdf(thresholds, beta_parameters[0], beta_parameters[1])
+    beta_probs = np.diff(beta_cdf)
+
+    n_bins_per_semitone = int(np.ceil(1.0 / resolution))
+    n_pitch_bins = int(np.floor(12 * n_bins_per_semitone * np.log2(fmax / fmin))) + 1
+
+    helper = np.vectorize(
+        lambda a, b: PYIN_HELPER(
+            a,
+            b,
+            sr,
+            thresholds,
+            boltzmann_parameter,
+            beta_probs,
+            no_trough_prob,
+            min_period,
+            fmin,
+            n_pitch_bins,
+            n_bins_per_semitone,
+        ),
+        signature="(f,t),(k,t)->(1,d,t),(j,t)",
+    )
+    observation_probs, voiced_prob = helper(yin_frames, parabolic_shifts)
+
+    max_semitones_per_frame = round(max_transition_rate * 12 * hop_length / sr)
+    transition_width = max_semitones_per_frame * n_bins_per_semitone + 1
+    transition = librosa.sequence.transition_local(
+        n_pitch_bins, transition_width, window="triangle", wrap=False
+    )
+    t_switch = librosa.sequence.transition_loop(2, 1 - switch_prob)
+    transition = np.kron(t_switch, transition)
+    p_init = np.ones(2 * n_pitch_bins) / (2 * n_pitch_bins)
+
+    return {
+        "observation_probs": observation_probs,
+        "voiced_prob": voiced_prob,
+        "transition": transition,
+        "p_init": p_init,
+        "frames": int(observation_probs.shape[-1]),
+    }
+
+
+def benchmark(args):
+    y = synth_audio(args.duration, args.sr, args.repeat_audio)
+    state = prepare_pyin_state(y, args.sr)
+
+    legacy_states = PYIN_VITERBI(
+        state["observation_probs"],
+        state["transition"],
+        p_init=state["p_init"],
+        viterbi_impl="legacy",
+    )
+    fast_states = PYIN_VITERBI(
+        state["observation_probs"],
+        state["transition"],
+        p_init=state["p_init"],
+        viterbi_impl="fast",
+    )
+
+    f0_legacy, voiced_legacy, prob_legacy = librosa.pyin(
+        y,
+        sr=args.sr,
+        fmin=110,
+        fmax=880,
+        center=False,
+        fill_na=-1,
+        viterbi_impl="legacy",
+    )
+    f0_fast, voiced_fast, prob_fast = librosa.pyin(
+        y,
+        sr=args.sr,
+        fmin=110,
+        fmax=880,
+        center=False,
+        fill_na=-1,
+        viterbi_impl="fast",
+    )
+
+    return {
+        "duration": args.duration,
+        "repeat_audio": args.repeat_audio,
+        "frames": state["frames"],
+        "decoder_parity_ok": bool(np.array_equal(legacy_states, fast_states)),
+        "f0_parity_ok": bool(np.array_equal(f0_legacy, f0_fast)),
+        "voiced_parity_ok": bool(np.array_equal(voiced_legacy, voiced_fast)),
+        "prob_parity_ok": bool(np.array_equal(prob_legacy, prob_fast)),
+        "pyin_viterbi_legacy_ms": time_call(
+            lambda: PYIN_VITERBI(
+                state["observation_probs"],
+                state["transition"],
+                p_init=state["p_init"],
+                viterbi_impl="legacy",
+            ),
+            warmup=args.warmup,
+            iters=args.iters,
+        ),
+        "pyin_viterbi_fast_ms": time_call(
+            lambda: PYIN_VITERBI(
+                state["observation_probs"],
+                state["transition"],
+                p_init=state["p_init"],
+                viterbi_impl="fast",
+            ),
+            warmup=args.warmup,
+            iters=args.iters,
+        ),
+        "pyin_legacy_ms": time_call(
+            lambda: librosa.pyin(
+                y,
+                sr=args.sr,
+                fmin=110,
+                fmax=880,
+                center=False,
+                fill_na=-1,
+                viterbi_impl="legacy",
+            ),
+            warmup=args.warmup,
+            iters=args.iters,
+        ),
+        "pyin_fast_ms": time_call(
+            lambda: librosa.pyin(
+                y,
+                sr=args.sr,
+                fmin=110,
+                fmax=880,
+                center=False,
+                fill_na=-1,
+                viterbi_impl="fast",
+            ),
+            warmup=args.warmup,
+            iters=args.iters,
+        ),
+    }
+
+
+def render_markdown(result):
+    core_speedup = result["pyin_viterbi_legacy_ms"] / result["pyin_viterbi_fast_ms"]
+    full_speedup = result["pyin_legacy_ms"] / result["pyin_fast_ms"]
+    lines = [
+        "## librosa pYIN Benchmark",
+        "",
+        f"**Duration:** `{result['duration']}` seconds",
+        f"**Repeated:** `{result['repeat_audio']}`",
+        f"**Frames:** `{result['frames']}`",
+        "",
+        "---",
+        "",
+        "## pYIN Decoder Core",
+        "",
+        "| Impl | Time |",
+        "|:--|--:|",
+        f"| `legacy` | **{result['pyin_viterbi_legacy_ms']:.3f} ms** |",
+        f"| `fast` | **{result['pyin_viterbi_fast_ms']:.3f} ms** |",
+        "",
+        f"> ✅ **Core speedup:** `{core_speedup:.2f}x`",
+        "",
+        "---",
+        "",
+        "## Full pYIN",
+        "",
+        "| Impl | Time |",
+        "|:--|--:|",
+        f"| `legacy` | **{result['pyin_legacy_ms']:.3f} ms** |",
+        f"| `fast` | **{result['pyin_fast_ms']:.3f} ms** |",
+        "",
+        f"> ✅ **End-to-end speedup:** `{full_speedup:.2f}x`",
+        "",
+        "## Parity",
+        "",
+        f"- decoder states: `{'ok' if result['decoder_parity_ok'] else 'mismatch'}`",
+        f"- f0: `{'ok' if result['f0_parity_ok'] else 'mismatch'}`",
+        f"- voiced flags: `{'ok' if result['voiced_parity_ok'] else 'mismatch'}`",
+        f"- voiced probability: `{'ok' if result['prob_parity_ok'] else 'mismatch'}`",
+    ]
+    return "\n".join(lines)
+
+
+def main():
+    args = parse_args()
+    result = benchmark(args)
+    if args.json:
+        print(json.dumps(result, indent=2))
+        return
+    print(render_markdown(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1241,6 +1241,20 @@ def test_pyin_tone(freq):
     assert np.allclose(np.log2(f0), np.log2(freq), rtol=0, atol=1e-2)
 
 
+@pytest.mark.parametrize("freq", [110, 440])
+def test_pyin_viterbi_impl_parity_tone(freq):
+    y = librosa.tone(freq, duration=1.0)
+    f0_legacy, vf_legacy, vp_legacy = librosa.pyin(
+        y, fmin=110, fmax=1000, center=False, fill_na=-1, viterbi_impl="legacy"
+    )
+    f0_fast, vf_fast, vp_fast = librosa.pyin(
+        y, fmin=110, fmax=1000, center=False, fill_na=-1, viterbi_impl="fast"
+    )
+    assert np.array_equal(f0_legacy, f0_fast)
+    assert np.array_equal(vf_legacy, vf_fast)
+    assert np.array_equal(vp_legacy, vp_fast)
+
+
 def test_pyin_multi():
     y = np.stack([librosa.tone(440, duration=1.0), librosa.tone(560, duration=1.0)])
 
@@ -1261,6 +1275,23 @@ def test_pyin_multi():
     assert np.allclose(vall[1], v1)
     assert np.allclose(vpall[0], vp0)
     assert np.allclose(vpall[1], vp1)
+
+
+def test_pyin_viterbi_impl_parity_multi():
+    y = np.stack([librosa.tone(440, duration=1.0), librosa.tone(560, duration=1.0)])
+    h = librosa.filters.get_window("triangle", y.shape[-1])
+    y = y * h[np.newaxis, :]
+
+    fall_legacy, vall_legacy, vpall_legacy = librosa.pyin(
+        y, fmin=100, fmax=1000, center=False, fill_na=-1, viterbi_impl="legacy"
+    )
+    fall_fast, vall_fast, vpall_fast = librosa.pyin(
+        y, fmin=100, fmax=1000, center=False, fill_na=-1, viterbi_impl="fast"
+    )
+
+    assert np.array_equal(fall_legacy, fall_fast)
+    assert np.array_equal(vall_legacy, vall_fast)
+    assert np.array_equal(vpall_legacy, vpall_fast)
 
 
 @pytest.mark.skipif(
@@ -1319,6 +1350,32 @@ def test_pyin_chirp():
     assert np.allclose(
         np.log2(f0[voiced_flag]), np.log2(target_f0[target_f0 > 0]), rtol=0, atol=1e-2
     )
+
+
+def test_pyin_viterbi_impl_parity_chirp():
+    y = librosa.chirp(fmin=220, fmax=640, duration=1.0)
+    y = np.pad(y, (22050,))
+
+    kwargs = dict(
+        fmin=60,
+        fmax=900,
+        center=False,
+        frame_length=1024,
+        hop_length=512,
+        resolution=0.2,
+        fill_na=-1,
+    )
+
+    f0_legacy, voiced_legacy, prob_legacy = librosa.pyin(
+        y, viterbi_impl="legacy", **kwargs
+    )
+    f0_fast, voiced_fast, prob_fast = librosa.pyin(
+        y, viterbi_impl="fast", **kwargs
+    )
+
+    assert np.array_equal(f0_legacy, f0_fast)
+    assert np.array_equal(voiced_legacy, voiced_fast)
+    assert np.array_equal(prob_legacy, prob_fast)
 
 
 def test_pyin_chirp_instant():
@@ -1381,6 +1438,12 @@ def test_pyin_warn():
     # win_length is deprecated
     with pytest.warns(FutureWarning, match="deprecated"):
         librosa.pyin(y, fmin=110, fmax=1000, win_length=1024)
+
+
+def test_pyin_viterbi_impl_fail():
+    y = librosa.tone(110, duration=1.0)
+    with pytest.raises(librosa.ParameterError):
+        librosa.pyin(y, fmin=110, fmax=1000, viterbi_impl="bogus")
 
 
 @pytest.mark.parametrize("freq", [110, 220, 440, 880])


### PR DESCRIPTION

## Summary

This PR adds an exact structured Viterbi backend to `librosa.pyin()` while
keeping the generic `librosa.sequence.viterbi` API unchanged and preserving the
current pYIN behavior as the default.

The patch is intentionally conservative:

- pYIN-scoped only
- additive backend selection
- exact parity coverage
- benchmark harness for the pYIN path

## What This Adds

- `librosa.pyin(..., viterbi_impl="legacy")`
  - preserves current behavior
- `librosa.pyin(..., viterbi_impl="fast")`
  - exact structured pYIN backend
- private helper functions for sparse predecessor construction and pYIN-only
  structured decoding
- focused pYIN parity tests
- `scripts/benchmark_pyin_viterbi.py`

## Why

`librosa.pyin()` already builds a local transition structure for the pYIN HMM
stage, but it currently routes through the generic dense
`librosa.sequence.viterbi(...)` implementation.

This PR keeps the same dynamic program and the same transition probabilities,
but evaluates the recurrence only over reachable predecessor states for the
pYIN topology.

The key point is scope: this PR does **not** attempt to redesign the generic
`sequence.viterbi` API. It only adds an alternative implementation for the
already-structured pYIN case.

## Benchmark Notes

Local benchmark results on synthetic chirp workloads showed:

- `255` frames:
  - decoder core: `192.483 ms` -> `29.010 ms` (`6.64x`)
  - full `pyin()`: `213.456 ms` -> `51.338 ms` (`4.16x`)
- `1030` frames:
  - decoder core: `780.758 ms` -> `114.260 ms` (`6.83x`)
  - full `pyin()`: `859.665 ms` -> `198.277 ms` (`4.34x`)

Local timing on an official `tests/data` WAV fixture also showed:

- `tests/data/test1_22050.wav`
  - full `pyin()`: `163.2 ms` -> `40.496 ms`
  - about `4.03x`

## Parity

On the exercised local workloads, parity was exact for:

- decoder states
- `f0`
- voiced flags
- voiced probabilities

The test set in this PR includes:

- tone parity
- multichannel parity
- chirp parity
- invalid backend-mode handling

I also validated locally with the official `tests/data` submodule restored so
that the existing `pitch-pyin.npy` chirp reference fixture remained in play.

## Validation

Commands used locally:

```bash
python -m pytest -o addopts='' tests/test_core.py \
  -k 'pyin_viterbi_impl or test_pyin_chirp or pyin_viterbi_impl_parity_chirp' -q
python -m py_compile \
  librosa/core/pitch.py \
  tests/test_core.py \
  scripts/benchmark_pyin_viterbi.py
```

## Reviewer Notes

- `viterbi_impl="legacy"` remains the default in this PR.
- The new path is opt-in as `viterbi_impl="fast"`.
- The generic `librosa.sequence.viterbi` API is intentionally untouched.
- If maintainers are interested, a later follow-up can discuss whether the
  pYIN default should move after broader review.

## Scope

This patch is meant to be the smallest useful upstream proposal:

- pYIN only
- exact implementation change
- no generic API redesign

## Context

This patch comes from a broader cross-repo study of exact structured Viterbi in
pitch trackers. That study produced repeated positive transfer in `penn-mlx`,
vendored upstream `penn` on both CPU and MPS, `mlxcrepe`, `torchcrepe`, and
`libf0`. The `librosa` proposal is intentionally narrower than those repo-local
changes: it keeps the optimization scoped to `pyin()` and leaves the generic
`sequence.viterbi` API unchanged.
