### PR TITLE
Dynamic vectorize

### DIFF
--- a/librosa/beat.py
+++ b/librosa/beat.py
@@ -492,7 +492,8 @@ def __beat_tracker(
     frames_per_beat = np.round(frame_rate * 60.0 / bpm)
 
     # localscore is a smoothed version of AGC'd onset envelope
-    localscore = __beat_local_score(__normalize_onsets(onset_envelope), frames_per_beat)
+    localscore = np.empty_like(onset_envelope)
+    __beat_local_score(__normalize_onsets(onset_envelope), frames_per_beat, localscore)
 
     # run the DP
     backlink, cumscore = __beat_track_dp(localscore, frames_per_beat, tightness)
@@ -503,8 +504,9 @@ def __beat_tracker(
     __dp_backtrack(backlink, tail, beats)
 
     # Discard spurious trailing beats
-    beats = np.asarray(__trim_beats(localscore, beats, trim))
-    return beats
+    beats_trimmed = np.empty_like(beats)
+    __trim_beats(localscore, beats, trim, beats_trimmed)
+    return beats_trimmed
 
 
 # -- Helper functions for beat tracking
@@ -515,10 +517,6 @@ def __normalize_onsets(onsets):
 
 
 @numba.guvectorize(
-        [
-            "void(float32[:], float32[:], float32[:])",
-            "void(float64[:], float64[:], float64[:])",
-        ],
         "(t),(n)->(t)",
         nopython=True, cache=False)
 def __beat_local_score(onset_envelope, frames_per_beat, localscore):
@@ -609,10 +607,6 @@ def __beat_track_dp(localscore, frames_per_beat, tightness, backlink, cumscore):
 
 
 @numba.guvectorize(
-    [
-        "void(float32[:], bool_[:], bool_, bool_[:])",
-        "void(float64[:], bool_[:], bool_, bool_[:])"
-        ],
     "(t),(t),()->(t)",
     nopython=True, cache=True
     )
@@ -662,10 +656,6 @@ def __last_beat(cumscore):
 
 
 @numba.guvectorize(
-        [
-            "void(float32[:], bool_[:], float32, int64[:])",
-            "void(float64[:], bool_[:], float64, int64[:])",
-        ],
         "(t),(t),()->()",
         nopython=True, cache=True
         )
@@ -686,10 +676,6 @@ def __last_beat_selector(cumscore, mask, threshold, out):
 
 
 @numba.guvectorize(
-        [
-            "void(int32[:], int32, bool_[:])",
-            "void(int64[:], int64, bool_[:])"
-        ],
         "(t),()->(t)",
         nopython=True, cache=True
         )

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -1316,10 +1316,6 @@ def _zc_stencil(x: np.ndarray, threshold: float, zero_pos: bool) -> np.ndarray:
 
 
 @guvectorize(
-    [
-        "void(float32[:], float32, bool_, bool_[:])",
-        "void(float64[:], float64, bool_, bool_[:])",
-    ],
     "(n),(),()->(n)",
     cache=True,
     nopython=True,

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -424,7 +424,6 @@ def _pi_stencil(x: np.ndarray) -> np.ndarray:
 
 
 @numba.guvectorize(
-    ["void(float32[:], float32[:])", "void(float64[:], float64[:])"],
     "(n)->(n)",
     cache=True,
     nopython=True,

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -2531,7 +2531,7 @@ def is_unique(data: np.ndarray, *, axis: int = -1) -> np.ndarray:
 
 
 @numba.vectorize(
-    ["float32(complex64)", "float64(complex128)"], nopython=True, cache=True, identity=0
+    nopython=True, cache=True, identity=0
 )  # type: ignore
 def _cabs2(x: _ComplexLike_co) -> _FloatLike_co:  # pragma: no cover
     """Efficiently compute abs2 on complex inputs"""
@@ -2583,7 +2583,7 @@ def abs2(x: _NumberOrArray, dtype: Optional[DTypeLike] = None) -> _NumberOrArray
 
 
 @numba.vectorize(
-    ["complex64(float32)", "complex128(float64)"], nopython=True, cache=True, identity=1
+    nopython=True, cache=True, identity=1
 )  # type: ignore
 def _phasor_angles(x) -> np.complexfloating[Any, Any]:
     return np.cos(x) + 1j * np.sin(x)  # type: ignore
@@ -2660,7 +2660,11 @@ def phasor(
     >>> librosa.util.phasor(np.array([0, np.pi/2]), mag=np.array([0.5, 1.5]))
     array([5.000e-01+0.j , 9.185e-17+1.5j])
     """
-    z = _phasor_angles(angles)
+    if np.isscalar(angles):
+        angles = np.asarray(angles)
+
+    z = np.empty_like(angles, dtype=dtype_r2c(angles.dtype))
+    _phasor_angles(angles, z)
 
     if mag is not None:
         z *= mag

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -1032,13 +1032,6 @@ def _localmin_sten(x):  # pragma: no cover
 
 
 @numba.guvectorize(
-    [
-        "void(int16[:], bool_[:])",
-        "void(int32[:], bool_[:])",
-        "void(int64[:], bool_[:])",
-        "void(float32[:], bool_[:])",
-        "void(float64[:], bool_[:])",
-    ],
     "(n)->(n)",
     cache=True,
     nopython=True,
@@ -1049,13 +1042,6 @@ def _localmax(x, y):  # pragma: no cover
 
 
 @numba.guvectorize(
-    [
-        "void(int16[:], bool_[:])",
-        "void(int32[:], bool_[:])",
-        "void(int64[:], bool_[:])",
-        "void(float32[:], bool_[:])",
-        "void(float64[:], bool_[:])",
-    ],
     "(n)->(n)",
     cache=True,
     nopython=True,
@@ -1189,12 +1175,6 @@ def localmin(x: np.ndarray, *, axis: int = 0) -> np.ndarray:
 
 
 @numba.guvectorize(
-    [
-        "void(float32[:], uint32, uint32, uint32, uint32, float32, uint32, bool_[:])",
-        "void(float64[:], uint32, uint32, uint32, uint32, float32, uint32, bool_[:])",
-        "void(int32[:], uint32, uint32, uint32, uint32, float32, uint32, bool_[:])",
-        "void(int64[:], uint32, uint32, uint32, uint32, float32, uint32, bool_[:])",
-    ],
     "(n),(),(),(),(),(),()->(n)",
     nopython=True,
     cache=True,
@@ -1232,12 +1212,6 @@ def __peak_pick_greedy(x, pre_max, post_max, pre_avg, post_avg, delta, wait, pea
 
 
 @numba.guvectorize(
-    [
-        "void(float32[:], uint32, uint32, uint32, uint32, float32, uint32, bool_, bool_[:])",
-        "void(float64[:], uint32, uint32, uint32, uint32, float32, uint32, bool_, bool_[:])",
-        "void(int32[:], uint32, uint32, uint32, uint32, float32, uint32, bool_, bool_[:])",
-        "void(int64[:], uint32, uint32, uint32, uint32, float32, uint32, bool_, bool_[:])",
-    ],
     "(n),(),(),(),(),(),(),()->(n)",
     nopython=True,
     cache=True,

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -2539,6 +2539,12 @@ def _cabs2(x: _ComplexLike_co) -> _FloatLike_co:  # pragma: no cover
 
 _Number = Union[complex, "np.number[Any]"]
 
+@overload
+def abs2(x: np.ndarray, dtype: Optional[DTypeLike] = ...) -> np.ndarray: ...
+
+@overload
+def abs2(x: _Complex, dtype: Optional[DTypeLike] = ...) -> np.floating[Any]: ...
+
 def abs2(x: Union[np.ndarray, _Real, _Complex],
          dtype: Optional[DTypeLike] = None
 ) -> Union[np.ndarray, np.floating[Any]]:

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -2572,11 +2572,11 @@ def abs2(x: _NumberOrArray, dtype: Optional[DTypeLike] = None) -> _NumberOrArray
     """
     if np.iscomplexobj(x):
         # suppress type check, mypy doesn't like vectorization
-        y = _cabs2(x)
         if dtype is None:
-            return y  # type: ignore
-        else:
-            return y.astype(dtype)  # type: ignore
+            dtype = dtype_c2r(np.asarray(x).dtype)
+        y = np.empty_like(x, dtype=dtype)
+        _cabs2(x, y)
+        return y
     else:
         # suppress type check, mypy doesn't know this is real
         return np.square(x, dtype=dtype)  # type: ignore
@@ -2660,10 +2660,7 @@ def phasor(
     >>> librosa.util.phasor(np.array([0, np.pi/2]), mag=np.array([0.5, 1.5]))
     array([5.000e-01+0.j , 9.185e-17+1.5j])
     """
-    if np.isscalar(angles):
-        angles = np.asarray(angles)
-
-    z = np.empty_like(angles, dtype=dtype_r2c(angles.dtype))  # type: ignore
+    z = np.empty_like(angles, dtype=dtype_r2c(np.asarray(angles).dtype))  # type: ignore
     _phasor_angles(angles, z)
 
     if mag is not None:

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -14,7 +14,6 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
-    TypeVar,
     Union,
     overload,
 )
@@ -2539,10 +2538,10 @@ def _cabs2(x: _ComplexLike_co) -> _FloatLike_co:  # pragma: no cover
 
 
 _Number = Union[complex, "np.number[Any]"]
-_NumberOrArray = TypeVar("_NumberOrArray", bound=Union[_Number, np.ndarray])
 
-
-def abs2(x: _NumberOrArray, dtype: Optional[DTypeLike] = None) -> _NumberOrArray:
+def abs2(x: Union[np.ndarray, _Real, _Complex],
+         dtype: Optional[DTypeLike] = None
+) -> Union[np.ndarray, np.floating[Any]]:
     """Compute the squared magnitude of a real or complex array.
 
     This function is equivalent to calling `np.abs(x)**2` but it
@@ -2574,12 +2573,12 @@ def abs2(x: _NumberOrArray, dtype: Optional[DTypeLike] = None) -> _NumberOrArray
         # suppress type check, mypy doesn't like vectorization
         if dtype is None:
             dtype = dtype_c2r(np.asarray(x).dtype)
-        y = np.empty_like(x, dtype=dtype)
+        y: np.ndarray = np.empty_like(x, dtype=dtype)
         _cabs2(x, y)
         return y
     else:
         # suppress type check, mypy doesn't know this is real
-        return np.square(x, dtype=dtype)  # type: ignore
+        return np.square(x, dtype=dtype)
 
 
 @numba.vectorize(
@@ -2590,6 +2589,7 @@ def _phasor_angles(x) -> np.complexfloating[Any, Any]:
 
 
 _Real = Union[float, "np.integer[Any]", "np.floating[Any]"]
+_Complex = Union[_Real, "np.complexfloating[Any, Any]"]
 
 
 @overload
@@ -2660,7 +2660,7 @@ def phasor(
     >>> librosa.util.phasor(np.array([0, np.pi/2]), mag=np.array([0.5, 1.5]))
     array([5.000e-01+0.j , 9.185e-17+1.5j])
     """
-    z = np.empty_like(angles, dtype=dtype_r2c(np.asarray(angles).dtype))  # type: ignore
+    z = np.empty_like(angles, dtype=dtype_r2c(np.asarray(angles).dtype))
     _phasor_angles(angles, z)
 
     if mag is not None:

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -2663,13 +2663,13 @@ def phasor(
     if np.isscalar(angles):
         angles = np.asarray(angles)
 
-    z = np.empty_like(angles, dtype=dtype_r2c(angles.dtype))
+    z = np.empty_like(angles, dtype=dtype_r2c(angles.dtype))  # type: ignore
     _phasor_angles(angles, z)
 
     if mag is not None:
         z *= mag
 
-    return z  # type: ignore
+    return z
 
 
 @overload


### PR DESCRIPTION
#### Reference Issue
Fixes #2001 


#### What does this implement/fix? Explain your changes.

Since we bumped numba to >=0.61 (#2018 ), we can now make use of dynamic guvectorize.  This eliminates the need to specify signatures on generic ufuncs up front, which had the side effect of triggering heavy compilations at import time.