### PR TITLE
Document specshow frequency axis scaling

### DIFF
--- a/librosa/display.py
+++ b/librosa/display.py
@@ -1189,6 +1189,11 @@ def specshow(
         `oct3`-type use SI prefixes for frequencies, e.g., `1 kHz`, `2 MHz`, and are
         well adapted for scientific applications using high-frequency data.
 
+        .. note::
+            The 'log', 'fft_note', 'fft_svara', 'log_oct3', 'mel', and
+            'mel_oct3' axes use symmetric-log scaling to retain frequency
+            bins near 0 Hz.  CQT and VQT axes use logarithmic scaling.
+
         Any spectrogram parameters (hop_length, sr, bins_per_octave, etc.)
         used to generate the input data should also be provided when
         calling `specshow`.


### PR DESCRIPTION
#### Reference Issue

Refs #1984

#### What does this implement/fix? Explain your changes.

Adds a short note to `librosa.display.specshow` documenting that FFT-style and mel-style log frequency axes use symmetric-log scaling to retain bins near 0 Hz, while CQT and VQT axes use logarithmic scaling.

This documents the current behavior without adding new API surface.

#### Validation

- Checked the note against `__scale_axes`.
- Parsed the inserted RST note.
- Ran `python3 -m py_compile librosa/display.py` and `git diff --check`.

#### Any other comments?

No changelog or AUTHORS update included in this initial draft; the contributing guide asks for changelog updates after review.