### PR TITLE
Even faster import

### DIFF
--- a/.github/environment-ci.yml
+++ b/.github/environment-ci.yml
@@ -17,7 +17,6 @@ dependencies:
   - soxr-python>=1.0.0
   - msgpack-python>=1.0.5
   - lazy_loader>=0.3
-  - typing_extensions>=4.7.1
 
   # optional, but required for testing
   - matplotlib>=3.10.0

--- a/.github/environment-docs.yml
+++ b/.github/environment-docs.yml
@@ -27,7 +27,7 @@ dependencies:
   - sphinx_rtd_theme>=1.2.0
   - sphinx-copybutton>=0.5.2
   - lazy_loader>=0.3
-  - typing_extensions>=4.7.1
+  - typing_extensions>=4.7.1  # keeping for historical builds
   - ffmpeg
   - standard-sunau
   - standard-aifc

--- a/.github/environment-minimal.yml
+++ b/.github/environment-minimal.yml
@@ -17,7 +17,6 @@ dependencies:
   - soxr-python==1.0.0
   - msgpack-python==1.0.5
   - lazy_loader==0.3
-  - typing_extensions==4.7.1
 
   # optional, but required for testing
   - matplotlib~=3.10.0

--- a/librosa/_typing.py
+++ b/librosa/_typing.py
@@ -128,3 +128,8 @@ _InterpKind = Literal[
 # DCT normalization modes
 _DCTNorm = Literal["backward", "ortho", "forward"]
 _DCTType = Literal[1, 2, 3, 4]
+
+# More specialized number types
+_Real = Union[float, "np.integer[Any]", "np.floating[Any]"]
+_Complex = Union[_Real, "np.complexfloating[Any, Any]"]
+_Number = Union[complex, "np.number[Any]"]

--- a/librosa/_typing.py
+++ b/librosa/_typing.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Any, Callable, Generator, List, Tuple, TypeVar, Union
+from typing import Any, Callable, Generator, List, Literal, Never, Tuple, TypeVar, Union
 
 import numpy as np
 import scipy.sparse as sp
 from numpy.typing import ArrayLike
-from typing_extensions import Literal, Never
 
 # RNG types
 SeedLike = Union[int, np.integer, Sequence[int], np.random.SeedSequence]

--- a/librosa/beat.py
+++ b/librosa/beat.py
@@ -9,20 +9,24 @@ Beat and tempo
    beat_track
    plp
 """
+from __future__ import annotations
 
-from typing import Optional, Tuple, Union
+from typing import TYPE_CHECKING, Optional, Tuple, Union
 
 import numba
 import numpy as np
 import scipy
-import scipy.stats
 
 from . import core, onset, util
-from ._typing import _FloatLike_co
 from .feature import fourier_tempogram
 from .feature import tempo as _tempo
 from .util.decorators import moved
 from .util.exceptions import ParameterError
+
+if TYPE_CHECKING:
+    import scipy.stats
+
+    from ._typing import _FloatLike_co
 
 __all__ = ["beat_track", "tempo", "plp"]
 

--- a/librosa/beat.py
+++ b/librosa/beat.py
@@ -11,7 +11,7 @@ Beat and tempo
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Tuple, Union
+from typing import TYPE_CHECKING
 
 import numba
 import numpy as np
@@ -24,6 +24,8 @@ from .util.decorators import moved
 from .util.exceptions import ParameterError
 
 if TYPE_CHECKING:
+    from typing import Optional, Tuple, Union
+
     import scipy.stats
 
     from ._typing import _FloatLike_co

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 import lazy_loader as lazy
 import numpy as np
 import scipy
-import scipy.signal
 import soundfile as sf
 import soxr
 from numba import guvectorize, jit, stencil
@@ -844,12 +843,16 @@ def resample(
     n_samples = int(np.ceil(y.shape[axis] * ratio))
 
     if res_type in ("scipy", "fft"):
+        import scipy.signal
+
         y_hat = scipy.signal.resample(y, n_samples, axis=axis)
     elif res_type == "polyphase":
         if int(orig_sr) != orig_sr or int(target_sr) != target_sr:
             raise ParameterError(
                 "polyphase resampling is only supported for integer-valued sampling rates."
             )
+
+        import scipy.signal
 
         # For polyphase resampling, we need up- and down-sampling ratios
         # We can get those from the greatest common divisor of the rates
@@ -1760,6 +1763,7 @@ def chirp(
         phi = -np.pi * 0.5
 
     method = "linear" if linear else "logarithmic"
+    import scipy.signal
     y: np.ndarray = scipy.signal.chirp(  # type: ignore[misc,call-overload]
         np.arange(int(duration * sr)) / sr,
         fmin,

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -3,8 +3,7 @@
 """Core IO, DSP and utility functions."""
 from __future__ import annotations
 
-import os
-from typing import Any, BinaryIO, Callable, Generator, Optional, Tuple, Union
+from typing import TYPE_CHECKING
 
 import lazy_loader as lazy
 import numpy as np
@@ -13,13 +12,20 @@ import scipy.signal
 import soundfile as sf
 import soxr
 from numba import guvectorize, jit, stencil
-from numpy.typing import DTypeLike
 
 from .. import util
 from .._cache import cache
-from .._typing import _FloatLike_co, _IntLike_co, _ScalarOrSequence, _SequenceLike
 from ..util.exceptions import ParameterError
 from .convert import frames_to_samples, time_to_samples
+
+if TYPE_CHECKING:
+    import os
+    from typing import Any, BinaryIO, Callable, Generator, Optional, Tuple, Union
+
+    from numpy.typing import DTypeLike
+
+    from .._typing import _FloatLike_co, _IntLike_co, _ScalarOrSequence, _SequenceLike
+
 
 # Lazy-load optional dependencies
 samplerate = lazy.load("samplerate")

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Collection, List, Optional, Union
+from typing import TYPE_CHECKING
 
 import numpy as np
 import scipy
@@ -21,6 +21,8 @@ from .pitch import estimate_tuning
 from .spectrum import istft, stft
 
 if TYPE_CHECKING:
+    from typing import Collection, List, Optional, Union
+
     from numpy.typing import DTypeLike
 
     from .._typing import (

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -1,23 +1,17 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Constant-Q transforms"""
+from __future__ import annotations
+
 import warnings
-from typing import Collection, List, Optional, Union
+from typing import TYPE_CHECKING, Collection, List, Optional, Union
 
 import numpy as np
 import scipy
 from numba import jit
-from numpy.typing import DTypeLike
 
 from .. import filters, util
 from .._cache import cache
-from .._typing import (
-    RNGLike,
-    SeedLike,
-    _FloatLike_co,
-    _PadMode,
-    _WindowSpec,
-)
 from ..util.deprecation import Deprecated, rename_kw
 from ..util.exceptions import ParameterError
 from . import audio
@@ -25,6 +19,17 @@ from .convert import cqt_frequencies, note_to_hz
 from .intervals import interval_frequencies
 from .pitch import estimate_tuning
 from .spectrum import istft, stft
+
+if TYPE_CHECKING:
+    from numpy.typing import DTypeLike
+
+    from .._typing import (
+        RNGLike,
+        SeedLike,
+        _FloatLike_co,
+        _PadMode,
+        _WindowSpec,
+    )
 
 __all__ = ["cqt", "hybrid_cqt", "pseudo_cqt", "icqt", "griffinlim_cqt", "vqt"]
 

--- a/librosa/core/convert.py
+++ b/librosa/core/convert.py
@@ -4,20 +4,25 @@
 from __future__ import annotations
 
 import warnings
-from typing import Any, Callable, Dict, Iterable, Optional, Sized, Union, overload
+from typing import TYPE_CHECKING, overload
 
 import numpy as np
 
-from .._typing import (
-    _FloatLike_co,
-    _IntLike_co,
-    _IterableLike,
-    _ScalarOrSequence,
-    _SequenceLike,
-)
 from ..util.decorators import vectorize
 from ..util.exceptions import ParameterError
 from . import notation
+
+if TYPE_CHECKING:
+    from typing import Any, Callable, Dict, Iterable, Optional, Sized, Union
+
+    from .._typing import (
+        _FloatLike_co,
+        _IntLike_co,
+        _IterableLike,
+        _ScalarOrSequence,
+        _SequenceLike,
+    )
+
 
 __all__ = [
     "frames_to_samples",

--- a/librosa/core/harmonic.py
+++ b/librosa/core/harmonic.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Callable, Optional, Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -13,6 +13,8 @@ from ..util import is_unique
 from ..util.exceptions import ParameterError
 
 if TYPE_CHECKING:
+    from typing import Callable, Optional, Sequence
+
     from numpy.typing import ArrayLike
 
     from .._typing import _InterpKind

--- a/librosa/core/harmonic.py
+++ b/librosa/core/harmonic.py
@@ -2,17 +2,20 @@
 # -*- coding: utf-8 -*-
 """Harmonic calculations for frequency representations"""
 
+from __future__ import annotations
+
 import warnings
-from typing import Callable, Optional, Sequence
+from typing import TYPE_CHECKING, Callable, Optional, Sequence
 
 import numpy as np
-import scipy.interpolate
-import scipy.signal
-from numpy.typing import ArrayLike
 
-from .._typing import _InterpKind
 from ..util import is_unique
 from ..util.exceptions import ParameterError
+
+if TYPE_CHECKING:
+    from numpy.typing import ArrayLike
+
+    from .._typing import _InterpKind
 
 __all__ = ["salience", "interp_harmonics", "f0_harmonics"]
 
@@ -126,6 +129,8 @@ def salience(
         S_sal = aggregate(S_harm, axis=axis - 1)
 
     if filter_peaks:
+        import scipy.signal
+
         S_peaks = scipy.signal.argrelmax(S, axis=axis)
         S_out = np.empty(S.shape)
         S_out.fill(fill_value)
@@ -233,6 +238,8 @@ def interp_harmonics(
     >>> librosa.display.colorbar_db(img, ax=ax)
     >>> plt.show()
     """
+    import scipy.interpolate
+
     if freqs.ndim == 1 and len(freqs) == x.shape[axis]:
         # Build the 1-D interpolator.
         # All frames have a common domain, so we only need one interpolator here.
@@ -388,6 +395,8 @@ def f0_harmonics(
     >>> ax[1].set(ylabel='Harmonics')
     """
     result: np.ndarray
+    import scipy.interpolate
+
     if freqs.ndim == 1 and len(freqs) == x.shape[axis]:
         if not is_unique(freqs, axis=0):
             warnings.warn(

--- a/librosa/core/intervals.py
+++ b/librosa/core/intervals.py
@@ -3,16 +3,17 @@
 """Functions for interval construction"""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Collection, Dict, Iterable, List, Union, overload
+from typing import TYPE_CHECKING, overload
 
 import msgpack
 import numpy as np
-from typing_extensions import Literal
 
 from .._cache import cache
 from ..util.files import _resource_file
 
 if TYPE_CHECKING:
+    from typing import Collection, Dict, Iterable, List, Literal, Union
+
     from numpy.typing import ArrayLike
 
     from .._typing import _FloatLike_co

--- a/librosa/core/intervals.py
+++ b/librosa/core/intervals.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
 """Functions for interval construction"""
+from __future__ import annotations
 
-from typing import Collection, Dict, Iterable, List, Union, overload
+from typing import TYPE_CHECKING, Collection, Dict, Iterable, List, Union, overload
 
 import msgpack
 import numpy as np
-from numpy.typing import ArrayLike
 from typing_extensions import Literal
 
 from .._cache import cache
-from .._typing import _FloatLike_co
 from ..util.files import _resource_file
+
+if TYPE_CHECKING:
+    from numpy.typing import ArrayLike
+
+    from .._typing import _FloatLike_co
+
 
 with _resource_file("librosa.core", "intervals.msgpack") as imsgpack, imsgpack.open("rb") as _fdesc:
     # We use floats for dictionary keys, so strict mapping is disabled

--- a/librosa/core/notation.py
+++ b/librosa/core/notation.py
@@ -1,19 +1,22 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Music notation utilities"""
+from __future__ import annotations
 
 import re
 from collections import Counter
-from typing import Dict, Iterable, List, Union, overload
+from typing import TYPE_CHECKING, Dict, Iterable, List, Union, overload
 
 import numpy as np
 from numba import jit
 
 from .._cache import cache
-from .._typing import _FloatLike_co, _IterableLike, _ScalarOrSequence, _SequenceLike
 from ..util.decorators import vectorize
 from ..util.exceptions import ParameterError
 from .intervals import INTERVALS
+
+if TYPE_CHECKING:
+    from .._typing import _FloatLike_co, _IterableLike, _ScalarOrSequence, _SequenceLike
 
 __all__ = [
     "key_to_degrees",

--- a/librosa/core/notation.py
+++ b/librosa/core/notation.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import re
 from collections import Counter
-from typing import TYPE_CHECKING, Dict, Iterable, List, Union, overload
+from typing import TYPE_CHECKING, overload
 
 import numpy as np
 from numba import jit
@@ -16,6 +16,8 @@ from ..util.exceptions import ParameterError
 from .intervals import INTERVALS
 
 if TYPE_CHECKING:
+    from typing import Dict, Iterable, List, Union
+
     from .._typing import _FloatLike_co, _IterableLike, _ScalarOrSequence, _SequenceLike
 
 __all__ = [

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -1,21 +1,24 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Pitch-tracking and tuning estimation"""
+from __future__ import annotations
 
 import warnings
-from typing import Any, Callable, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple, Union
 
 import numba
 import numpy as np
-import scipy
-from numpy.typing import ArrayLike
 
 from .. import sequence, util
 from .._cache import cache
-from .._typing import _PadMode, _PadModeSTFT, _WindowSpec
 from ..util.exceptions import ParameterError
 from . import audio, convert
 from .spectrum import _spectrogram
+
+if TYPE_CHECKING:
+    from numpy.typing import ArrayLike
+
+    from .._typing import _PadMode, _PadModeSTFT, _WindowSpec
 
 __all__ = ["estimate_tuning", "pitch_tuning", "piptrack", "yin", "pyin"]
 
@@ -786,6 +789,8 @@ def pyin(
     # The implementation here follows the official pYIN software which
     # differs from the method described in the paper.
     # 1. Define the prior over the thresholds.
+    import scipy.stats
+
     thresholds = np.linspace(0, 1, n_thresholds + 1)
     beta_cdf = scipy.stats.beta.cdf(thresholds, beta_parameters[0], beta_parameters[1])
     beta_probs = np.diff(beta_cdf)
@@ -873,6 +878,8 @@ def __pyin_helper(
         # Smaller periods are weighted more.
         trough_positions = np.cumsum(trough_thresholds, axis=0) - 1
         n_troughs = np.count_nonzero(trough_thresholds, axis=0)
+
+        import scipy.stats
 
         trough_prior = scipy.stats.boltzmann.pmf(
             trough_positions, boltzmann_parameter, n_troughs

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple, Union
+from typing import TYPE_CHECKING
 
 import numba
 import numpy as np
@@ -16,6 +16,8 @@ from . import audio, convert
 from .spectrum import _spectrogram
 
 if TYPE_CHECKING:
+    from typing import Any, Callable, Optional, Tuple, Union
+
     from numpy.typing import ArrayLike
 
     from .._typing import _PadMode, _PadModeSTFT, _WindowSpec

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -8,9 +8,6 @@ from typing import TYPE_CHECKING, overload
 
 import numpy as np
 import scipy
-import scipy.interpolate
-import scipy.ndimage
-import scipy.signal
 from numba import jit
 from typing_extensions import Literal
 
@@ -1506,6 +1503,8 @@ def phase_vocoder(
     np.cumsum(phase, axis=-1, out=phase)
 
     # Interpolate magnitudes
+    import scipy.interpolate
+
     mag_interp = scipy.interpolate.interp1d(
         np.arange(n_frames),
         np.abs(D),
@@ -1667,6 +1666,7 @@ def iirt(
     bands_power = np.empty_like(y, shape=shape)
 
     slices: List[Union[int, slice]] = [slice(None) for _ in bands_power.shape]
+    import scipy.signal
     for i, (cur_sr, cur_filter) in enumerate(zip(sample_rates,
                                                  filterbank_ct,
                                                  strict=True)):
@@ -2309,6 +2309,8 @@ def fmt(
     x = np.linspace(0, 1, num=n, endpoint=False)
 
     # build the interpolator
+    import scipy.interpolate
+
     f_interp = scipy.interpolate.interp1d(x, y, kind=kind, axis=axis)
 
     # build the new sampling grid
@@ -2653,7 +2655,10 @@ def pcen(
                 # if axis = +- 1, max_axis = 0
                 max_axis = np.mod(1 - axis, 2)
 
+            import scipy.ndimage
             ref = scipy.ndimage.maximum_filter1d(S, max_size, axis=max_axis)
+
+    import scipy.signal
 
     if zi is None:
         # Make sure zi matches dimension to input

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import Any, Callable, List, Optional, Tuple, Union, overload
+from typing import TYPE_CHECKING, overload
 
 import numpy as np
 import scipy
@@ -12,28 +12,33 @@ import scipy.interpolate
 import scipy.ndimage
 import scipy.signal
 from numba import jit
-from numpy.typing import DTypeLike
 from typing_extensions import Literal
 
 from .. import util
 from .._cache import cache
-from .._typing import (
-    RNGLike,
-    SeedLike,
-    _ComplexLike_co,
-    _FloatLike_co,
-    _InterpKind,
-    _PadMode,
-    _PadModeSTFT,
-    _ScalarOrSequence,
-    _SequenceLike,
-    _WindowSpec,
-)
 from ..filters import get_window, semitone_filterbank, window_sumsquare
 from ..util.deprecation import Deprecated, rename_kw
 from ..util.exceptions import ParameterError
 from . import convert
 from .audio import resample
+
+if TYPE_CHECKING:
+    from typing import Any, Callable, List, Optional, Tuple, Union
+
+    from numpy.typing import DTypeLike
+
+    from .._typing import (
+        RNGLike,
+        SeedLike,
+        _ComplexLike_co,
+        _FloatLike_co,
+        _InterpKind,
+        _PadMode,
+        _PadModeSTFT,
+        _ScalarOrSequence,
+        _SequenceLike,
+        _WindowSpec,
+    )
 
 __all__ = [
     "stft",

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, overload
 import numpy as np
 import scipy
 from numba import jit
-from typing_extensions import Literal
 
 from .. import util
 from .._cache import cache
@@ -20,7 +19,7 @@ from . import convert
 from .audio import resample
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, List, Optional, Tuple, Union
+    from typing import Any, Callable, List, Literal, Optional, Tuple, Union
 
     from numpy.typing import DTypeLike
 

--- a/librosa/decompose.py
+++ b/librosa/decompose.py
@@ -15,8 +15,6 @@ from typing import Any, Callable, List, Optional, Tuple, Union
 
 import numpy as np
 import scipy.sparse
-import sklearn.decomposition
-from scipy.ndimage import median_filter
 
 from . import core, segment, util
 from ._cache import cache
@@ -179,6 +177,8 @@ def decompose(
     if transformer is None:
         if fit is False:
             raise ParameterError("fit must be True if transformer is None")
+
+        import sklearn.decomposition
 
         transformer = sklearn.decomposition.NMF(n_components=n_components, **kwargs)
 
@@ -379,7 +379,10 @@ def hpss(
     perc_shape[-2] = int(win_perc)
 
     # Compute median filters. Pre-allocation here preserves memory layout.
+    from scipy.ndimage import median_filter
+
     harm = np.empty_like(S)
+
     harm[:] = median_filter(S, size=harm_shape, mode="reflect")
 
     perc = np.empty_like(S)

--- a/librosa/decompose.py
+++ b/librosa/decompose.py
@@ -10,16 +10,19 @@ Spectrogram decomposition
     hpss
     nn_filter
 """
+from __future__ import annotations
 
-from typing import Any, Callable, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple, Union
 
 import numpy as np
 import scipy.sparse
 
 from . import core, segment, util
 from ._cache import cache
-from ._typing import _FloatLike_co, _IntLike_co, _SparseArray
 from .util.exceptions import ParameterError
+
+if TYPE_CHECKING:
+    from ._typing import _FloatLike_co, _IntLike_co, _SparseArray
 
 __all__ = ["decompose", "hpss", "nn_filter"]
 

--- a/librosa/decompose.py
+++ b/librosa/decompose.py
@@ -12,7 +12,7 @@ Spectrogram decomposition
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING
 
 import numpy as np
 import scipy.sparse
@@ -22,6 +22,8 @@ from ._cache import cache
 from .util.exceptions import ParameterError
 
 if TYPE_CHECKING:
+    from typing import Any, Callable, List, Optional, Tuple, Union
+
     from ._typing import _FloatLike_co, _IntLike_co, _SparseArray
 
 __all__ = ["decompose", "hpss", "nn_filter"]

--- a/librosa/display.py
+++ b/librosa/display.py
@@ -53,20 +53,7 @@ import warnings
 import weakref
 from fractions import Fraction
 from itertools import cycle, product
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Collection,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    Sequence,
-    Tuple,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, cast
 
 import matplotlib.axes as mplaxes
 import matplotlib.collections as mcollections
@@ -77,7 +64,6 @@ import matplotlib.pyplot as plt
 import matplotlib.ticker as mplticker
 import matplotlib.transforms as mtransforms
 import numpy as np
-import scipy.interpolate
 from matplotlib import colormaps as mcm
 from matplotlib.transforms import Bbox
 
@@ -86,6 +72,8 @@ from .util.decorators import moved
 from .util.exceptions import ParameterError
 
 if TYPE_CHECKING:
+    from typing import Any, Callable, Collection, Dict, List, Literal, Optional, Sequence, Tuple, Union
+
     import cycler
     import matplotlib
     import matplotlib.figure
@@ -983,6 +971,8 @@ class Transformf0(mtransforms.Transform):
             raise ParameterError("f0 must be strictly positive (or NaN) and contain at least one finite value")
 
         times = offset + core.times_like(f0, sr=sr, hop_length=hop_length)
+        import scipy.interpolate
+
         self.f0_interp = scipy.interpolate.interp1d(
             times,
             f0,

--- a/librosa/display.py
+++ b/librosa/display.py
@@ -82,7 +82,6 @@ from matplotlib import colormaps as mcm
 from matplotlib.transforms import Bbox
 
 from . import core, util
-from ._typing import ArrayLike, _FloatLike_co
 from .util.decorators import moved
 from .util.exceptions import ParameterError
 
@@ -95,6 +94,8 @@ if TYPE_CHECKING:
     from matplotlib.lines import Line2D
     from matplotlib.markers import MarkerStyle
     from matplotlib.path import Path as MplPath
+
+    from ._typing import ArrayLike, _FloatLike_co
 
 
 __all__ = [
@@ -1837,7 +1838,7 @@ def __decorate_axis(
         axis.set_major_locator(
             mplticker.FixedLocator(
                 cast(
-                    Sequence[float],
+                    "Sequence[float]",
                     np.add.outer(12 * np.arange(10), degrees, dtype=float).ravel(),
                 )
             )
@@ -1858,7 +1859,7 @@ def __decorate_axis(
         axis.set_major_locator(
             mplticker.FixedLocator(
                 cast(
-                    Sequence[float],
+                    "Sequence[float]",
                     np.add.outer(12 * np.arange(10), degrees, dtype=float).ravel(),
                 )
             )
@@ -1877,7 +1878,7 @@ def __decorate_axis(
         axis.set_major_locator(
             mplticker.FixedLocator(
                 cast(
-                    Sequence[float],
+                    "Sequence[float]",
                     np.add.outer(12 * np.arange(10), degrees, dtype=float).ravel(),
                 )
             )
@@ -2675,7 +2676,7 @@ def waveshow(
 
     if mask is not None:
         mask = cast(
-            Sequence[bool],
+            "Sequence[bool]",
             np.asarray(mask, dtype=bool)[: len(y_top) * hop_length : hop_length]
         )
 

--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -34,15 +34,16 @@ Miscellaneous
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Iterable, List, Optional, Tuple, Union, overload
+from typing import TYPE_CHECKING, overload
 
 import numpy as np
-from typing_extensions import Literal
 
 from . import core, decompose, feature, util
 from .util.exceptions import ParameterError
 
 if TYPE_CHECKING:
+    from typing import Any, Callable, Iterable, List, Literal, Optional, Tuple, Union
+
     from numpy.typing import ArrayLike
 
     from ._typing import (

--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -32,22 +32,26 @@ Miscellaneous
     preemphasis
     deemphasis
 """
+from __future__ import annotations
 
-from typing import Any, Callable, Iterable, List, Optional, Tuple, Union, overload
+from typing import TYPE_CHECKING, Any, Callable, Iterable, List, Optional, Tuple, Union, overload
 
 import numpy as np
-import scipy.signal
-from numpy.typing import ArrayLike
 from typing_extensions import Literal
 
 from . import core, decompose, feature, util
-from ._typing import (
-    _FloatLike_co,
-    _IntLike_co,
-    _PadModeSTFT,
-    _WindowSpec,
-)
 from .util.exceptions import ParameterError
+
+if TYPE_CHECKING:
+    from numpy.typing import ArrayLike
+
+    from ._typing import (
+        _FloatLike_co,
+        _IntLike_co,
+        _PadModeSTFT,
+        _WindowSpec,
+    )
+
 
 __all__ = [
     "hpss",
@@ -881,6 +885,7 @@ def preemphasis(
     y_out: np.ndarray
     z_f: np.ndarray
 
+    import scipy.signal
     y_out, z_f = scipy.signal.lfilter(b, a, y, zi=np.asarray(zi, dtype=y.dtype))
 
     if return_zf:
@@ -978,6 +983,7 @@ def deemphasis(
 
     y_out: np.ndarray
     zf: np.ndarray
+    import scipy.signal
     if zi is None:
         # initialize with all zeros
         zi = np.zeros([*list(y.shape[:-1]), 1], dtype=y.dtype)

--- a/librosa/feature/inverse.py
+++ b/librosa/feature/inverse.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING
 
 import numpy as np
 import scipy
@@ -16,6 +16,8 @@ from ..util.exceptions import ParameterError
 from ..util.utils import tiny
 
 if TYPE_CHECKING:
+    from typing import Any, Optional
+
     from numpy.typing import DTypeLike
 
     from .._typing import _DCTNorm, _DCTType, _PadModeSTFT, _WindowSpec

--- a/librosa/feature/inverse.py
+++ b/librosa/feature/inverse.py
@@ -1,20 +1,24 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Feature inversion"""
+from __future__ import annotations
 
 import warnings
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import numpy as np
 import scipy
-from numpy.typing import DTypeLike
 
 from .. import filters
-from .._typing import _DCTNorm, _DCTType, _PadModeSTFT, _WindowSpec
 from ..core.spectrum import db_to_power, griffinlim
 from ..util import expand_to, nnls
 from ..util.exceptions import ParameterError
 from ..util.utils import tiny
+
+if TYPE_CHECKING:
+    from numpy.typing import DTypeLike
+
+    from .._typing import _DCTNorm, _DCTType, _PadModeSTFT, _WindowSpec
 
 __all__ = ["mel_to_stft", "mel_to_audio", "mfcc_to_mel", "mfcc_to_audio"]
 

--- a/librosa/feature/rhythm.py
+++ b/librosa/feature/rhythm.py
@@ -1,22 +1,26 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Rhythmic feature extraction"""
+from __future__ import annotations
 
-from typing import Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import numpy as np
-import scipy
-import scipy.interpolate
 
 from .. import util
 from .._cache import cache
-from .._typing import _InterpKind, _WindowSpec
 from ..core.audio import autocorrelate
 from ..core.convert import fourier_tempo_frequencies, tempo_frequencies, time_to_frames
 from ..core.harmonic import f0_harmonics, interp_harmonics
 from ..core.spectrum import stft
 from ..filters import get_window
 from ..util.exceptions import ParameterError
+
+if TYPE_CHECKING:
+    import scipy
+
+    from .._typing import _InterpKind, _WindowSpec
+
 
 __all__ = [
     "tempogram",
@@ -799,6 +803,8 @@ def hybrid_tempogram(
     lags_finite = lags[1:]
 
     # 4. Hybrid Interpolation
+    import scipy.interpolate
+
     f_interp = scipy.interpolate.interp1d(
         lags_finite, tg_a_finite, **interp_kwargs_dict
     )

--- a/librosa/feature/rhythm.py
+++ b/librosa/feature/rhythm.py
@@ -3,7 +3,7 @@
 """Rhythmic feature extraction"""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -17,6 +17,8 @@ from ..filters import get_window
 from ..util.exceptions import ParameterError
 
 if TYPE_CHECKING:
+    from typing import Any, Callable, Optional
+
     import scipy
 
     from .._typing import _InterpKind, _WindowSpec

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -1,22 +1,26 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Spectral feature extraction"""
+from __future__ import annotations
 
 import itertools
-from typing import Any, Collection, Optional, Union
+from typing import TYPE_CHECKING, Any, Collection, Optional, Union
 
 import numpy as np
-from numpy.typing import DTypeLike
 from typing_extensions import Literal
 
 from .. import filters, util
-from .._typing import _DCTNorm, _DCTType, _FloatLike_co, _PadMode, _PadModeSTFT, _WindowSpec
 from ..core.audio import zero_crossings
 from ..core.constantq import cqt, hybrid_cqt, vqt
 from ..core.convert import fft_frequencies
 from ..core.pitch import estimate_tuning
 from ..core.spectrum import _spectrogram, power_to_db
 from ..util.exceptions import ParameterError
+
+if TYPE_CHECKING:
+    from numpy.typing import DTypeLike
+
+    from .._typing import _DCTNorm, _DCTType, _FloatLike_co, _PadMode, _PadModeSTFT, _WindowSpec
 
 __all__ = [
     "spectral_centroid",

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -4,10 +4,9 @@
 from __future__ import annotations
 
 import itertools
-from typing import TYPE_CHECKING, Any, Collection, Optional, Union
+from typing import TYPE_CHECKING
 
 import numpy as np
-from typing_extensions import Literal
 
 from .. import filters, util
 from ..core.audio import zero_crossings
@@ -18,6 +17,8 @@ from ..core.spectrum import _spectrogram, power_to_db
 from ..util.exceptions import ParameterError
 
 if TYPE_CHECKING:
+    from typing import Any, Collection, Literal, Optional, Union
+
     from numpy.typing import DTypeLike
 
     from .._typing import _DCTNorm, _DCTType, _FloatLike_co, _PadMode, _PadModeSTFT, _WindowSpec

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -6,7 +6,6 @@ import itertools
 from typing import Any, Collection, Optional, Union
 
 import numpy as np
-import scipy
 from numpy.typing import DTypeLike
 from typing_extensions import Literal
 
@@ -1552,6 +1551,8 @@ def chroma_cens(
         # reshape for broadcasting
         win = util.expand_to(win, ndim=chroma_quant.ndim, axes=-1)
 
+        import scipy.ndimage
+
         cens = scipy.ndimage.convolve(chroma_quant, win, mode="constant")
     else:
         cens = chroma_quant
@@ -1989,6 +1990,8 @@ def mfcc(
     if S is None:
         # multichannel behavior may be different due to relative noise floor differences between channels
         S = power_to_db(melspectrogram(y=y, sr=sr, norm = mel_norm, **kwargs))
+
+    import scipy.fft
 
     M: np.ndarray = scipy.fft.dct(S, axis=-2, type=dct_type, norm=norm)[
         ..., :n_mfcc, :

--- a/librosa/feature/utils.py
+++ b/librosa/feature/utils.py
@@ -3,13 +3,16 @@
 """Feature manipulation utilities"""
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import TYPE_CHECKING
 
 import numpy as np
 from numba import jit
 
 from .._cache import cache
 from ..util.exceptions import ParameterError
+
+if TYPE_CHECKING:
+    from typing import Any, Literal
 
 __all__ = ["delta", "stack_memory"]
 

--- a/librosa/feature/utils.py
+++ b/librosa/feature/utils.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Feature manipulation utilities"""
+from __future__ import annotations
 
 from typing import Any, Literal
 
 import numpy as np
-import scipy.signal
 from numba import jit
 
 from .._cache import cache
@@ -120,6 +120,8 @@ def delta(
 
     kwargs.pop("deriv", None)
     kwargs.setdefault("polyorder", order)
+    import scipy.signal
+
     result: np.ndarray = scipy.signal.savgol_filter(
         data, width, deriv=order, axis=axis, mode=mode, **kwargs
     )

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -33,22 +33,25 @@ Miscellaneous
     window_sumsquare
     diagonal_filter
 """
+from __future__ import annotations
+
 import warnings
-from typing import Any, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
 
 import numpy as np
-import scipy
-import scipy.ndimage
-import scipy.signal
 from numba import jit
-from numpy.typing import ArrayLike, DTypeLike
 from typing_extensions import Literal
 
 from . import util
 from ._cache import cache
-from ._typing import _FloatLike_co, _WindowSpec
 from .core.convert import fft_frequencies, hz_to_midi, hz_to_octs, mel_frequencies, midi_to_hz, note_to_hz
 from .util.exceptions import ParameterError
+
+if TYPE_CHECKING:
+    from numpy.typing import ArrayLike, DTypeLike
+
+    from ._typing import _FloatLike_co, _WindowSpec
+
 
 __all__ = [
     "mel",
@@ -850,6 +853,8 @@ def cq_to_chroma(
     cq_to_ch = np.roll(cq_to_ch, roll, axis=0).astype(dtype)
 
     if window is not None:
+        import scipy.signal
+
         cq_to_ch = scipy.signal.convolve(cq_to_ch, np.atleast_2d(window), mode="same")
 
     return cq_to_ch
@@ -958,6 +963,7 @@ def get_window(window: _WindowSpec, Nx: int, *, fftbins: bool = True) -> np.ndar
     elif isinstance(window, (str, tuple)) or np.isscalar(window):
         # TODO: if we add custom window functions in librosa, call them here
 
+        import scipy.signal
         win: np.ndarray = scipy.signal.get_window(window, Nx, fftbins=fftbins)  # type: ignore
         return win
 
@@ -1076,6 +1082,7 @@ def _multirate_fb(
             cur_center_freq + cur_bw,
         ] / cur_nyquist
 
+        import scipy.signal
         cur_filter = scipy.signal.iirdesign(
             passband_freqs,
             stopband_freqs,
@@ -1387,6 +1394,7 @@ def diagonal_filter(
     win: np.ndarray = np.diag(get_window(window, n, fftbins=False))
 
     if not np.isclose(angle, np.pi / 4):
+        import scipy.ndimage
         win = scipy.ndimage.rotate(
             win, 45 - angle * 180 / np.pi, order=5, prefilter=False
         )

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -36,11 +36,10 @@ Miscellaneous
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING
 
 import numpy as np
 from numba import jit
-from typing_extensions import Literal
 
 from . import util
 from ._cache import cache
@@ -48,6 +47,8 @@ from .core.convert import fft_frequencies, hz_to_midi, hz_to_octs, mel_frequenci
 from .util.exceptions import ParameterError
 
 if TYPE_CHECKING:
+    from typing import Any, List, Literal, Optional, Tuple, Union
+
     from numpy.typing import ArrayLike, DTypeLike
 
     from ._typing import _FloatLike_co, _WindowSpec

--- a/librosa/onset.py
+++ b/librosa/onset.py
@@ -13,7 +13,7 @@ Onset detection
 """
 from __future__ import annotations
 
-from typing import Any, Callable, Optional, Sequence, Union
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -21,6 +21,9 @@ from . import core, util
 from ._cache import cache
 from .feature.spectral import melspectrogram
 from .util.exceptions import ParameterError
+
+if TYPE_CHECKING:
+    from typing import Any, Callable, Optional, Sequence, Union
 
 __all__ = ["onset_detect", "onset_strength", "onset_strength_multi", "onset_backtrack"]
 

--- a/librosa/onset.py
+++ b/librosa/onset.py
@@ -631,6 +631,8 @@ def onset_strength_multi(
 
     # remove the DC component
     if detrend:
+        import scipy.signal
+
         onset_env = scipy.signal.lfilter([1.0, -1.0], [1.0, -0.99], onset_env, axis=-1)
 
     # Trim to match the input duration

--- a/librosa/onset.py
+++ b/librosa/onset.py
@@ -11,11 +11,11 @@ Onset detection
     onset_strength
     onset_strength_multi
 """
+from __future__ import annotations
 
 from typing import Any, Callable, Optional, Sequence, Union
 
 import numpy as np
-import scipy
 
 from . import core, util
 from ._cache import cache
@@ -594,6 +594,7 @@ def onset_strength_multi(
         if max_size == 1:
             ref = S
         else:
+            import scipy.ndimage
             ref = scipy.ndimage.maximum_filter1d(S, max_size, axis=-2)
     elif ref.shape != S.shape:
         raise ParameterError(

--- a/librosa/segment.py
+++ b/librosa/segment.py
@@ -27,7 +27,7 @@ Temporal clustering
 from __future__ import annotations
 
 import itertools
-from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, Union, overload
+from typing import TYPE_CHECKING, overload
 
 import numpy as np
 import scipy
@@ -35,13 +35,23 @@ from decorator import decorator
 
 from . import util
 from ._cache import cache
-from ._typing import _FloatLike_co, _SparseArray, _WindowSpec
 from .filters import diagonal_filter
 from .util.exceptions import ParameterError
 
 if TYPE_CHECKING:
+    from typing import Any, Callable, Literal, Optional, TypeVar, Union
+
     import sklearn.cluster
-    from typing_extensions import Literal
+
+    from ._typing import _FloatLike_co, _SparseArray, _WindowSpec
+
+    _F = TypeVar("_F", bound=Callable[..., Any])
+
+    _ArrayOrSparseArray = TypeVar(
+        "_ArrayOrSparseArray", bound=Union[np.ndarray, _SparseArray]
+    )
+
+
 
 __all__ = [
     "cross_similarity",
@@ -704,11 +714,6 @@ def recurrence_matrix(
     return rec
 
 
-_ArrayOrSparseArray = TypeVar(
-    "_ArrayOrSparseArray", bound=Union[np.ndarray, _SparseArray]
-)
-
-
 def recurrence_to_lag(
     rec: _ArrayOrSparseArray, *, pad: bool = True, axis: int = -1
 ) -> _ArrayOrSparseArray:
@@ -893,8 +898,6 @@ def lag_to_recurrence(
     rec_slice: _ArrayOrSparseArray = rec[tuple(sub_slice)]  # type: ignore[assignment]
     return rec_slice
 
-
-_F = TypeVar("_F", bound=Callable[..., Any])
 
 
 def timelag_filter(function: _F, pad: bool = True, index: int = 0) -> _F:

--- a/librosa/segment.py
+++ b/librosa/segment.py
@@ -24,25 +24,24 @@ Temporal clustering
     agglomerative
     subsegment
 """
+from __future__ import annotations
 
 import itertools
-from typing import Any, Callable, Optional, TypeVar, Union, overload
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, Union, overload
 
 import numpy as np
 import scipy
-import scipy.ndimage
-import sklearn
-import sklearn.cluster
-import sklearn.feature_extraction
-import sklearn.neighbors
 from decorator import decorator
-from typing_extensions import Literal
 
 from . import util
 from ._cache import cache
 from ._typing import _FloatLike_co, _SparseArray, _WindowSpec
 from .filters import diagonal_filter
 from .util.exceptions import ParameterError
+
+if TYPE_CHECKING:
+    import sklearn.cluster
+    from typing_extensions import Literal
 
 __all__ = [
     "cross_similarity",
@@ -297,6 +296,8 @@ def cross_similarity(
     # Build the neighbor search object
     # `auto` mode does not work with some choices of metric.  Rather than special-case
     # those here, we instead use a fall-back to brute force if auto fails.
+    import sklearn.neighbors
+
     try:
         knn = sklearn.neighbors.NearestNeighbors(
             n_neighbors=min(n_ref, k), metric=metric, algorithm="auto"
@@ -623,6 +624,8 @@ def recurrence_matrix(
         k = t
 
     # Build the neighbor search object
+    import sklearn.neighbors
+
     try:
         knn = sklearn.neighbors.NearestNeighbors(
             n_neighbors=min(t - 1, k + 2 * width), metric=metric, algorithm="auto"
@@ -1142,6 +1145,9 @@ def agglomerative(
     data = data.reshape((n, -1), order="F")
 
     if clusterer is None:
+        import sklearn.cluster
+        import sklearn.feature_extraction
+
         # Connect the temporal connectivity graph
         grid = sklearn.feature_extraction.image.grid_to_graph(n_x=n, n_y=1, n_z=1)
 
@@ -1306,6 +1312,8 @@ def path_enhance(
         shape = [1] * R.ndim
         shape[-2:] = kernel.shape
         kernel = np.reshape(kernel, shape)
+
+        import scipy.ndimage
 
         if R_smooth is None:
             R_smooth = scipy.ndimage.convolve(R, kernel, **kwargs)

--- a/librosa/sequence.py
+++ b/librosa/sequence.py
@@ -38,9 +38,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, overload
 
 import numpy as np
-import scipy.interpolate
 from numba import jit
-from scipy.spatial.distance import cdist
 
 from .filters import get_window
 from .util import expand_to, fill_off_diagonal, is_positive_int, pad_center, tiny
@@ -395,6 +393,7 @@ def dtw(
         Y = Y.reshape((Y.shape[0], -1), order="F")
 
         try:
+            from scipy.spatial.distance import cdist
             C = cdist(X, Y, metric=metric)  # type: ignore[call-overload]
         except ValueError as exc:
             raise ParameterError(
@@ -1185,6 +1184,7 @@ def path_to_steps(path: np.ndarray, *, inverse: bool = False) -> np.ndarray:
     else:
         idx_from, idx_to = 0, 1
 
+    import scipy.interpolate
     step_interp = scipy.interpolate.interp1d(
         path[:, idx_to], path[:, idx_from], kind="linear"
     )

--- a/librosa/sequence.py
+++ b/librosa/sequence.py
@@ -45,9 +45,7 @@ from .util import expand_to, fill_off_diagonal, is_positive_int, pad_center, tin
 from .util.exceptions import ParameterError
 
 if TYPE_CHECKING:
-    from typing import Any, Iterable, List, Optional, Tuple, Union
-
-    from typing_extensions import Literal
+    from typing import Any, Iterable, List, Literal, Optional, Tuple, Union
 
     from ._typing import _WindowSpec
 

--- a/librosa/sequence.py
+++ b/librosa/sequence.py
@@ -35,18 +35,24 @@ Transition matrices
 
 from __future__ import annotations
 
-from typing import Any, Iterable, List, Optional, Tuple, Union, overload
+from typing import TYPE_CHECKING, overload
 
 import numpy as np
 import scipy.interpolate
 from numba import jit
 from scipy.spatial.distance import cdist
-from typing_extensions import Literal
 
-from ._typing import _WindowSpec
 from .filters import get_window
 from .util import expand_to, fill_off_diagonal, is_positive_int, pad_center, tiny
 from .util.exceptions import ParameterError
+
+if TYPE_CHECKING:
+    from typing import Any, Iterable, List, Optional, Tuple, Union
+
+    from typing_extensions import Literal
+
+    from ._typing import _WindowSpec
+
 
 __all__ = [
     "dtw",

--- a/librosa/util/_nnls.py
+++ b/librosa/util/_nnls.py
@@ -10,11 +10,14 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 from .utils import MAX_MEM_BLOCK
+
+if TYPE_CHECKING:
+    from typing import Any, Optional, Sequence, Tuple
 
 __all__ = ["nnls"]
 

--- a/librosa/util/_nnls.py
+++ b/librosa/util/_nnls.py
@@ -12,7 +12,6 @@
 from typing import Any, Optional, Sequence, Tuple
 
 import numpy as np
-import scipy.optimize
 
 from .utils import MAX_MEM_BLOCK
 
@@ -76,6 +75,8 @@ def _nnls_lbfgs_block(
     shape = x_init.shape
 
     # optimize
+    import scipy.optimize
+
     x, _obj_value, _diagnostics = scipy.optimize.fmin_l_bfgs_b(
         _nnls_obj, x_init, args=(shape, A, B), bounds=bounds, **kwargs
     )
@@ -139,6 +140,8 @@ def nnls(A: np.ndarray, B: np.ndarray, **kwargs: Any) -> np.ndarray:
     >>> ax[1].label_outer()
     >>> librosa.display.colorbar_db(img, ax=ax)
     """
+    import scipy.optimize
+
     # If B is a single vector, punt up to the scipy method
     if B.ndim == 1:
         return scipy.optimize.nnls(A, B)[0]

--- a/librosa/util/_nnls.py
+++ b/librosa/util/_nnls.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Non-negative least squares"""
-
 # The scipy library provides an nnls solver, but it does
 # not generalize efficiently to matrix-valued problems.
 # We therefore provide an alternate solver here.
 #
 # The vectorized solver uses the L-BFGS-B over blocks of
 # data to efficiently solve the constrained least-squares problem.
+
+from __future__ import annotations
 
 from typing import Any, Optional, Sequence, Tuple
 

--- a/librosa/util/decorators.py
+++ b/librosa/util/decorators.py
@@ -2,15 +2,18 @@
 # -*- encoding: utf-8 -*-
 # CREATED:2015-02-15 10:06:03 by Brian McFee <brian.mcfee@nyu.edu>
 """Helpful tools for deprecation"""
+from __future__ import annotations
 
 import functools
 import warnings
-from typing import Any, Callable, Iterable, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Optional, TypeVar, Union
 
 import numpy as np
 from decorator import decorator
-from numpy.typing import DTypeLike
 from typing_extensions import ParamSpec  # Install typing_extensions in Python 3.8
+
+if TYPE_CHECKING:
+    from numpy.typing import DTypeLike
 
 __all__ = ["moved", "deprecated", "vectorize"]
 

--- a/librosa/util/decorators.py
+++ b/librosa/util/decorators.py
@@ -6,12 +6,14 @@ from __future__ import annotations
 
 import functools
 import warnings
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Optional, ParamSpec, TypeVar, Union
+from typing import TYPE_CHECKING
 
 import numpy as np
 from decorator import decorator
 
 if TYPE_CHECKING:
+    from typing import Any, Callable, Iterable, Optional, ParamSpec, TypeVar, Union
+
     from numpy.typing import DTypeLike
     P = ParamSpec("P")
     R = TypeVar("R")

--- a/librosa/util/decorators.py
+++ b/librosa/util/decorators.py
@@ -6,19 +6,18 @@ from __future__ import annotations
 
 import functools
 import warnings
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Optional, ParamSpec, TypeVar, Union
 
 import numpy as np
 from decorator import decorator
-from typing_extensions import ParamSpec  # Install typing_extensions in Python 3.8
 
 if TYPE_CHECKING:
     from numpy.typing import DTypeLike
+    P = ParamSpec("P")
+    R = TypeVar("R")
+    _F = TypeVar("_F", bound=Callable[..., Any])
 
 __all__ = ["moved", "deprecated", "vectorize"]
-
-P = ParamSpec("P")
-R = TypeVar("R")
 
 
 def moved(
@@ -68,8 +67,6 @@ def deprecated(
 
     return decorator(__wrapper)
 
-
-_F = TypeVar("_F", bound=Callable[..., Any])
 
 
 def vectorize(

--- a/librosa/util/matching.py
+++ b/librosa/util/matching.py
@@ -1,13 +1,18 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Matching functions"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import numba
 import numpy as np
 
-from .._typing import _SequenceLike
 from .exceptions import ParameterError
 from .utils import valid_intervals
+
+if TYPE_CHECKING:
+    from .._typing import _SequenceLike
 
 __all__ = ["match_intervals", "match_events"]
 

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -2803,6 +2803,8 @@ def interp_broadcast(
             f"axis={axis} is out of range for minimum ndim={min_ndim}"
         )
 
+    import scipy.interpolate
+
     x1_interp = scipy.interpolate.interp1d(
         x1_pos,
         x1,

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -5,29 +5,34 @@
 from __future__ import annotations
 
 import itertools
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    Union,
-    overload,
-)
+from typing import TYPE_CHECKING, overload
 
 import numba
 import numpy as np
 import scipy.sparse
 from numpy.lib.stride_tricks import as_strided
-from numpy.typing import DTypeLike
-from typing_extensions import Literal
 
 from .._cache import cache
-from .._typing import _ComplexLike_co, _FloatLike_co, _InterpKind, _SequenceLike, _SparseArray, _SparseMatrix
 from .exceptions import ParameterError
+
+if TYPE_CHECKING:
+    from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+
+    from numpy.typing import DTypeLike
+    from typing_extensions import Literal
+
+    from .._typing import (
+        _Complex,
+        _ComplexLike_co,
+        _FloatLike_co,
+        _InterpKind,
+        _Number,
+        _Real,
+        _SequenceLike,
+        _SparseArray,
+        _SparseMatrix,
+    )
+
 
 # Constrain STFT block sizes to 256 KB
 MAX_MEM_BLOCK = 2**8 * 2**10
@@ -2537,8 +2542,6 @@ def _cabs2(x: _ComplexLike_co) -> _FloatLike_co:  # pragma: no cover
     return x.real**2 + x.imag**2
 
 
-_Number = Union[complex, "np.number[Any]"]
-
 @overload
 def abs2(x: np.ndarray, dtype: Optional[DTypeLike] = ...) -> np.ndarray: ...
 
@@ -2593,9 +2596,6 @@ def abs2(x: Union[np.ndarray, _Real, _Complex],
 def _phasor_angles(x) -> np.complexfloating[Any, Any]:
     return np.cos(x) + 1j * np.sin(x)  # type: ignore
 
-
-_Real = Union[float, "np.integer[Any]", "np.floating[Any]"]
-_Complex = Union[_Real, "np.complexfloating[Any, Any]"]
 
 
 @overload

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -16,10 +16,9 @@ from .._cache import cache
 from .exceptions import ParameterError
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+    from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Tuple, Union
 
     from numpy.typing import DTypeLike
-    from typing_extensions import Literal
 
     from .._typing import (
         _Complex,

--- a/librosa/version.py
+++ b/librosa/version.py
@@ -36,7 +36,6 @@ def show_versions() -> None:
         "soundfile",
         "pooch",
         "soxr",
-        "typing_extensions",
         "lazy_loader",
         "msgpack",
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = 'setuptools.build_meta'
 line-length = 119
 
 [tool.ruff.lint]
-select = ["E", "F", "S", "D", "W", "I", "PYI", "Q", "B", "SIM", "RUF"]
+select = ["E", "F", "S", "D", "W", "I", "PYI", "Q", "B", "SIM", "RUF", "TC"]
 ignore = [
     "D107",  # This only affects inherited classes for us
     "D203",  # Blank line before class docstring is silly

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,6 @@ install_requires =
     soundfile >= 0.12.1
     pooch >= 1.7
     soxr >= 1.0.0
-    typing_extensions >= 4.7.1
     lazy_loader >= 0.3
     msgpack >= 1.0.5
 


### PR DESCRIPTION
#### Reference Issue
Continues #2001 

#### What does this implement/fix? Explain your changes.

This PR does two things with an aim of reducing import times:

1. Heavy but infrequently used external imports are moved from module-level to function-level.
2. More careful use of `from __future__ import annotations` makes it easier to identify imports that are only used for type annotations, and can therefore be moved into TYPE_CHECKING blocks.

#### Any other comments?

(1) is doing most of the work here.  It does technically violate pep8, but I don't feel too badly about that.  We really shouldn't be paying to import a module that is only used for one function (looking at you, `decompose`) that is almost never called by users.

(2) completely eliminates the `typing_extensions` dependency, which is no longer needed since we're on python 3.12+.  I'm keeping it in the doc build environment for historical build purposes.