### PR TITLE
Yet another Viterbi acceleration PR

### DIFF
--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -641,6 +641,7 @@ def pyin(
     fill_na: Optional[float] = np.nan,
     center: bool = True,
     pad_mode: _PadMode = "constant",
+    transition_min_prob: Optional[float] = 1e-4,
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Fundamental frequency (F0) estimation using probabilistic YIN (pYIN).
 
@@ -708,6 +709,12 @@ def pyin(
         ``y`` is padded on both sides with zeros.
         If ``center=False``,  this argument is ignored.
         .. see also:: `np.pad`
+    transition_min_prob : None or float > 0
+        If `None`, then Viterbi decoding considers all possible predecessor states
+        for each time step, providing an exact inference.
+        Otherwise, only transitions with probability at least `transition_min_prob`
+        are considered.  This provides an approximate inference, but can
+        significantly reduce computation time.
 
     Returns
     -------
@@ -822,7 +829,8 @@ def pyin(
 
     p_init = np.ones(2 * n_pitch_bins) / (2 * n_pitch_bins)
 
-    states = sequence.viterbi(observation_probs, transition, p_init=p_init)
+    states = sequence.viterbi(observation_probs, transition, p_init=p_init,
+                              transition_min_prob=transition_min_prob)
 
     # Find f0 corresponding to each decoded pitch bin.
     freqs = fmin * 2 ** (np.arange(n_pitch_bins) / (12 * n_bins_per_semitone))

--- a/librosa/sequence.py
+++ b/librosa/sequence.py
@@ -1230,13 +1230,14 @@ def _viterbi(
         #    then take the max over columns
         # We'll do this in log-space for stability
 
-        trans_out = value[t - 1] + log_trans.T
+#        trans_out = value[t - 1] + log_trans.T
 
         # Unroll the max/argmax loop to enable numba support
         for j in range(n_states):
-            ptr[t, j] = np.argmax(trans_out[j])
+            tmp_out = value[t - 1] + log_trans[:, j]
+            ptr[t, j] = np.argmax(tmp_out)
             # value[t, j] = log_prob[t, j] + np.max(trans_out[j])
-            value[t, j] = log_prob[t, j] + trans_out[j, ptr[t][j]]
+            value[t, j] = log_prob[t, j] + tmp_out[ptr[t][j]]
 
     # Now roll backward
 

--- a/librosa/sequence.py
+++ b/librosa/sequence.py
@@ -1227,7 +1227,11 @@ def _viterbi(
     if np.isfinite(log_trans_threshold):
         pred_states = []
         for j in range(n_states):
-            pred_states.append(np.flatnonzero(log_trans[:, j] >= log_trans_threshold))
+            possible_states = np.flatnonzero(log_trans[:, j] >= log_trans_threshold)
+            if len(possible_states) == 0:
+                raise ParameterError(f"Empty transition matrix detected for state {j} in Viterbi. "
+                                     f"Try reducing your minimum transition probability threshold.")
+            pred_states.append(possible_states)
 
         for t in range(1, n_steps):
             # Want V[t, j] <- p[t, j] * max_k V[t-1, k] * A[k, j]

--- a/librosa/sequence.py
+++ b/librosa/sequence.py
@@ -1257,10 +1257,10 @@ def _viterbi(
         for t in range(1, n_steps):
             for j in range(n_states):
                 best_cost = -np.inf
-                for k in range(n_states):
-                    cost = value[t - 1, k] + log_trans[k, j]
+                for kj in range(n_states):
+                    cost = value[t - 1, kj] + log_trans[kj, j]
                     if cost > best_cost:
-                        ptr[t, j] = k
+                        ptr[t, j] = kj
                         best_cost = cost
                 value[t, j] = log_prob[t, j] + best_cost
 
@@ -1332,7 +1332,7 @@ def viterbi(
         If not provided, a uniform distribution is assumed.
     return_logp : bool
         If ``True``, return the log-likelihood of the state sequence.
-    transition_min_prob : float
+    transition_min_prob : float, >=0
         Optional: if provided, the minimum transition probability to consider
         during decoding.
 
@@ -1416,10 +1416,14 @@ def viterbi(
     log_prob = np.log(prob + epsilon)
     log_p_init = np.log(p_init + epsilon)
 
-    if transition_min_prob is not None:
+    if transition_min_prob is not None and transition_min_prob > 0:
         log_trans_threshold = np.log(transition_min_prob + epsilon)
-    else:
+    elif transition_min_prob is None or transition_min_prob == 0:
         log_trans_threshold = -np.inf
+    else:
+        raise ParameterError(
+            f"Invalid transition_min_prob={transition_min_prob}, must be None or non-negative."
+        )
 
     def _helper(lp):
         # Transpose input
@@ -1532,7 +1536,7 @@ def viterbi_discriminative(
         If not provided, it is assumed to be uniform.
     return_logp : bool
         If ``True``, return the log-likelihood of the state sequence.
-    transition_min_prob : float
+    transition_min_prob : float, >= 0
         Optional: if provided, the minimum transition probability to consider
         during decoding.
 
@@ -1671,10 +1675,14 @@ def viterbi_discriminative(
     log_trans = np.log(transition + epsilon)
     log_marginal = np.log(p_state + epsilon)
 
-    if transition_min_prob is not None:
+    if transition_min_prob is not None and transition_min_prob > 0:
         log_trans_threshold = np.log(transition_min_prob + epsilon)
-    else:
+    elif transition_min_prob is None or transition_min_prob == 0:
         log_trans_threshold = -np.inf
+    else:
+        raise ParameterError(
+            f"Invalid transition_min_prob={transition_min_prob}, must be None or non-negative."
+        )
 
     # reshape to broadcast against prob
     log_marginal = expand_to(log_marginal, ndim=prob.ndim, axes=-2)
@@ -1806,7 +1814,7 @@ def viterbi_binary(
     return_logp : bool
         If ``True``, return the (unnormalized) log-likelihood of the state sequences.
 
-    transition_min_prob : float
+    transition_min_prob : float, >= 0
         Optional: if provided, the minimum transition probability to consider
         during decoding.
 

--- a/librosa/sequence.py
+++ b/librosa/sequence.py
@@ -1220,6 +1220,10 @@ def _viterbi(
     # factor in initial state distribution
     value[0] = log_prob[0] + log_p_init
 
+    pred_states = []
+    for j in range(n_states):
+        pred_states.append(np.flatnonzero(log_trans[:, j] >= -86))
+
     for t in range(1, n_steps):
         # Want V[t, j] <- p[t, j] * max_k V[t-1, k] * A[k, j]
         #    assume at time t-1 we were in state k
@@ -1234,10 +1238,16 @@ def _viterbi(
 
         # Unroll the max/argmax loop to enable numba support
         for j in range(n_states):
-            tmp_out = value[t - 1] + log_trans[:, j]
-            ptr[t, j] = np.argmax(tmp_out)
-            # value[t, j] = log_prob[t, j] + np.max(trans_out[j])
-            value[t, j] = log_prob[t, j] + tmp_out[ptr[t][j]]
+            #tmp_out = value[t - 1] + log_trans[:, j]
+            #ptr[t, j] = np.argmax(tmp_out)
+            #value[t, j] = log_prob[t, j] + tmp_out[ptr[t][j]]
+            best_cost = -np.inf
+            for k in pred_states[j]:
+                cost = value[t-1, k] + log_trans[k, j]
+                if cost > best_cost:
+                    ptr[t, j] = k
+                    best_cost = cost
+            value[t, j] = log_prob[t, j] + best_cost
 
     # Now roll backward
 

--- a/librosa/sequence.py
+++ b/librosa/sequence.py
@@ -1189,7 +1189,7 @@ def path_to_steps(path: np.ndarray, *, inverse: bool = False) -> np.ndarray:
 
 @jit(nopython=True, cache=True)  # type: ignore
 def _viterbi(
-    log_prob: np.ndarray, log_trans: np.ndarray, log_p_init: np.ndarray
+    log_prob: np.ndarray, log_trans: np.ndarray, log_p_init: np.ndarray, log_trans_threshold: float
 ) -> Tuple[np.ndarray, np.ndarray]:  # pragma: no cover
     """Core Viterbi algorithm.
 
@@ -1205,7 +1205,11 @@ def _viterbi(
         ``log_trans[i, j] = log P[State(t+1) = j | State(t) = i]``
     log_p_init : np.ndarray [shape=(m,)]
         log of the initial state distribution
-
+    log_trans_threshold : float
+        threshold above which transitions are considered feasible.
+        Use -np.inf to perform a full search (exact viterbi).
+        Otherwise, only transitions with (log) probability above the threshold
+        are considered in the loop.
     Returns
     -------
     None
@@ -1220,37 +1224,48 @@ def _viterbi(
     # factor in initial state distribution
     value[0] = log_prob[0] + log_p_init
 
-    pred_states = []
-    for j in range(n_states):
-        pred_states.append(np.flatnonzero(log_trans[:, j] >= -86))
-
-    for t in range(1, n_steps):
-        # Want V[t, j] <- p[t, j] * max_k V[t-1, k] * A[k, j]
-        #    assume at time t-1 we were in state k
-        #    transition k -> j
-
-        # Broadcast over rows:
-        #    Tout[k, j] = V[t-1, k] * A[k, j]
-        #    then take the max over columns
-        # We'll do this in log-space for stability
-
-#        trans_out = value[t - 1] + log_trans.T
-
-        # Unroll the max/argmax loop to enable numba support
+    if np.isfinite(log_trans_threshold):
+        pred_states = []
         for j in range(n_states):
-            #tmp_out = value[t - 1] + log_trans[:, j]
-            #ptr[t, j] = np.argmax(tmp_out)
-            #value[t, j] = log_prob[t, j] + tmp_out[ptr[t][j]]
-            best_cost = -np.inf
-            for k in pred_states[j]:
-                cost = value[t-1, k] + log_trans[k, j]
-                if cost > best_cost:
-                    ptr[t, j] = k
-                    best_cost = cost
-            value[t, j] = log_prob[t, j] + best_cost
+            pred_states.append(np.flatnonzero(log_trans[:, j] >= log_trans_threshold))
+
+        for t in range(1, n_steps):
+            # Want V[t, j] <- p[t, j] * max_k V[t-1, k] * A[k, j]
+            #    assume at time t-1 we were in state k
+            #    transition k -> j
+    
+            # Broadcast over rows:
+            #    Tout[k, j] = V[t-1, k] * A[k, j]
+            #    then take the max over columns
+            # We'll do this in log-space for stability
+    
+    #        trans_out = value[t - 1] + log_trans.T
+
+            # Unroll the max/argmax loop to enable numba support
+            for j in range(n_states):
+                #tmp_out = value[t - 1] + log_trans[:, j]
+                #ptr[t, j] = np.argmax(tmp_out)
+                #value[t, j] = log_prob[t, j] + tmp_out[ptr[t][j]]
+                best_cost = -np.inf
+                for k in pred_states[j]:
+                    cost = value[t-1, k] + log_trans[k, j]
+                    if cost > best_cost:
+                        ptr[t, j] = k
+                        best_cost = cost
+                value[t, j] = log_prob[t, j] + best_cost
+    else:
+        # Same as above, but doing a full search over previous states
+        for t in range(1, n_steps):
+            for j in range(n_states):
+                best_cost = -np.inf
+                for k in range(n_states):
+                    cost = value[t-1, k] + log_trans[k, j]
+                    if cost > best_cost:
+                        ptr[t, j] = k
+                        best_cost = cost
+                value[t, j] = log_prob[t, j] + best_cost
 
     # Now roll backward
-
     # Get the last state
     state[-1] = np.argmax(value[-1])
 
@@ -1269,6 +1284,7 @@ def viterbi(
     *,
     p_init: Optional[np.ndarray] = ...,
     return_logp: Literal[True],
+    transition_min_prob: Optional[float] = ...,
 ) -> Tuple[np.ndarray, np.ndarray]: ...
 
 
@@ -1279,6 +1295,7 @@ def viterbi(
     *,
     p_init: Optional[np.ndarray] = ...,
     return_logp: Literal[False] = ...,
+    transition_min_prob: Optional[float] = ...,
 ) -> np.ndarray: ...
 
 
@@ -1288,6 +1305,7 @@ def viterbi(
     *,
     p_init: Optional[np.ndarray] = None,
     return_logp: bool = False,
+    transition_min_prob: Optional[float] = None,
 ) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
     """Viterbi decoding from observation likelihoods.
 
@@ -1315,6 +1333,9 @@ def viterbi(
         If not provided, a uniform distribution is assumed.
     return_logp : bool
         If ``True``, return the log-likelihood of the state sequence.
+    transition_min_prob : float
+        Optional: if provided, the minimum transition probability to consider
+        during decoding.
 
     Returns
     -------
@@ -1396,9 +1417,14 @@ def viterbi(
     log_prob = np.log(prob + epsilon)
     log_p_init = np.log(p_init + epsilon)
 
+    if transition_min_prob is not None:
+        log_trans_threshold = np.log(transition_min_prob + epsilon)
+    else:
+        log_trans_threshold = -np.inf
+
     def _helper(lp):
         # Transpose input
-        _state, logp = _viterbi(lp.T, log_trans, log_p_init)
+        _state, logp = _viterbi(lp.T, log_trans, log_p_init, log_trans_threshold)
         # Transpose outputs for return
         return _state.T, logp
 
@@ -1432,6 +1458,7 @@ def viterbi_discriminative(
     p_state: Optional[np.ndarray] = ...,
     p_init: Optional[np.ndarray] = ...,
     return_logp: Literal[False] = ...,
+    transition_min_prob: Optional[float] = ...,
 ) -> np.ndarray: ...
 
 
@@ -1443,6 +1470,7 @@ def viterbi_discriminative(
     p_state: Optional[np.ndarray] = ...,
     p_init: Optional[np.ndarray] = ...,
     return_logp: Literal[True],
+    transition_min_prob: Optional[float] = ...,
 ) -> Tuple[np.ndarray, np.ndarray]: ...
 
 
@@ -1454,6 +1482,7 @@ def viterbi_discriminative(
     p_state: Optional[np.ndarray] = ...,
     p_init: Optional[np.ndarray] = ...,
     return_logp: bool,
+    transition_min_prob: Optional[float] = ...,
 ) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]: ...
 
 
@@ -1464,6 +1493,7 @@ def viterbi_discriminative(
     p_state: Optional[np.ndarray] = None,
     p_init: Optional[np.ndarray] = None,
     return_logp: bool = False,
+    transition_min_prob: Optional[float] = None,
 ) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
     """Viterbi decoding from discriminative state predictions.
 
@@ -1503,6 +1533,9 @@ def viterbi_discriminative(
         If not provided, it is assumed to be uniform.
     return_logp : bool
         If ``True``, return the log-likelihood of the state sequence.
+    transition_min_prob : float
+        Optional: if provided, the minimum transition probability to consider
+        during decoding.
 
     Returns
     -------
@@ -1639,6 +1672,11 @@ def viterbi_discriminative(
     log_trans = np.log(transition + epsilon)
     log_marginal = np.log(p_state + epsilon)
 
+    if transition_min_prob is not None:
+        log_trans_threshold = np.log(transition_min_prob + epsilon)
+    else:
+        log_trans_threshold = -np.inf
+
     # reshape to broadcast against prob
     log_marginal = expand_to(log_marginal, ndim=prob.ndim, axes=-2)
 
@@ -1646,7 +1684,7 @@ def viterbi_discriminative(
 
     def _helper(lp):
         # Transpose input
-        _state, logp = _viterbi(lp.T, log_trans, log_p_init)
+        _state, logp = _viterbi(lp.T, log_trans, log_p_init, log_trans_threshold)
         # Transpose outputs for return
         return _state.T, logp
 
@@ -1679,6 +1717,7 @@ def viterbi_binary(
     p_state: Optional[np.ndarray] = ...,
     p_init: Optional[np.ndarray] = ...,
     return_logp: Literal[False] = ...,
+    transition_min_prob: Optional[float] = ...,
 ) -> np.ndarray: ...
 
 
@@ -1690,6 +1729,7 @@ def viterbi_binary(
     p_state: Optional[np.ndarray] = ...,
     p_init: Optional[np.ndarray] = ...,
     return_logp: Literal[True],
+    transition_min_prob: Optional[float] = ...,
 ) -> Tuple[np.ndarray, np.ndarray]: ...
 
 
@@ -1701,6 +1741,7 @@ def viterbi_binary(
     p_state: Optional[np.ndarray] = ...,
     p_init: Optional[np.ndarray] = ...,
     return_logp: bool = ...,
+    transition_min_prob: Optional[float] = ...,
 ) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]: ...
 
 
@@ -1711,6 +1752,7 @@ def viterbi_binary(
     p_state: Optional[np.ndarray] = None,
     p_init: Optional[np.ndarray] = None,
     return_logp: bool = False,
+    transition_min_prob: Optional[float] = None,
 ) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
     """Viterbi decoding from binary (multi-label), discriminative state predictions.
 
@@ -1764,6 +1806,10 @@ def viterbi_binary(
 
     return_logp : bool
         If ``True``, return the (unnormalized) log-likelihood of the state sequences.
+
+    transition_min_prob : float
+        Optional: if provided, the minimum transition probability to consider
+        during decoding.
 
     Returns
     -------
@@ -1866,6 +1912,7 @@ def viterbi_binary(
             p_state=p_state_binary,
             p_init=p_init_binary,
             return_logp=True,
+            transition_min_prob=transition_min_prob
         )
 
     if return_logp:

--- a/librosa/sequence.py
+++ b/librosa/sequence.py
@@ -32,6 +32,7 @@ Transition matrices
     transition_cycle
     transition_local
 """
+
 from __future__ import annotations
 
 import numpy as np
@@ -1189,7 +1190,10 @@ def path_to_steps(path: np.ndarray, *, inverse: bool = False) -> np.ndarray:
 
 @jit(nopython=True, cache=True)  # type: ignore
 def _viterbi(
-    log_prob: np.ndarray, log_trans: np.ndarray, log_p_init: np.ndarray, log_trans_threshold: float
+    log_prob: np.ndarray,
+    log_trans: np.ndarray,
+    log_p_init: np.ndarray,
+    log_trans_threshold: float,
 ) -> Tuple[np.ndarray, np.ndarray]:  # pragma: no cover
     """Core Viterbi algorithm.
 
@@ -1210,6 +1214,7 @@ def _viterbi(
         Use -np.inf to perform a full search (exact viterbi).
         Otherwise, only transitions with (log) probability above the threshold
         are considered in the loop.
+
     Returns
     -------
     None
@@ -1229,30 +1234,20 @@ def _viterbi(
         for j in range(n_states):
             possible_states = np.flatnonzero(log_trans[:, j] >= log_trans_threshold)
             if len(possible_states) == 0:
-                raise ParameterError(f"Empty transition matrix detected for state {j} in Viterbi. "
-                                     f"Try reducing your minimum transition probability threshold.")
+                raise ParameterError(
+                    f"Empty transition matrix detected for state {j} in Viterbi. "
+                    f"Try reducing your minimum transition probability threshold."
+                )
             pred_states.append(possible_states)
 
         for t in range(1, n_steps):
             # Want V[t, j] <- p[t, j] * max_k V[t-1, k] * A[k, j]
             #    assume at time t-1 we were in state k
             #    transition k -> j
-    
-            # Broadcast over rows:
-            #    Tout[k, j] = V[t-1, k] * A[k, j]
-            #    then take the max over columns
-            # We'll do this in log-space for stability
-    
-    #        trans_out = value[t - 1] + log_trans.T
-
-            # Unroll the max/argmax loop to enable numba support
             for j in range(n_states):
-                #tmp_out = value[t - 1] + log_trans[:, j]
-                #ptr[t, j] = np.argmax(tmp_out)
-                #value[t, j] = log_prob[t, j] + tmp_out[ptr[t][j]]
                 best_cost = -np.inf
                 for k in pred_states[j]:
-                    cost = value[t-1, k] + log_trans[k, j]
+                    cost = value[t - 1, k] + log_trans[k, j]
                     if cost > best_cost:
                         ptr[t, j] = k
                         best_cost = cost
@@ -1263,7 +1258,7 @@ def _viterbi(
             for j in range(n_states):
                 best_cost = -np.inf
                 for k in range(n_states):
-                    cost = value[t-1, k] + log_trans[k, j]
+                    cost = value[t - 1, k] + log_trans[k, j]
                     if cost > best_cost:
                         ptr[t, j] = k
                         best_cost = cost
@@ -1916,7 +1911,7 @@ def viterbi_binary(
             p_state=p_state_binary,
             p_init=p_init_binary,
             return_logp=True,
-            transition_min_prob=transition_min_prob
+            transition_min_prob=transition_min_prob,
         )
 
     if return_logp:

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -118,6 +118,39 @@ def test_viterbi_sparse(transition_min_prob):
     assert np.isclose(logp, reg_logp)
 
 @pytest.mark.xfail(raises=librosa.ParameterError)
+def test_viterbi_negative_minprob():
+    p_init = np.asarray([0.6, 0.4])
+    transition = np.asarray([[0.7, 0.3], [0.4, 0.6]])
+    emit_p = [
+        dict(normal=0.5, cold=0.4, dizzy=0.1),
+        dict(normal=0.1, cold=0.3, dizzy=0.6),
+    ]
+    obs = ["normal", "cold", "dizzy"]
+    prob = np.asarray([np.asarray([ep[o] for o in obs]) for ep in emit_p])
+    librosa.sequence.viterbi(
+        prob, transition, p_init=p_init, return_logp=True,
+        transition_min_prob=-1
+    )
+
+
+@pytest.mark.xfail(raises=librosa.ParameterError)
+def test_viterbi_discriminative_negative_minprob():
+    transition = np.asarray([[0.75, 0.25], [0.25, 0.75]])
+    p_joint = np.asarray([[0.25, 0.25], [0.1, 0.4]])
+    p_obs_marginal = p_joint.sum(axis=0)
+    p_state_marginal = p_joint.sum(axis=1)
+    p_init = p_state_marginal
+    p_state_given_obs = (p_joint / p_obs_marginal).T
+    seq = np.asarray([1, 1, 0, 1, 1, 1, 0, 0])
+    prob_d = np.asarray([p_state_given_obs[i] for i in seq]).T
+
+    librosa.sequence.viterbi_discriminative(
+        prob_d, transition, p_state=p_state_marginal, p_init=p_init, return_logp=True,
+        transition_min_prob=-1
+    )
+
+
+@pytest.mark.xfail(raises=librosa.ParameterError)
 def test_viterbi_sparse_fail():
     p_init = np.asarray([0.6, 0.4])
     transition = np.asarray([[0.7, 0.3], [0.4, 0.6]])

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -93,6 +93,47 @@ def test_viterbi_multichannel():
     assert np.allclose(logp2, logp[2])
 
 
+@pytest.mark.parametrize("transition_min_prob", [None, 0, 1e-10, 0.25])
+def test_viterbi_sparse(transition_min_prob):
+    
+    p_init = np.asarray([0.6, 0.4])
+    transition = np.asarray([[0.7, 0.3], [0.4, 0.6]])
+    emit_p = [
+        dict(normal=0.5, cold=0.4, dizzy=0.1),
+        dict(normal=0.1, cold=0.3, dizzy=0.6),
+    ]
+    obs = ["normal", "cold", "dizzy"]
+    prob = np.asarray([np.asarray([ep[o] for o in obs]) for ep in emit_p])
+    path, logp = librosa.sequence.viterbi(
+        prob, transition, p_init=p_init, return_logp=True,
+        transition_min_prob=transition_min_prob
+    )
+
+    ref_path, reg_logp = librosa.sequence.viterbi(
+        prob, transition, p_init=p_init, return_logp=True,
+        transition_min_prob=None
+    )
+
+    assert np.array_equal(path, ref_path)
+    assert np.isclose(logp, reg_logp)
+
+@pytest.mark.xfail(raises=librosa.ParameterError)
+def test_viterbi_sparse_fail():
+    p_init = np.asarray([0.6, 0.4])
+    transition = np.asarray([[0.7, 0.3], [0.4, 0.6]])
+    emit_p = [
+        dict(normal=0.5, cold=0.4, dizzy=0.1),
+        dict(normal=0.1, cold=0.3, dizzy=0.6),
+    ]
+    obs = ["normal", "cold", "dizzy"]
+    prob = np.asarray([np.asarray([ep[o] for o in obs]) for ep in emit_p])
+    # This threshold is above all transition probabilities into state 1
+    # so the algorithm should raise an error about disconnected states
+    librosa.sequence.viterbi(
+        prob, transition, p_init=p_init, return_logp=True,
+        transition_min_prob=0.65
+    )
+
 def test_viterbi_init():
     # Example from https://en.wikipedia.org/wiki/Viterbi_algorithm#Example
 

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -208,7 +208,8 @@ def test_viterbi_bad_obs(trans, offset, rng):
 
 
 # Discriminative viterbi
-def test_viterbi_discriminative_example():
+@pytest.mark.parametrize("transition_min_prob", [None, 1e-3])
+def test_viterbi_discriminative_example(transition_min_prob):
     # A pre-baked example with coin tosses
 
     transition = np.asarray([[0.75, 0.25], [0.25, 0.75]])
@@ -232,7 +233,7 @@ def test_viterbi_discriminative_example():
     prob_d = np.asarray([p_state_given_obs[i] for i in seq]).T
 
     path, logp = librosa.sequence.viterbi_discriminative(
-        prob_d, transition, p_state=p_state_marginal, p_init=p_init, return_logp=True
+        prob_d, transition, p_state=p_state_marginal, p_init=p_init, return_logp=True, transition_min_prob=transition_min_prob
     )
 
     # Pre-computed optimal path, determined by brute-force search
@@ -240,7 +241,7 @@ def test_viterbi_discriminative_example():
 
     # And check the second code path
     path2 = librosa.sequence.viterbi_discriminative(
-        prob_d, transition, p_state=p_state_marginal, p_init=p_init, return_logp=False
+        prob_d, transition, p_state=p_state_marginal, p_init=p_init, return_logp=False, transition_min_prob=transition_min_prob
     )
     assert np.array_equal(path, path2)
 


### PR DESCRIPTION
#### Reference Issue
For whatever reason, we've had a flurry of PRs to speed up our Viterbi and pyin implementations recently: #1995, #1996, #1997, #2002, and #2003.  There's a bit of redundancy in these PRs, and some of the changes are split across multiple functions in a way that makes it a little difficult to evaluate.

#### What does this implement/fix? Explain your changes.

This PR does a couple of things inspired by #1996 and #1997, but relegates all optimizations to the core viterbi function and eliminates redundant implementations wherever possible.  This should translate to the maximum potential for accelerating viterbi-dependent processing with the minimal set of changes.

The main idea here is a combination of things identified in #1996 (avoid redundant array allocations) and #1997 (sparsification of the transition matrix).  The viterbi implementation allows a user to supply a minimum transition probability threshold, and pre-processes the transition matrix to identify incoming links to each state with transition probabilities above that threshold.  

During the forward pass, only those (likely sparse) set of links are considered in the argmax, which can drastically reduce time for sparse and well structured transition matrices (as in pyin).  If the threshold is not provided, a full search is still conducted, albeit in a faster implementation due to #1996.

Downstream functions like pyin are not changed, except to surface the new parameter in the API.  This leaves further room for improvement as implemented in #1997, but I think it's worthwhile to have an isolated improvement to viterbi that applies universally first.

#### Any other comments?

I by no means wish to to erase the contributions from newcomers @asymptotax and @ssmall256 .  This PR is meant to consolidate the minimal set of changes into one place for a more focused review.