### PR TITLE
Follow-up: use Kronecker pYIN transition structure in fast Viterbi

### DIFF
--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -22,6 +22,8 @@ from .._typing import _WindowSpec, _PadMode, _PadModeSTFT
 
 __all__ = ["estimate_tuning", "pitch_tuning", "piptrack", "yin", "pyin"]
 
+_PYIN_VITERBI_IMPLS = ("legacy", "fast")
+
 
 def estimate_tuning(
     *,
@@ -666,6 +668,7 @@ def pyin(
     switch_prob: float = 0.01,
     no_trough_prob: float = 0.01,
     fill_na: Optional[float] = np.nan,
+    viterbi_impl: str = "legacy",
     center: bool = True,
     pad_mode: _PadMode = "constant",
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
@@ -737,6 +740,10 @@ def pyin(
         default value for unvoiced frames of ``f0``.
         If ``None``, the unvoiced frames will contain a best guess value.
 
+    viterbi_impl : str
+        Viterbi backend used for the pYIN HMM smoothing stage.
+        One of ``"legacy"`` or ``"fast"``.
+
     center : boolean
         If ``True``, the signal ``y`` is padded so that frame
         ``D[:, t]`` is centered at ``y[t * hop_length]``.
@@ -796,6 +803,12 @@ def pyin(
     """
     if fmin is None or fmax is None:
         raise ParameterError('both "fmin" and "fmax" must be provided')
+
+    if viterbi_impl not in _PYIN_VITERBI_IMPLS:
+        raise ParameterError(
+            f'Invalid pyin viterbi_impl="{viterbi_impl}". '
+            f"Expected one of {_PYIN_VITERBI_IMPLS}."
+        )
 
     if not isinstance(win_length, Deprecated):
         warnings.warn(
@@ -880,7 +893,12 @@ def pyin(
 
     p_init = np.ones(2 * n_pitch_bins) / (2 * n_pitch_bins)
 
-    states = sequence.viterbi(observation_probs, transition, p_init=p_init)
+    states = __pyin_viterbi(
+        observation_probs,
+        transition,
+        p_init=p_init,
+        viterbi_impl=viterbi_impl,
+    )
 
     # Find f0 corresponding to each decoded pitch bin.
     freqs = fmin * 2 ** (np.arange(n_pitch_bins) / (12 * n_bins_per_semitone))
@@ -891,6 +909,109 @@ def pyin(
         f0[~voiced_flag] = fill_na
 
     return f0[..., 0, :], voiced_flag[..., 0, :], voiced_prob[..., 0, :]
+
+
+@numba.jit(nopython=True, cache=True)  # type: ignore
+def __pyin_transition_structure(
+    transition: np.ndarray,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:  # pragma: no cover
+    n_states = transition.shape[0]
+    max_width = 0
+    for target in range(n_states):
+        count = 0
+        for source in range(n_states):
+            if transition[source, target] > 0:
+                count += 1
+        if count > max_width:
+            max_width = count
+
+    source_idx = np.zeros((n_states, max_width), dtype=np.uint16)
+    log_trans = np.full((n_states, max_width), -np.inf, dtype=np.float64)
+    counts = np.zeros(n_states, dtype=np.uint16)
+
+    for target in range(n_states):
+        count = 0
+        for source in range(n_states):
+            value = transition[source, target]
+            if value > 0:
+                source_idx[target, count] = source
+                log_trans[target, count] = np.log(value)
+                count += 1
+        counts[target] = count
+
+    return source_idx, log_trans, counts
+
+
+@numba.jit(nopython=True, cache=True)  # type: ignore
+def __pyin_viterbi_sparse(
+    log_prob: np.ndarray,
+    source_idx: np.ndarray,
+    log_trans: np.ndarray,
+    counts: np.ndarray,
+    log_p_init: np.ndarray,
+) -> Tuple[np.ndarray, np.ndarray]:  # pragma: no cover
+    n_steps, n_states = log_prob.shape
+    state = np.zeros(n_steps, dtype=np.uint16)
+    value = np.zeros((n_steps, n_states), dtype=np.float64)
+    ptr = np.zeros((n_steps, n_states), dtype=np.uint16)
+
+    value[0] = log_prob[0] + log_p_init
+
+    for t in range(1, n_steps):
+        prev = value[t - 1]
+        for target in range(n_states):
+            best_source = 0
+            best_val = -np.inf
+            count = counts[target]
+            for k in range(count):
+                source = source_idx[target, k]
+                candidate = prev[source] + log_trans[target, k]
+                if candidate > best_val:
+                    best_val = candidate
+                    best_source = source
+            ptr[t, target] = best_source
+            value[t, target] = log_prob[t, target] + best_val
+
+    state[-1] = np.argmax(value[-1])
+
+    for t in range(n_steps - 2, -1, -1):
+        state[t] = ptr[t + 1, state[t + 1]]
+
+    logp = value[-1:, state[-1]]
+    return state, logp
+
+
+def __pyin_viterbi(
+    prob: np.ndarray,
+    transition: np.ndarray,
+    *,
+    p_init: np.ndarray,
+    viterbi_impl: str,
+) -> np.ndarray:
+    if viterbi_impl == "legacy":
+        return sequence.viterbi(prob, transition, p_init=p_init)
+
+    n_states, _ = prob.shape[-2:]
+    epsilon = util.tiny(prob)
+    log_prob = np.log(prob + epsilon)
+    log_p_init = np.log(p_init + epsilon)
+    source_idx, log_trans, counts = __pyin_transition_structure(transition)
+
+    def _helper(lp):
+        state, _ = __pyin_viterbi_sparse(
+            lp.T,
+            source_idx,
+            log_trans,
+            counts,
+            log_p_init,
+        )
+        return state.T
+
+    if log_prob.ndim == 2:
+        return _helper(log_prob)
+
+    __viterbi = np.vectorize(_helper, otypes=[np.uint16], signature="(s,t)->(t)")
+    return __viterbi(log_prob)
 
 
 def __pyin_helper(

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -887,10 +887,6 @@ def pyin(
         n_pitch_bins, transition_width, window="triangle", wrap=False
     )
 
-    # Include across voicing transition probabilities
-    t_switch = sequence.transition_loop(2, 1 - switch_prob)
-    transition = np.kron(t_switch, transition)
-
     p_init = np.ones(2 * n_pitch_bins) / (2 * n_pitch_bins)
 
     states = __pyin_viterbi(
@@ -898,6 +894,7 @@ def pyin(
         transition,
         p_init=p_init,
         viterbi_impl=viterbi_impl,
+        switch_prob=switch_prob,
     )
 
     # Find f0 corresponding to each decoded pitch bin.
@@ -943,6 +940,73 @@ def __pyin_transition_structure(
 
 
 @numba.jit(nopython=True, cache=True)  # type: ignore
+def __pyin_transition_structure_kron(
+    transition_local: np.ndarray,
+    switch_prob: float,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:  # pragma: no cover
+    """Build predecessor structure for kron([[1-s, s], [s, 1-s]], transition_local)."""
+    n_pitch_bins = transition_local.shape[0]
+    n_states = 2 * n_pitch_bins
+    tiny = np.finfo(0.0).tiny
+
+    max_count = 0
+    for target_pitch in range(n_pitch_bins):
+        count = 0
+        for source_pitch in range(n_pitch_bins):
+            if transition_local[source_pitch, target_pitch] > 0:
+                count += 1
+        if count > max_count:
+            max_count = count
+
+    max_width = 2 * max_count
+    source_idx = np.zeros((n_states, max_width), dtype=np.int32)
+    log_trans = np.full((n_states, max_width), -np.inf, dtype=np.float64)
+    counts = np.zeros(n_states, dtype=np.int32)
+
+    same_prob = 1.0 - switch_prob
+    cross_prob = switch_prob
+
+    for target_pitch in range(n_pitch_bins):
+        # Voiced target ordering matches dense source scan: voiced sources first,
+        # then unvoiced sources.
+        target_voiced = target_pitch
+        for source_pitch in range(n_pitch_bins):
+            value = transition_local[source_pitch, target_pitch]
+            if value > 0:
+                idx = counts[target_voiced]
+                source_idx[target_voiced, idx] = source_pitch
+                log_trans[target_voiced, idx] = np.log(same_prob * value + tiny)
+                counts[target_voiced] += 1
+        for source_pitch in range(n_pitch_bins):
+            value = transition_local[source_pitch, target_pitch]
+            if value > 0:
+                idx = counts[target_voiced]
+                source_idx[target_voiced, idx] = source_pitch + n_pitch_bins
+                log_trans[target_voiced, idx] = np.log(cross_prob * value + tiny)
+                counts[target_voiced] += 1
+
+        # Unvoiced target ordering matches dense source scan: voiced sources first,
+        # then unvoiced sources.
+        target_unvoiced = target_pitch + n_pitch_bins
+        for source_pitch in range(n_pitch_bins):
+            value = transition_local[source_pitch, target_pitch]
+            if value > 0:
+                idx = counts[target_unvoiced]
+                source_idx[target_unvoiced, idx] = source_pitch
+                log_trans[target_unvoiced, idx] = np.log(cross_prob * value + tiny)
+                counts[target_unvoiced] += 1
+        for source_pitch in range(n_pitch_bins):
+            value = transition_local[source_pitch, target_pitch]
+            if value > 0:
+                idx = counts[target_unvoiced]
+                source_idx[target_unvoiced, idx] = source_pitch + n_pitch_bins
+                log_trans[target_unvoiced, idx] = np.log(same_prob * value + tiny)
+                counts[target_unvoiced] += 1
+
+    return source_idx, log_trans, counts
+
+
+@numba.jit(nopython=True, cache=True)  # type: ignore
 def __pyin_viterbi_sparse(
     log_prob: np.ndarray,
     source_idx: np.ndarray,
@@ -983,19 +1047,23 @@ def __pyin_viterbi_sparse(
 
 def __pyin_viterbi(
     prob: np.ndarray,
-    transition: np.ndarray,
+    transition_local: np.ndarray,
     *,
     p_init: np.ndarray,
     viterbi_impl: str,
+    switch_prob: float,
 ) -> np.ndarray:
     if viterbi_impl == "legacy":
+        t_switch = sequence.transition_loop(2, 1 - switch_prob)
+        transition = np.kron(t_switch, transition_local)
         return sequence.viterbi(prob, transition, p_init=p_init)
 
-    n_states, _ = prob.shape[-2:]
     epsilon = util.tiny(prob)
     log_prob = np.log(prob + epsilon)
     log_p_init = np.log(p_init + epsilon)
-    source_idx, log_trans, counts = __pyin_transition_structure(transition)
+    source_idx, log_trans, counts = __pyin_transition_structure_kron(
+        transition_local, switch_prob
+    )
 
     def _helper(lp):
         state, _ = __pyin_viterbi_sparse(
@@ -1010,7 +1078,7 @@ def __pyin_viterbi(
     if log_prob.ndim == 2:
         return _helper(log_prob)
 
-    __viterbi = np.vectorize(_helper, otypes=[np.uint16], signature="(s,t)->(t)")
+    __viterbi = np.vectorize(_helper, otypes=[np.int32], signature="(s,t)->(t)")
     return __viterbi(log_prob)
 
 

--- a/scripts/benchmark_pyin_viterbi.py
+++ b/scripts/benchmark_pyin_viterbi.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python
+import argparse
+import importlib
+import json
+import pathlib
+import sys
+import time
+
+import numpy as np
+import scipy
+
+# Ensure the local checkout is imported rather than any site-packages install.
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import librosa
+
+pitch_mod = importlib.import_module("librosa.core.pitch")
+PYIN_VITERBI = getattr(pitch_mod, "__pyin_viterbi")
+PYIN_HELPER = getattr(pitch_mod, "__pyin_helper")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--duration", type=float, default=4.0)
+    parser.add_argument("--repeat-audio", type=int, default=1)
+    parser.add_argument("--sr", type=int, default=22050)
+    parser.add_argument("--warmup", type=int, default=1)
+    parser.add_argument("--iters", type=int, default=3)
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args()
+
+
+def synth_audio(duration: float, sr: int, repeat_audio: int) -> np.ndarray:
+    y = librosa.chirp(fmin=220, fmax=640, sr=sr, duration=duration, linear=False)
+    y = np.pad(y, (sr,))
+    if repeat_audio > 1:
+        y = np.tile(y, repeat_audio)
+    return y.astype(np.float64, copy=False)
+
+
+def time_call(fn, *, warmup: int, iters: int) -> float:
+    for _ in range(warmup):
+        fn()
+    durations_ms = []
+    for _ in range(iters):
+        start = time.perf_counter()
+        fn()
+        durations_ms.append((time.perf_counter() - start) * 1000.0)
+    durations_ms.sort()
+    return durations_ms[len(durations_ms) // 2]
+
+
+def prepare_pyin_state(
+    y: np.ndarray,
+    sr: int,
+    frame_length: int = 2048,
+    hop_length: int = 512,
+    fmin: float = 110.0,
+    fmax: float = 880.0,
+    n_thresholds: int = 100,
+    beta_parameters=(2, 18),
+    boltzmann_parameter: float = 2.0,
+    resolution: float = 0.1,
+    max_transition_rate: float = 35.92,
+    switch_prob: float = 0.01,
+    no_trough_prob: float = 0.01,
+):
+    min_period = int(np.floor(sr / fmax))
+    max_period = min(int(np.ceil(sr / fmin)), frame_length - 1)
+    y_frames = librosa.util.frame(y, frame_length=frame_length, hop_length=hop_length)
+    yin_frames = pitch_mod._cumulative_mean_normalized_difference(
+        y_frames, min_period, max_period
+    )
+    parabolic_shifts = pitch_mod._parabolic_interpolation(yin_frames)
+
+    thresholds = np.linspace(0, 1, n_thresholds + 1)
+    beta_cdf = scipy.stats.beta.cdf(thresholds, beta_parameters[0], beta_parameters[1])
+    beta_probs = np.diff(beta_cdf)
+
+    n_bins_per_semitone = int(np.ceil(1.0 / resolution))
+    n_pitch_bins = int(np.floor(12 * n_bins_per_semitone * np.log2(fmax / fmin))) + 1
+
+    helper = np.vectorize(
+        lambda a, b: PYIN_HELPER(
+            a,
+            b,
+            sr,
+            thresholds,
+            boltzmann_parameter,
+            beta_probs,
+            no_trough_prob,
+            min_period,
+            fmin,
+            n_pitch_bins,
+            n_bins_per_semitone,
+        ),
+        signature="(f,t),(k,t)->(1,d,t),(j,t)",
+    )
+    observation_probs, voiced_prob = helper(yin_frames, parabolic_shifts)
+
+    max_semitones_per_frame = round(max_transition_rate * 12 * hop_length / sr)
+    transition_width = max_semitones_per_frame * n_bins_per_semitone + 1
+    transition = librosa.sequence.transition_local(
+        n_pitch_bins, transition_width, window="triangle", wrap=False
+    )
+    t_switch = librosa.sequence.transition_loop(2, 1 - switch_prob)
+    transition = np.kron(t_switch, transition)
+    p_init = np.ones(2 * n_pitch_bins) / (2 * n_pitch_bins)
+
+    return {
+        "observation_probs": observation_probs,
+        "voiced_prob": voiced_prob,
+        "transition": transition,
+        "p_init": p_init,
+        "frames": int(observation_probs.shape[-1]),
+    }
+
+
+def benchmark(args):
+    y = synth_audio(args.duration, args.sr, args.repeat_audio)
+    state = prepare_pyin_state(y, args.sr)
+
+    legacy_states = PYIN_VITERBI(
+        state["observation_probs"],
+        state["transition"],
+        p_init=state["p_init"],
+        viterbi_impl="legacy",
+    )
+    fast_states = PYIN_VITERBI(
+        state["observation_probs"],
+        state["transition"],
+        p_init=state["p_init"],
+        viterbi_impl="fast",
+    )
+
+    f0_legacy, voiced_legacy, prob_legacy = librosa.pyin(
+        y,
+        sr=args.sr,
+        fmin=110,
+        fmax=880,
+        center=False,
+        fill_na=-1,
+        viterbi_impl="legacy",
+    )
+    f0_fast, voiced_fast, prob_fast = librosa.pyin(
+        y,
+        sr=args.sr,
+        fmin=110,
+        fmax=880,
+        center=False,
+        fill_na=-1,
+        viterbi_impl="fast",
+    )
+
+    return {
+        "duration": args.duration,
+        "repeat_audio": args.repeat_audio,
+        "frames": state["frames"],
+        "decoder_parity_ok": bool(np.array_equal(legacy_states, fast_states)),
+        "f0_parity_ok": bool(np.array_equal(f0_legacy, f0_fast)),
+        "voiced_parity_ok": bool(np.array_equal(voiced_legacy, voiced_fast)),
+        "prob_parity_ok": bool(np.array_equal(prob_legacy, prob_fast)),
+        "pyin_viterbi_legacy_ms": time_call(
+            lambda: PYIN_VITERBI(
+                state["observation_probs"],
+                state["transition"],
+                p_init=state["p_init"],
+                viterbi_impl="legacy",
+            ),
+            warmup=args.warmup,
+            iters=args.iters,
+        ),
+        "pyin_viterbi_fast_ms": time_call(
+            lambda: PYIN_VITERBI(
+                state["observation_probs"],
+                state["transition"],
+                p_init=state["p_init"],
+                viterbi_impl="fast",
+            ),
+            warmup=args.warmup,
+            iters=args.iters,
+        ),
+        "pyin_legacy_ms": time_call(
+            lambda: librosa.pyin(
+                y,
+                sr=args.sr,
+                fmin=110,
+                fmax=880,
+                center=False,
+                fill_na=-1,
+                viterbi_impl="legacy",
+            ),
+            warmup=args.warmup,
+            iters=args.iters,
+        ),
+        "pyin_fast_ms": time_call(
+            lambda: librosa.pyin(
+                y,
+                sr=args.sr,
+                fmin=110,
+                fmax=880,
+                center=False,
+                fill_na=-1,
+                viterbi_impl="fast",
+            ),
+            warmup=args.warmup,
+            iters=args.iters,
+        ),
+    }
+
+
+def render_markdown(result):
+    core_speedup = result["pyin_viterbi_legacy_ms"] / result["pyin_viterbi_fast_ms"]
+    full_speedup = result["pyin_legacy_ms"] / result["pyin_fast_ms"]
+    lines = [
+        "## librosa pYIN Benchmark",
+        "",
+        f"**Duration:** `{result['duration']}` seconds",
+        f"**Repeated:** `{result['repeat_audio']}`",
+        f"**Frames:** `{result['frames']}`",
+        "",
+        "---",
+        "",
+        "## pYIN Decoder Core",
+        "",
+        "| Impl | Time |",
+        "|:--|--:|",
+        f"| `legacy` | **{result['pyin_viterbi_legacy_ms']:.3f} ms** |",
+        f"| `fast` | **{result['pyin_viterbi_fast_ms']:.3f} ms** |",
+        "",
+        f"> ✅ **Core speedup:** `{core_speedup:.2f}x`",
+        "",
+        "---",
+        "",
+        "## Full pYIN",
+        "",
+        "| Impl | Time |",
+        "|:--|--:|",
+        f"| `legacy` | **{result['pyin_legacy_ms']:.3f} ms** |",
+        f"| `fast` | **{result['pyin_fast_ms']:.3f} ms** |",
+        "",
+        f"> ✅ **End-to-end speedup:** `{full_speedup:.2f}x`",
+        "",
+        "## Parity",
+        "",
+        f"- decoder states: `{'ok' if result['decoder_parity_ok'] else 'mismatch'}`",
+        f"- f0: `{'ok' if result['f0_parity_ok'] else 'mismatch'}`",
+        f"- voiced flags: `{'ok' if result['voiced_parity_ok'] else 'mismatch'}`",
+        f"- voiced probability: `{'ok' if result['prob_parity_ok'] else 'mismatch'}`",
+    ]
+    return "\n".join(lines)
+
+
+def main():
+    args = parse_args()
+    result = benchmark(args)
+    if args.json:
+        print(json.dumps(result, indent=2))
+        return
+    print(render_markdown(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark_pyin_viterbi.py
+++ b/scripts/benchmark_pyin_viterbi.py
@@ -102,17 +102,16 @@ def prepare_pyin_state(
 
     max_semitones_per_frame = round(max_transition_rate * 12 * hop_length / sr)
     transition_width = max_semitones_per_frame * n_bins_per_semitone + 1
-    transition = librosa.sequence.transition_local(
+    transition_local = librosa.sequence.transition_local(
         n_pitch_bins, transition_width, window="triangle", wrap=False
     )
-    t_switch = librosa.sequence.transition_loop(2, 1 - switch_prob)
-    transition = np.kron(t_switch, transition)
     p_init = np.ones(2 * n_pitch_bins) / (2 * n_pitch_bins)
 
     return {
         "observation_probs": observation_probs,
         "voiced_prob": voiced_prob,
-        "transition": transition,
+        "transition_local": transition_local,
+        "switch_prob": switch_prob,
         "p_init": p_init,
         "frames": int(observation_probs.shape[-1]),
     }
@@ -124,15 +123,17 @@ def benchmark(args):
 
     legacy_states = PYIN_VITERBI(
         state["observation_probs"],
-        state["transition"],
+        state["transition_local"],
         p_init=state["p_init"],
         viterbi_impl="legacy",
+        switch_prob=state["switch_prob"],
     )
     fast_states = PYIN_VITERBI(
         state["observation_probs"],
-        state["transition"],
+        state["transition_local"],
         p_init=state["p_init"],
         viterbi_impl="fast",
+        switch_prob=state["switch_prob"],
     )
 
     f0_legacy, voiced_legacy, prob_legacy = librosa.pyin(
@@ -165,9 +166,10 @@ def benchmark(args):
         "pyin_viterbi_legacy_ms": time_call(
             lambda: PYIN_VITERBI(
                 state["observation_probs"],
-                state["transition"],
+                state["transition_local"],
                 p_init=state["p_init"],
                 viterbi_impl="legacy",
+                switch_prob=state["switch_prob"],
             ),
             warmup=args.warmup,
             iters=args.iters,
@@ -175,9 +177,10 @@ def benchmark(args):
         "pyin_viterbi_fast_ms": time_call(
             lambda: PYIN_VITERBI(
                 state["observation_probs"],
-                state["transition"],
+                state["transition_local"],
                 p_init=state["p_init"],
                 viterbi_impl="fast",
+                switch_prob=state["switch_prob"],
             ),
             warmup=args.warmup,
             iters=args.iters,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1294,6 +1294,33 @@ def test_pyin_viterbi_impl_parity_multi():
     assert np.array_equal(vpall_legacy, vpall_fast)
 
 
+def test_pyin_kron_transition_structure_matches_dense():
+    n_pitch_bins = 72
+    transition_width = 11
+    switch_prob = 0.01
+
+    transition_local = librosa.sequence.transition_local(
+        n_pitch_bins, transition_width, window="triangle", wrap=False
+    )
+    t_switch = librosa.sequence.transition_loop(2, 1 - switch_prob)
+    transition_dense = np.kron(t_switch, transition_local)
+
+    source_dense, log_dense, counts_dense = librosa.core.pitch.__pyin_transition_structure(
+        transition_dense
+    )
+    source_kron, log_kron, counts_kron = librosa.core.pitch.__pyin_transition_structure_kron(
+        transition_local, switch_prob
+    )
+
+    assert np.array_equal(counts_dense, counts_kron)
+    for target in range(source_dense.shape[0]):
+        count = int(counts_dense[target])
+        assert np.array_equal(source_dense[target, :count], source_kron[target, :count])
+        assert np.allclose(
+            log_dense[target, :count], log_kron[target, :count], rtol=0, atol=1e-12
+        )
+
+
 @pytest.mark.skipif(
     sys.platform == "darwin", reason="Skip on OSX due to openblas issue"
 )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1241,6 +1241,20 @@ def test_pyin_tone(freq):
     assert np.allclose(np.log2(f0), np.log2(freq), rtol=0, atol=1e-2)
 
 
+@pytest.mark.parametrize("freq", [110, 440])
+def test_pyin_viterbi_impl_parity_tone(freq):
+    y = librosa.tone(freq, duration=1.0)
+    f0_legacy, vf_legacy, vp_legacy = librosa.pyin(
+        y, fmin=110, fmax=1000, center=False, fill_na=-1, viterbi_impl="legacy"
+    )
+    f0_fast, vf_fast, vp_fast = librosa.pyin(
+        y, fmin=110, fmax=1000, center=False, fill_na=-1, viterbi_impl="fast"
+    )
+    assert np.array_equal(f0_legacy, f0_fast)
+    assert np.array_equal(vf_legacy, vf_fast)
+    assert np.array_equal(vp_legacy, vp_fast)
+
+
 def test_pyin_multi():
     y = np.stack([librosa.tone(440, duration=1.0), librosa.tone(560, duration=1.0)])
 
@@ -1261,6 +1275,23 @@ def test_pyin_multi():
     assert np.allclose(vall[1], v1)
     assert np.allclose(vpall[0], vp0)
     assert np.allclose(vpall[1], vp1)
+
+
+def test_pyin_viterbi_impl_parity_multi():
+    y = np.stack([librosa.tone(440, duration=1.0), librosa.tone(560, duration=1.0)])
+    h = librosa.filters.get_window("triangle", y.shape[-1])
+    y = y * h[np.newaxis, :]
+
+    fall_legacy, vall_legacy, vpall_legacy = librosa.pyin(
+        y, fmin=100, fmax=1000, center=False, fill_na=-1, viterbi_impl="legacy"
+    )
+    fall_fast, vall_fast, vpall_fast = librosa.pyin(
+        y, fmin=100, fmax=1000, center=False, fill_na=-1, viterbi_impl="fast"
+    )
+
+    assert np.array_equal(fall_legacy, fall_fast)
+    assert np.array_equal(vall_legacy, vall_fast)
+    assert np.array_equal(vpall_legacy, vpall_fast)
 
 
 @pytest.mark.skipif(
@@ -1319,6 +1350,32 @@ def test_pyin_chirp():
     assert np.allclose(
         np.log2(f0[voiced_flag]), np.log2(target_f0[target_f0 > 0]), rtol=0, atol=1e-2
     )
+
+
+def test_pyin_viterbi_impl_parity_chirp():
+    y = librosa.chirp(fmin=220, fmax=640, duration=1.0)
+    y = np.pad(y, (22050,))
+
+    kwargs = dict(
+        fmin=60,
+        fmax=900,
+        center=False,
+        frame_length=1024,
+        hop_length=512,
+        resolution=0.2,
+        fill_na=-1,
+    )
+
+    f0_legacy, voiced_legacy, prob_legacy = librosa.pyin(
+        y, viterbi_impl="legacy", **kwargs
+    )
+    f0_fast, voiced_fast, prob_fast = librosa.pyin(
+        y, viterbi_impl="fast", **kwargs
+    )
+
+    assert np.array_equal(f0_legacy, f0_fast)
+    assert np.array_equal(voiced_legacy, voiced_fast)
+    assert np.array_equal(prob_legacy, prob_fast)
 
 
 def test_pyin_chirp_instant():
@@ -1381,6 +1438,12 @@ def test_pyin_warn():
     # win_length is deprecated
     with pytest.warns(FutureWarning, match="deprecated"):
         librosa.pyin(y, fmin=110, fmax=1000, win_length=1024)
+
+
+def test_pyin_viterbi_impl_fail():
+    y = librosa.tone(110, duration=1.0)
+    with pytest.raises(librosa.ParameterError):
+        librosa.pyin(y, fmin=110, fmax=1000, viterbi_impl="bogus")
 
 
 @pytest.mark.parametrize("freq", [110, 220, 440, 880])


### PR DESCRIPTION
## Summary

Follow-up to #2002.

This PR switches `librosa.pyin(..., viterbi_impl="fast")` from sparse predecessor construction by scanning a doubled dense transition matrix to direct Kronecker-structured predecessor construction from `(transition_local, switch_prob)`.

## Dependency

- Depends on #2002 (`pr/pyin-structured-viterbi`) being merged first.
- This branch intentionally stacks on top of that branch.

## What Changed

- Added `__pyin_transition_structure_kron(transition_local, switch_prob)` in `librosa/core/pitch.py`
- Fast path now builds sparse predecessors from Kronecker block structure directly
- Added low-level equivalence test vs dense-derived structure
- Updated benchmark harness for the updated internal signature

## Validation

- `python -m pytest -o addopts='' tests/test_core.py -k 'pyin_viterbi_impl or pyin_kron_transition_structure_matches_dense or test_pyin_chirp' -q` (8 passed)
- `python -m py_compile librosa/core/pitch.py tests/test_core.py scripts/benchmark_pyin_viterbi.py`
- `python scripts/benchmark_pyin_viterbi.py --duration 4 --repeat-audio 1 --warmup 1 --iters 2 --json`
  - decoder parity: true
  - pyin parity (f0/voiced/prob): true
