### PR TITLE
Loadx

### DIFF
--- a/docs/examples/plot_audio_playback.py
+++ b/docs/examples/plot_audio_playback.py
@@ -50,7 +50,7 @@ Audio(data=y_sweep, rate=sr)
 # Of course, we can also play back real recorded sounds
 # in the same way.
 #
-y, sr = librosa.load(librosa.ex('trumpet'))
+y, sr = librosa.loadx('trumpet')
 
 Audio(data=y, rate=sr)
 

--- a/docs/examples/plot_chroma.py
+++ b/docs/examples/plot_chroma.py
@@ -36,7 +36,7 @@ import librosa
 #######################################################################
 # We'll use a track that has harmonic, melodic, and percussive elements
 #  Karissa Hobbs - Let's Go Fishin'
-y, sr = librosa.load(librosa.ex('fishin'))
+y, sr = librosa.loadx('fishin')
 
 
 #######################################

--- a/docs/examples/plot_display.py
+++ b/docs/examples/plot_display.py
@@ -25,7 +25,7 @@ import librosa
 # %%
 # First, we'll load in a demo track
 
-y, sr = librosa.load(librosa.ex('trumpet'))
+y, sr = librosa.loadx('trumpet')
 
 
 # %%
@@ -383,7 +383,7 @@ ax[0].set(xlim=[1, 3])  # Zoom to seconds 1-3
 # (or `y_coords`) array indicating the position of each sample, as demonstrated
 # below.
 
-y, sr = librosa.load(librosa.ex('nutcracker'))
+y, sr = librosa.loadx('nutcracker')
 chroma = librosa.feature.chroma_cqt(y=y, sr=sr)
 tempo, beats = librosa.beat.beat_track(y=y, sr=sr)
 

--- a/docs/examples/plot_hprss.py
+++ b/docs/examples/plot_hprss.py
@@ -24,7 +24,7 @@ import librosa
 
 ########################
 # Load an example clip with harmonics and percussives
-y, sr = librosa.load(librosa.ex('fishin'), duration=5, offset=10)
+y, sr = librosa.loadx('fishin', duration=5, offset=10)
 
 Audio(data=y, rate=sr)
 

--- a/docs/examples/plot_patch_generation.py
+++ b/docs/examples/plot_patch_generation.py
@@ -23,7 +23,7 @@ import librosa
 
 ######################
 # Load an example clip
-y, sr = librosa.load(librosa.ex('libri1'))
+y, sr = librosa.loadx('libri1')
 
 
 ######################################

--- a/docs/examples/plot_segmentation.py
+++ b/docs/examples/plot_segmentation.py
@@ -33,7 +33,7 @@ import librosa
 
 #############################
 # First, we'll load in a song
-y, sr = librosa.load(librosa.ex('fishin'))
+y, sr = librosa.loadx('fishin')
 
 
 ##############################################

--- a/docs/examples/plot_spectral_harmonics.py
+++ b/docs/examples/plot_spectral_harmonics.py
@@ -38,7 +38,7 @@ import librosa
 
 ####################################################
 # We'll start by loading a speech example to analyze
-y, sr = librosa.load(librosa.ex('libri2'), duration=5)
+y, sr = librosa.loadx('libri2', duration=5)
 
 Audio(data=y, rate=sr)
 

--- a/docs/examples/plot_superflux.py
+++ b/docs/examples/plot_superflux.py
@@ -30,8 +30,7 @@ import librosa
 ######################################################
 # The method works fine for longer signals, but the
 # results are harder to visualize.
-y, sr = librosa.load(librosa.ex('trumpet', hq=True),
-                     sr=44100)
+y, sr = librosa.loadx('trumpet', sr=44100)
 
 
 ####################################################

--- a/docs/examples/plot_viterbi.py
+++ b/docs/examples/plot_viterbi.py
@@ -21,7 +21,7 @@ import librosa
 
 #############################################
 # Load an example signal
-y, sr = librosa.load(librosa.ex('trumpet'))
+y, sr = librosa.loadx('trumpet')
 
 
 # And compute the spectrogram magnitude and phase

--- a/docs/examples/plot_vocal_separation.py
+++ b/docs/examples/plot_vocal_separation.py
@@ -49,7 +49,7 @@ import librosa
 
 #############################################
 # Load an example with vocals.
-y, sr = librosa.load(librosa.ex('fishin'), duration=120)
+y, sr = librosa.loadx('fishin', duration=120)
 
 
 # And compute the spectrogram magnitude and phase

--- a/librosa/__init__.py
+++ b/librosa/__init__.py
@@ -10,6 +10,7 @@ Audio loading
     :toctree: generated/
 
     load
+    loadx
     stream
     resample
     to_mono

--- a/librosa/__init__.pyi
+++ b/librosa/__init__.pyi
@@ -148,6 +148,9 @@ from .core import (
     load as load,
 )
 from .core import (
+    loadx as loadx,
+)
+from .core import (
     lpc as lpc,
 )
 from .core import (

--- a/librosa/beat.py
+++ b/librosa/beat.py
@@ -154,7 +154,7 @@ def beat_track(
     --------
     Track beats using time series input
 
-    >>> y, sr = librosa.load(librosa.ex('choice'), duration=10)
+    >>> y, sr = librosa.loadx('choice', duration=10)
 
     >>> tempo, beats = librosa.beat.beat_track(y=y, sr=sr)
     >>> tempo
@@ -345,7 +345,7 @@ def plp(
     Visualize the PLP compared to an onset strength envelope.
     Both are normalized here to make comparison easier.
 
-    >>> y, sr = librosa.load(librosa.ex('brahms'))
+    >>> y, sr = librosa.loadx('brahms')
     >>> onset_env = librosa.onset.onset_strength(y=y, sr=sr)
     >>> pulse = librosa.beat.plp(onset_envelope=onset_env, sr=sr)
     >>> # Or compute pulse with an alternate prior, like log-normal

--- a/librosa/core/__init__.pyi
+++ b/librosa/core/__init__.pyi
@@ -17,6 +17,9 @@ from .audio import (
     load as load,
 )
 from .audio import (
+    loadx as loadx,
+)
+from .audio import (
     lpc as lpc,
 )
 from .audio import (

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -416,7 +416,6 @@ def loadx(key, *, hq: Optional[bool] = None, **kwargs):
     -------
     y : np.ndarray [shape=(n,) or (..., n)]
         audio time series. Multi-channel is supported.
-
     sr : number > 0 [scalar]
         sampling rate of ``y``
 

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -384,7 +384,7 @@ def stream(
             yield block.T
 
 
-def loadx(key, *, hq: Optional[bool] = None, **kwargs):
+def loadx(key: str, *, hq: Optional[bool] = None, **kwargs: Any) -> Tuple[np.ndarray, Union[int, float]]:
     """Load an example audio file by key.
 
     This is a wrapper around `librosa.util.example` that provides the same
@@ -405,7 +405,7 @@ def loadx(key, *, hq: Optional[bool] = None, **kwargs):
         If ``False``, return the 22KHz mono version of the recording.
 
         If not provided, `hq` is inferred based on additional parameters in `kwargs`:
-            - If `sr` is provided and greater than 22050, then `hq` is set to `True`.
+            - If `sr` is provided and greater than 22050 (or is `None`), then `hq` is set to `True`.
             - If `mono` is provided and set to `False`, then `hq` is set to `True`.
             - Otherwise, `hq` is set to `False`.
 

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -391,6 +391,10 @@ def loadx(key, *, hq: Optional[bool] = None, **kwargs):
     functionality as `load`, but with the convenience of loading from the
     built-in examples.
 
+    .. note:: This function is primarily useful for demonstration purposes,
+      and to make documentation examples more concise.
+      For general-purpose loading of audio files, use `load` instead.
+
     Parameters
     ----------
     key : str

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -384,7 +384,7 @@ def stream(
             yield block.T
 
 
-def loadx(key, *, hq: Optional[bool] = False, **kwargs):
+def loadx(key, *, hq: Optional[bool] = None, **kwargs):
     """Load an example audio file by key.
 
     This is a wrapper around `librosa.util.example` that provides the same
@@ -434,12 +434,13 @@ def loadx(key, *, hq: Optional[bool] = False, **kwargs):
     >>> # This is equivalent to the following more verbose code:
     >>> y, sr = librosa.load(librosa.ex('trumpet', hq=True), mono=False)
     """
-    if (("sr" in kwargs and (kwargs["sr"] is None or kwargs["sr"] > 22050)) or
-        ("mono" in kwargs and kwargs["mono"] is False)
-        ):
-        hq = True
-    else:
-        hq = False
+    if hq is None:
+        if (("sr" in kwargs and (kwargs["sr"] is None or kwargs["sr"] > 22050)) or
+            ("mono" in kwargs and kwargs["mono"] is False)
+            ):
+            hq = True
+        else:
+            hq = False
 
     path = example(key, hq=hq)
     return load(path, **kwargs)
@@ -499,7 +500,7 @@ def to_mono(*signals: np.ndarray, pad: bool = True, norm: bool = True) -> np.nda
     --------
     Downmix a stereo input
 
-    >>> y, sr = librosa.load(librosa.ex('trumpet', hq=True), mono=False)
+    >>> y, sr = librosa.loadx('trumpet', mono=False)
     >>> y.shape
     (2, 117601)
     >>> y_mono = librosa.to_mono(y)
@@ -896,7 +897,7 @@ def resample(
     --------
     Downsample from 22 KHz to 8 KHz
 
-    >>> y, sr = librosa.load(librosa.ex('trumpet'), sr=22050)
+    >>> y, sr = librosa.loadx('trumpet', sr=22050)
     >>> y_8k = librosa.resample(y, orig_sr=sr, target_sr=8000)
     >>> y.shape, y_8k.shape
     ((117601,), (42668,))
@@ -984,7 +985,7 @@ def get_duration(
     Examples
     --------
     >>> # Load an example audio file
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> librosa.get_duration(y=y, sr=sr)
     5.333378684807256
 
@@ -993,7 +994,7 @@ def get_duration(
     5.333378684807256
 
     >>> # Or compute duration from an STFT matrix
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> S = librosa.stft(y)
     >>> librosa.get_duration(S=S, sr=sr)
     5.317369614512471
@@ -1138,7 +1139,7 @@ def autocorrelate(
     --------
     Compute full autocorrelation of ``y``
 
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> librosa.autocorrelate(y)
     array([ 6.899e+02,  6.236e+02, ...,  3.710e-08, -1.796e-08])
 
@@ -1233,14 +1234,14 @@ def lpc(y: np.ndarray, *, order: int, axis: int = -1) -> np.ndarray:
     --------
     Compute LP coefficients of y at order 16 on entire series
 
-    >>> y, sr = librosa.load(librosa.ex('libri1'))
+    >>> y, sr = librosa.loadx('libri1')
     >>> librosa.lpc(y, order=16)
 
     Compute LP coefficients, and plot LP estimate of original series
 
     >>> import matplotlib.pyplot as plt
     >>> import scipy
-    >>> y, sr = librosa.load(librosa.ex('libri1'), duration=0.020)
+    >>> y, sr = librosa.loadx('libri1', duration=0.020)
     >>> a = librosa.lpc(y, order=2)
     >>> b = np.hstack([[0], -1 * a[1:]])
     >>> y_hat = scipy.signal.lfilter(b, [1], y)
@@ -1571,7 +1572,7 @@ def clicks(
     Examples
     --------
     >>> # Sonify detected beat events
-    >>> y, sr = librosa.load(librosa.ex('choice'), duration=10)
+    >>> y, sr = librosa.loadx('choice', duration=10)
     >>> tempo, beats = librosa.beat.beat_track(y=y, sr=sr)
     >>> y_beats = librosa.clicks(frames=beats, sr=sr)
 

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -15,6 +15,7 @@ from numba import guvectorize, jit, stencil
 from .. import util
 from .._cache import cache
 from ..util.exceptions import ParameterError
+from ..util.files import example
 from .convert import frames_to_samples, time_to_samples
 
 if TYPE_CHECKING:
@@ -32,6 +33,7 @@ resampy = lazy.load("resampy")
 
 __all__ = [
     "load",
+    "loadx",
     "stream",
     "to_mono",
     "to_stereo",
@@ -380,6 +382,67 @@ def stream(
             yield to_mono(block.T)
         else:
             yield block.T
+
+
+def loadx(key, *, hq: Optional[bool] = False, **kwargs):
+    """Load an example audio file by key.
+
+    This is a wrapper around `librosa.util.example` that provides the same
+    functionality as `load`, but with the convenience of loading from the
+    built-in examples.
+
+    Parameters
+    ----------
+    key : str
+        The identifier for the track to load
+
+    hq : bool, optional
+        If ``True``, return the high-quality version of the recording.
+        If ``False``, return the 22KHz mono version of the recording.
+
+        If not provided, `hq` is inferred based on additional parameters in `kwargs`:
+            - If `sr` is provided and greater than 22050, then `hq` is set to `True`.
+            - If `mono` is provided and set to `False`, then `hq` is set to `True`.
+            - Otherwise, `hq` is set to `False`.
+
+    **kwargs : additional keyword arguments
+        Additional keyword arguments to pass to `load`
+
+    Returns
+    -------
+    y : np.ndarray [shape=(n,) or (..., n)]
+        audio time series. Multi-channel is supported.
+
+    sr : number > 0 [scalar]
+        sampling rate of ``y``
+
+    See Also
+    --------
+    load
+    librosa.util.example
+    librosa.util.list_examples
+
+    Examples
+    --------
+    Load the default version of the 'trumpet' example
+
+    >>> y, sr = librosa.loadx('trumpet')
+
+    Load the stereo version of the 'trumpet' example
+
+    >>> y, sr = librosa.loadx('trumpet', mono=False)
+    >>> # This is equivalent to the following more verbose code:
+    >>> y, sr = librosa.load(librosa.ex('trumpet', hq=True), mono=False)
+    """
+    if (("sr" in kwargs and (kwargs["sr"] is None or kwargs["sr"] > 22050)) or
+        ("mono" in kwargs and kwargs["mono"] is False)
+        ):
+        hq = True
+    else:
+        hq = False
+
+    path = example(key, hq=hq)
+    return load(path, **kwargs)
 
 
 @cache(level=20)

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -151,7 +151,7 @@ def cqt(
     Generate and plot a constant-Q power spectrum
 
     >>> import matplotlib.pyplot as plt
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> C = np.abs(librosa.cqt(y, sr=sr))
     >>> fig, ax = plt.subplots()
     >>> img = librosa.display.specshow(C, vscale='dBFS',
@@ -645,7 +645,7 @@ def icqt(
     --------
     Using default parameters
 
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> C = librosa.cqt(y=y, sr=sr)
     >>> y_hat = librosa.icqt(C=C, sr=sr)
 
@@ -913,7 +913,7 @@ def vqt(
     Generate and plot a variable-Q power spectrum
 
     >>> import matplotlib.pyplot as plt
-    >>> y, sr = librosa.load(librosa.ex('choice'), duration=5)
+    >>> y, sr = librosa.loadx('choice', duration=5)
     >>> C = np.abs(librosa.cqt(y, sr=sr))
     >>> V = np.abs(librosa.vqt(y, sr=sr))
     >>> fig, ax = plt.subplots(nrows=2, sharex=True, sharey=True)
@@ -1372,9 +1372,9 @@ def griffinlim_cqt(
 
     Examples
     --------
-    A basis CQT inverse example
+    A basic CQT inverse example
 
-    >>> y, sr = librosa.load(librosa.ex('trumpet', hq=True), sr=None)
+    >>> y, sr = librosa.loadx('trumpet', sr=None)
     >>> # Get the CQT magnitude, 7 octaves at 36 bins per octave
     >>> C = np.abs(librosa.cqt(y=y, sr=sr, bins_per_octave=36, n_bins=7*36))
     >>> # Invert using Griffin-Lim

--- a/librosa/core/convert.py
+++ b/librosa/core/convert.py
@@ -118,7 +118,7 @@ def frames_to_samples(
 
     Examples
     --------
-    >>> y, sr = librosa.load(librosa.ex('choice'))
+    >>> y, sr = librosa.loadx('choice')
     >>> tempo, beats = librosa.beat.beat_track(y=y, sr=sr)
     >>> beat_samples = librosa.frames_to_samples(beats, sr=sr)
     """
@@ -274,7 +274,7 @@ def frames_to_time(
 
     Examples
     --------
-    >>> y, sr = librosa.load(librosa.ex('choice'))
+    >>> y, sr = librosa.loadx('choice')
     >>> tempo, beats = librosa.beat.beat_track(y=y, sr=sr)
     >>> beat_times = librosa.frames_to_time(beats, sr=sr)
     """
@@ -2337,7 +2337,7 @@ def times_like(
     --------
     Provide a feature matrix input:
 
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> D = librosa.stft(y)
     >>> times = librosa.times_like(D, sr=sr)
     >>> times
@@ -2394,7 +2394,7 @@ def samples_like(
     --------
     Provide a feature matrix input:
 
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> X = librosa.stft(y)
     >>> samples = librosa.samples_like(X)
     >>> samples

--- a/librosa/core/harmonic.py
+++ b/librosa/core/harmonic.py
@@ -95,7 +95,7 @@ def salience(
 
     Examples
     --------
-    >>> y, sr = librosa.load(librosa.ex('trumpet'), duration=3)
+    >>> y, sr = librosa.loadx('trumpet', duration=3)
     >>> S = np.abs(librosa.stft(y))
     >>> freqs = librosa.fft_frequencies(sr=sr)
     >>> harms = [1, 2, 3, 4]
@@ -198,7 +198,7 @@ def interp_harmonics(
     --------
     Estimate the harmonics of a time-averaged tempogram
 
-    >>> y, sr = librosa.load(librosa.ex('sweetwaltz'))
+    >>> y, sr = librosa.loadx('sweetwaltz')
     >>> # Compute the time-varying tempogram and average over time
     >>> tempi = np.mean(librosa.feature.tempogram(y=y, sr=sr), axis=1)
     >>> # We'll measure the first five harmonics
@@ -221,7 +221,7 @@ def interp_harmonics(
     We can also compute frequency harmonics for spectrograms.
     To calculate sub-harmonic energy, use values < 1.
 
-    >>> y, sr = librosa.load(librosa.ex('trumpet'), duration=3)
+    >>> y, sr = librosa.loadx('trumpet', duration=3)
     >>> harmonics = [1./3, 1./2, 1, 2, 3, 4]
     >>> S = np.abs(librosa.stft(y))
     >>> ref_value = np.max(S)  # Common reference for dB scaling
@@ -374,7 +374,7 @@ def f0_harmonics(
     This example estimates the fundamental (f0), and then extracts the first
     12 harmonics
 
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> f0, voicing, voicing_p = librosa.pyin(y=y, sr=sr, fmin=200, fmax=700)
     >>> S = np.abs(librosa.stft(y))
     >>> freqs = librosa.fft_frequencies(sr=sr)

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -71,7 +71,7 @@ def estimate_tuning(
     --------
     With time-series input
 
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> librosa.estimate_tuning(y=y, sr=sr)
     -0.08000000000000002
 
@@ -143,7 +143,7 @@ def pitch_tuning(
     0.25
 
     >>> # Track frequencies from a real spectrogram
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> freqs, times, mags = librosa.reassigned_spectrogram(y, sr=sr,
     ...                                                     fill_nan=True)
     >>> # Select out pitches with high energy
@@ -289,7 +289,7 @@ def piptrack(
     --------
     Computing pitches from a waveform input
 
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> pitches, magnitudes = librosa.piptrack(y=y, sr=sr)
 
     Or from a spectrogram input
@@ -736,7 +736,7 @@ def pyin(
     --------
     Computing a fundamental frequency (F0) curve from an audio input
 
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> f0, voiced_flag, voiced_probs = librosa.pyin(y,
     ...                                              sr=sr,
     ...                                              fmin=librosa.note_to_hz('C2'),

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -200,7 +200,7 @@ def stft(
 
     Examples
     --------
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> S = np.abs(librosa.stft(y))
     >>> S
     array([[5.395e-03, 3.332e-03, ..., 9.862e-07, 1.201e-05],
@@ -484,7 +484,7 @@ def istft(
 
     Examples
     --------
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> D = librosa.stft(y)
     >>> y_hat = librosa.istft(D)
     >>> y_hat
@@ -740,7 +740,7 @@ def __reassign_frequencies(
 
     Examples
     --------
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> frequencies, S = librosa.core.spectrum.__reassign_frequencies(y, sr=sr)
     >>> frequencies
     array([[0.000e+00, 0.000e+00, ..., 0.000e+00, 0.000e+00],
@@ -903,7 +903,7 @@ def __reassign_times(
 
     Examples
     --------
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> times, S = librosa.core.spectrum.__reassign_times(y, sr=sr)
     >>> times
     array([[ 2.268e-05,  1.144e-02, ...,  5.332e+00,  5.333e+00],
@@ -1313,7 +1313,7 @@ def magphase(D: np.ndarray, *, power: float = 1) -> Tuple[np.ndarray, np.ndarray
 
     Examples
     --------
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> D = librosa.stft(y)
     >>> magnitude, phase = librosa.magphase(D)
     >>> magnitude
@@ -1389,13 +1389,13 @@ def phase_vocoder(
     Examples
     --------
     >>> # Play at double speed
-    >>> y, sr   = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr   = librosa.loadx('trumpet')
     >>> D       = librosa.stft(y, n_fft=2048, hop_length=512)
     >>> D_fast  = librosa.phase_vocoder(D, rate=2.0, hop_length=512)
     >>> y_fast  = librosa.istft(D_fast, hop_length=512)
 
     >>> # Or play at 1/3 speed
-    >>> y, sr   = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr   = librosa.loadx('trumpet')
     >>> D       = librosa.stft(y, n_fft=2048, hop_length=512)
     >>> D_slow  = librosa.phase_vocoder(D, rate=1./3, hop_length=512)
     >>> y_slow  = librosa.istft(D_slow, hop_length=512)
@@ -1610,7 +1610,7 @@ def iirt(
     Examples
     --------
     >>> import matplotlib.pyplot as plt
-    >>> y, sr = librosa.load(librosa.ex('trumpet'), duration=3)
+    >>> y, sr = librosa.loadx('trumpet', duration=3)
     >>> D = np.abs(librosa.iirt(y, sr=sr))
     >>> C = np.abs(librosa.cqt(y=y, sr=sr))
     >>> fig, ax = plt.subplots(nrows=2, sharex=True, sharey=True)
@@ -1797,7 +1797,7 @@ def power_to_db(
     --------
     Get a power spectrogram from a waveform ``y``
 
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> S = np.abs(librosa.stft(y))
     >>> librosa.power_to_db(S**2)
     array([[-41.809, -41.809, ..., -41.809, -41.809],
@@ -2114,7 +2114,7 @@ def perceptual_weighting(
     --------
     Re-weight a CQT power spectrum, using peak power as reference
 
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> C = np.abs(librosa.cqt(y, sr=sr, fmin=librosa.note_to_hz('A1')))
     >>> freqs = librosa.cqt_frequencies(C.shape[0],
     ...                                 fmin=librosa.note_to_hz('A1'))
@@ -2257,7 +2257,7 @@ def fmt(
     >>> plt.show()
 
     >>> # Plot the scale transform of an onset strength autocorrelation
-    >>> y, sr = librosa.load(librosa.ex('choice'))
+    >>> y, sr = librosa.loadx('choice')
     >>> odf = librosa.onset.onset_strength(y=y, sr=sr)
     >>> # Auto-correlate with up to 10 seconds lag
     >>> odf_ac = librosa.autocorrelate(odf, max_size=10 * sr // 512)
@@ -2567,7 +2567,7 @@ def pcen(
     Compare PCEN to log amplitude (dB) scaling on Mel spectra
 
     >>> import matplotlib.pyplot as plt
-    >>> y, sr = librosa.load(librosa.ex('robin'))
+    >>> y, sr = librosa.loadx('robin')
 
     >>> # We recommend scaling y to the range [-2**31, 2**31[ before applying
     >>> # PCEN's default parameters. Furthermore, we use power=1 to get a
@@ -2817,7 +2817,7 @@ def griffinlim(
     --------
     A basic STFT inverse example
 
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> # Get the magnitude spectrogram
     >>> S = np.abs(librosa.stft(y))
     >>> # Invert using Griffin-Lim

--- a/librosa/decompose.py
+++ b/librosa/decompose.py
@@ -124,7 +124,7 @@ def decompose(
     --------
     Decompose a magnitude spectrogram into 16 components with NMF
 
-    >>> y, sr = librosa.load(librosa.ex('pistachio'), duration=5)
+    >>> y, sr = librosa.loadx('pistachio', duration=5)
     >>> S = np.abs(librosa.stft(y))
     >>> comps, acts = librosa.decompose.decompose(S, n_components=16)
 
@@ -295,7 +295,7 @@ def hpss(
     --------
     Separate into harmonic and percussive
 
-    >>> y, sr = librosa.load(librosa.ex('choice'), duration=5)
+    >>> y, sr = librosa.loadx('choice', duration=5)
     >>> D = librosa.stft(y)
     >>> H, P = librosa.decompose.hpss(D)
 
@@ -491,8 +491,7 @@ def nn_filter(
     By default this would use euclidean distance to select neighbors,
     but this can be overridden directly by setting the ``metric`` parameter.
 
-    >>> y, sr = librosa.load(librosa.ex('brahms'),
-    ...                      offset=30, duration=10)
+    >>> y, sr = librosa.loadx('brahms', offset=30, duration=10)
     >>> chroma = librosa.feature.chroma_cqt(y=y, sr=sr)
     >>> chroma_med = librosa.decompose.nn_filter(chroma,
     ...                                          aggregate=np.median,

--- a/librosa/display.py
+++ b/librosa/display.py
@@ -1528,7 +1528,7 @@ def specshow(
     Visualize an STFT magnitude spectrum using default parameters
 
     >>> import matplotlib.pyplot as plt
-    >>> y, sr = librosa.load(librosa.ex('choice'), duration=15)
+    >>> y, sr = librosa.loadx('choice', duration=15)
     >>> fig, ax = plt.subplots(nrows=2, ncols=1, sharex=True)
     >>> D = librosa.stft(y)
     >>> img = librosa.display.specshow(D, y_axis='linear', x_axis='time',
@@ -2573,7 +2573,7 @@ def waveshow(
     Plot a monophonic waveform with an envelope view
 
     >>> import matplotlib.pyplot as plt
-    >>> y, sr = librosa.load(librosa.ex('choice'), duration=10)
+    >>> y, sr = librosa.loadx('choice', duration=10)
     >>> fig, ax = plt.subplots(nrows=3, sharex=True)
     >>> librosa.display.waveshow(y, sr=sr, ax=ax[0])
     >>> ax[0].set(title='Envelope view, mono')
@@ -2581,14 +2581,14 @@ def waveshow(
 
     Or a stereo waveform
 
-    >>> y, sr = librosa.load(librosa.ex('choice', hq=True), mono=False, duration=10)
+    >>> y, sr = librosa.loadx('choice', mono=False, duration=10)
     >>> librosa.display.waveshow(y, sr=sr, ax=ax[1])
     >>> ax[1].set(title='Envelope view, stereo')
     >>> ax[1].label_outer()
 
     Or harmonic and percussive components with transparency
 
-    >>> y, sr = librosa.load(librosa.ex('choice'), duration=10)
+    >>> y, sr = librosa.loadx('choice', duration=10)
     >>> y_harm, y_perc = librosa.effects.hpss(y)
     >>> librosa.display.waveshow(y_harm, sr=sr, alpha=0.5, ax=ax[2], label='Harmonic')
     >>> librosa.display.waveshow(y_perc, sr=sr, color='r', alpha=0.5, ax=ax[2], label='Percussive')
@@ -2611,7 +2611,7 @@ def waveshow(
     Plotting a transposed wave along with a self-similarity matrix
 
     >>> fig, ax = plt.subplot_mosaic("hSSS;hSSS;hSSS;.vvv", layout='compressed')
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> chroma = librosa.feature.chroma_cqt(y=y, sr=sr)
     >>> sim = librosa.segment.recurrence_matrix(chroma, mode='affinity')
     >>> librosa.display.specshow(sim, ax=ax['S'], sr=sr,
@@ -2815,7 +2815,7 @@ def wavebars(
     Plot a waveform as bars, compared to the `waveshow` version of the plot
 
     >>> import matplotlib.pyplot as plt
-    >>> y, sr = librosa.load(librosa.ex('libri1'), duration=10)
+    >>> y, sr = librosa.loadx('libri1', duration=10)
     >>> fig, ax = plt.subplots(nrows=2, sharex=True)
     >>> librosa.display.waveshow(y=y, sr=sr, ax=ax[0], label='waveshow()')
     >>> ax[0].legend()
@@ -3055,7 +3055,7 @@ def wavef0(
     Visualize a waveform with an f0 displacement using `waveshow`
 
     >>> import matplotlib.pyplot as plt
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> f0, _, _ = librosa.pyin(y, fmin=librosa.note_to_hz('C2'),
     ...                         fmax=librosa.note_to_hz('C7'),
     ...                         sr=sr, hop_length=512)
@@ -3243,7 +3243,7 @@ def colorbar_phase(
 
     >>> import matplotlib.pyplot as plt
     >>> import librosa
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> S = librosa.stft(y)
     >>> fig, ax = plt.subplots()
     >>> im = librosa.display.specshow(S, ax=ax, y_axis='log', x_axis='time', vscale='phase')
@@ -3325,7 +3325,7 @@ def colorbar_db(
 
     >>> import matplotlib.pyplot as plt
     >>> import librosa
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> S = librosa.stft(y)
     >>> fig, ax = plt.subplots()
     >>> im = librosa.display.specshow(S, ax=ax, y_axis='log', x_axis='time', vscale='dB')
@@ -3781,7 +3781,7 @@ def multiplot(
     the figure and axes objects for us.
 
     >>> import matplotlib.pyplot as plt
-    >>> y, sr = librosa.load(librosa.ex('choice'), duration=10)
+    >>> y, sr = librosa.loadx('choice', duration=10)
     >>> yh, yp = librosa.effects.hpss(y)
     >>> librosa.display.multiplot('waveshow', y, yh, yp,
     ...                           labels=['Original', 'Harmonic', 'Percussive'],

--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -122,7 +122,7 @@ def hpss(
     Examples
     --------
     >>> # Extract harmonic and percussive components
-    >>> y, sr = librosa.load(librosa.ex('choice'))
+    >>> y, sr = librosa.loadx('choice')
     >>> y_harmonic, y_percussive = librosa.effects.hpss(y)
 
     >>> # Get a more isolated percussive component by widening its margin
@@ -217,7 +217,7 @@ def harmonic(
     Examples
     --------
     >>> # Extract harmonic component
-    >>> y, sr = librosa.load(librosa.ex('choice'))
+    >>> y, sr = librosa.loadx('choice')
     >>> y_harmonic = librosa.effects.harmonic(y)
 
     >>> # Use a margin > 1.0 for greater harmonic separation
@@ -303,7 +303,7 @@ def percussive(
     Examples
     --------
     >>> # Extract percussive component
-    >>> y, sr = librosa.load(librosa.ex('choice'))
+    >>> y, sr = librosa.loadx('choice')
     >>> y_percussive = librosa.effects.percussive(y)
 
     >>> # Use a margin > 1.0 for greater percussive separation
@@ -369,7 +369,7 @@ def time_stretch(y: np.ndarray, *, rate: float, **kwargs: Any) -> np.ndarray:
     --------
     Compress to be twice as fast
 
-    >>> y, sr = librosa.load(librosa.ex('choice'))
+    >>> y, sr = librosa.loadx('choice')
     >>> y_fast = librosa.effects.time_stretch(y, rate=2.0)
 
     Or half the original speed
@@ -457,7 +457,7 @@ def pitch_shift(
     --------
     Shift up by a major third (four steps if ``bins_per_octave`` is 12)
 
-    >>> y, sr = librosa.load(librosa.ex('choice'))
+    >>> y, sr = librosa.loadx('choice')
     >>> y_third = librosa.effects.pitch_shift(y, sr=sr, n_steps=4)
 
     Shift down by a tritone (six steps if ``bins_per_octave`` is 12)
@@ -516,7 +516,7 @@ def remix(
     --------
     Load in the example track and reverse the beats
 
-    >>> y, sr = librosa.load(librosa.ex('choice'))
+    >>> y, sr = librosa.loadx('choice')
 
     Compute beats
 
@@ -664,7 +664,7 @@ def trim(
     Examples
     --------
     >>> # Load some audio
-    >>> y, sr = librosa.load(librosa.ex('choice'))
+    >>> y, sr = librosa.loadx('choice')
     >>> # Trim the beginning and ending silence
     >>> yt, index = librosa.effects.trim(y)
     >>> # Print the durations
@@ -849,7 +849,7 @@ def preemphasis(
     Apply a standard pre-emphasis filter
 
     >>> import matplotlib.pyplot as plt
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> y_filt = librosa.effects.preemphasis(y)
     >>> # and plot the results for comparison
     >>> S_orig = librosa.amplitude_to_db(np.abs(librosa.stft(y)), ref=np.max, top_db=None)
@@ -969,7 +969,7 @@ def deemphasis(
     --------
     Apply a standard pre-emphasis filter and invert it with de-emphasis
 
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> y_filt = librosa.effects.preemphasis(y)
     >>> y_deemph = librosa.effects.deemphasis(y_filt)
     >>> np.allclose(y, y_deemph)

--- a/librosa/feature/inverse.py
+++ b/librosa/feature/inverse.py
@@ -78,7 +78,7 @@ def mel_to_stft(
 
     Examples
     --------
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> S = librosa.util.abs2(librosa.stft(y))
     >>> mel_spec = librosa.feature.melspectrogram(S=S, sr=sr)
     >>> S_inv = librosa.feature.inverse.mel_to_stft(mel_spec, sr=sr)

--- a/librosa/feature/rhythm.py
+++ b/librosa/feature/rhythm.py
@@ -109,7 +109,7 @@ def tempogram(
     Examples
     --------
     >>> # Compute local onset autocorrelation
-    >>> y, sr = librosa.load(librosa.ex('nutcracker'), duration=30)
+    >>> y, sr = librosa.loadx('nutcracker', duration=30)
     >>> hop_length = 512
     >>> oenv = librosa.onset.onset_strength(y=y, sr=sr, hop_length=hop_length)
     >>> tempogram = librosa.feature.tempogram(onset_envelope=oenv, sr=sr,
@@ -250,7 +250,7 @@ def fourier_tempogram(
     Examples
     --------
     >>> # Compute local onset autocorrelation
-    >>> y, sr = librosa.load(librosa.ex('nutcracker'))
+    >>> y, sr = librosa.loadx('nutcracker')
     >>> hop_length = 512
     >>> oenv = librosa.onset.onset_strength(y=y, sr=sr, hop_length=hop_length)
     >>> tempogram = librosa.feature.fourier_tempogram(onset_envelope=oenv, sr=sr,
@@ -356,7 +356,7 @@ def tempo(
     Examples
     --------
     >>> # Estimate a static tempo
-    >>> y, sr = librosa.load(librosa.ex('nutcracker'), duration=30)
+    >>> y, sr = librosa.loadx('nutcracker', duration=30)
     >>> onset_env = librosa.onset.onset_strength(y=y, sr=sr)
     >>> tempo = librosa.feature.tempo(onset_envelope=onset_env, sr=sr)
     >>> tempo
@@ -616,7 +616,7 @@ def tempogram_ratio(
     for a waltz (3/4 time)
 
     >>> import matplotlib.pyplot as plt
-    >>> y, sr = librosa.load(librosa.ex('sweetwaltz'))
+    >>> y, sr = librosa.loadx('sweetwaltz')
     >>> tempogram = librosa.feature.tempogram(y=y, sr=sr)
     >>> tgr = librosa.feature.tempogram_ratio(tg=tempogram, sr=sr)
     >>> fig, ax = plt.subplots(nrows=2, sharex=True)
@@ -726,7 +726,7 @@ def hybrid_tempogram(
     --------
     Compute local onset autocorrelation
 
-    >>> y, sr = librosa.load(librosa.ex('nutcracker'))
+    >>> y, sr = librosa.loadx('nutcracker')
     >>> hop_length = 512
     >>> oenv = librosa.onset.onset_strength(y=y, sr=sr, hop_length=hop_length)
 
@@ -893,7 +893,7 @@ def metrogram(
     >>> import numpy as np
     >>> import matplotlib.pyplot as plt
     >>> import librosa
-    >>> y, sr = librosa.load(librosa.ex("sweetwaltz"))
+    >>> y, sr = librosa.loadx("sweetwaltz")
     >>> # extend the window, to capture the slower downbeat pulses
     >>> win_length = 384 * 4
     >>> fourier_tempogram = librosa.feature.fourier_tempogram(y=y, win_length=win_length)

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -124,7 +124,7 @@ def spectral_centroid(
     --------
     From time-series input:
 
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> cent = librosa.feature.spectral_centroid(y=y, sr=sr)
     >>> cent
     array([[1768.888, 1921.774, ..., 5663.477, 5813.683]])
@@ -268,7 +268,7 @@ def spectral_bandwidth(
     --------
     From time-series input
 
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> spec_bw = librosa.feature.spectral_bandwidth(y=y, sr=sr)
     >>> spec_bw
     array([[1273.836, 1228.873, ..., 2952.357, 3013.68 ]])
@@ -438,7 +438,7 @@ def spectral_contrast(
 
     Examples
     --------
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> S = np.abs(librosa.stft(y))
     >>> contrast = librosa.feature.spectral_contrast(S=S, sr=sr)
 
@@ -599,7 +599,7 @@ def spectral_rolloff(
     --------
     From time-series input
 
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> # Approximate maximum frequencies with roll_percent=0.85 (default)
     >>> librosa.feature.spectral_rolloff(y=y, sr=sr)
     array([[2583.984, 3036.182, ..., 9173.145, 9248.511]])
@@ -748,7 +748,7 @@ def spectral_flatness(
     --------
     From time-series input
 
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> flatness = librosa.feature.spectral_flatness(y=y)
     >>> flatness
     array([[0.001, 0.   , ..., 0.218, 0.184]], dtype=float32)
@@ -844,7 +844,7 @@ def rms(
 
     Examples
     --------
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> librosa.feature.rms(y=y)
     array([[1.248e-01, 1.259e-01, ..., 1.845e-05, 1.796e-05]],
           dtype=float32)
@@ -980,7 +980,7 @@ def poly_features(
 
     Examples
     --------
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> S = np.abs(librosa.stft(y))
 
     Fit a degree-0 polynomial (constant) to each frame
@@ -1105,7 +1105,7 @@ def zero_crossing_rate(
 
     Examples
     --------
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> librosa.feature.zero_crossing_rate(y)
     array([[0.044, 0.074, ..., 0.488, 0.355]])
     """
@@ -1220,7 +1220,7 @@ def chroma_stft(
 
     Examples
     --------
-    >>> y, sr = librosa.load(librosa.ex('nutcracker'), duration=15)
+    >>> y, sr = librosa.loadx('nutcracker', duration=15)
     >>> librosa.feature.chroma_stft(y=y, sr=sr)
     array([[1.   , 0.962, ..., 0.143, 0.278],
            [0.688, 0.745, ..., 0.103, 0.162],
@@ -1354,7 +1354,7 @@ def chroma_cqt(
     --------
     Compare a long-window STFT chromagram to the CQT chromagram
 
-    >>> y, sr = librosa.load(librosa.ex('nutcracker'), duration=15)
+    >>> y, sr = librosa.loadx('nutcracker', duration=15)
     >>> chroma_stft = librosa.feature.chroma_stft(y=y, sr=sr,
     ...                                           n_chroma=12, n_fft=4096)
     >>> chroma_cq = librosa.feature.chroma_cqt(y=y, sr=sr)
@@ -1500,7 +1500,7 @@ def chroma_cens(
     --------
     Compare standard cqt chroma to CENS.
 
-    >>> y, sr = librosa.load(librosa.ex('nutcracker'), duration=15)
+    >>> y, sr = librosa.loadx('nutcracker', duration=15)
     >>> chroma_cens = librosa.feature.chroma_cens(y=y, sr=sr)
     >>> chroma_cq = librosa.feature.chroma_cqt(y=y, sr=sr)
 
@@ -1638,7 +1638,7 @@ def chroma_vqt(
     Compare an equal-temperament CQT chromagram to a 5-limit just intonation
     chromagram.  Both use 36 bins per octave.
 
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> n_bins = 36
     >>> chroma_cq = librosa.feature.chroma_cqt(y=y, sr=sr, n_chroma=n_bins)
     >>> chroma_vq = librosa.feature.chroma_vqt(y=y, sr=sr,
@@ -1778,7 +1778,7 @@ def tonnetz(
     --------
     Compute tonnetz features from the harmonic component of a song
 
-    >>> y, sr = librosa.load(librosa.ex('nutcracker'), duration=10, offset=10)
+    >>> y, sr = librosa.loadx('nutcracker', duration=10, offset=10)
     >>> y = librosa.effects.harmonic(y)
     >>> tonnetz = librosa.feature.tonnetz(y=y, sr=sr)
     >>> tonnetz
@@ -1931,7 +1931,7 @@ def mfcc(
     --------
     Generate mfccs from a time series
 
-    >>> y, sr = librosa.load(librosa.ex('libri1'))
+    >>> y, sr = librosa.loadx('libri1')
     >>> librosa.feature.mfcc(y=y, sr=sr)
     array([[-565.919, -564.288, ..., -426.484, -434.668],
            [  10.305,   12.509, ...,   88.43 ,   90.12 ],
@@ -2107,7 +2107,7 @@ def melspectrogram(
 
     Examples
     --------
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> librosa.feature.melspectrogram(y=y, sr=sr)
     array([[3.837e-06, 1.451e-06, ..., 8.352e-14, 1.296e-11],
            [2.213e-05, 7.866e-06, ..., 8.532e-14, 1.329e-11],

--- a/librosa/feature/utils.py
+++ b/librosa/feature/utils.py
@@ -74,7 +74,7 @@ def delta(
     --------
     Compute MFCC deltas, delta-deltas
 
-    >>> y, sr = librosa.load(librosa.ex('libri1'), duration=5)
+    >>> y, sr = librosa.loadx('libri1', duration=5)
     >>> mfcc = librosa.feature.mfcc(y=y, sr=sr)
     >>> mfcc_delta = librosa.feature.delta(mfcc)
     >>> mfcc_delta
@@ -211,7 +211,7 @@ def stack_memory(
 
     Stack time-lagged beat-synchronous chroma edge padding
 
-    >>> y, sr = librosa.load(librosa.ex('sweetwaltz'), duration=10)
+    >>> y, sr = librosa.loadx('sweetwaltz', duration=10)
     >>> chroma = librosa.feature.chroma_cqt(y=y, sr=sr)
     >>> tempo, beats = librosa.beat.beat_track(y=y, sr=sr, hop_length=512)
     >>> beats = librosa.util.fix_frames(beats, x_min=0)

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -785,7 +785,7 @@ def cq_to_chroma(
     --------
     Get a CQT, and wrap bins to chroma
 
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> CQT = np.abs(librosa.cqt(y, sr=sr))
     >>> chroma_map = librosa.filters.cq_to_chroma(CQT.shape[0])
     >>> chromagram = chroma_map.dot(CQT)

--- a/librosa/onset.py
+++ b/librosa/onset.py
@@ -129,7 +129,7 @@ def onset_detect(
     --------
     Get onset times from a signal
 
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> librosa.onset.onset_detect(y=y, sr=sr, units='time')
     array([0.07 , 0.232, 0.395, 0.604, 0.743, 0.929, 1.045, 1.115,
            1.416, 1.672, 1.881, 2.043, 2.206, 2.368, 2.554, 3.019])
@@ -312,7 +312,7 @@ def onset_strength(
     First, load some audio and plot the spectrogram
 
     >>> import matplotlib.pyplot as plt
-    >>> y, sr = librosa.load(librosa.ex('trumpet'), duration=3)
+    >>> y, sr = librosa.loadx('trumpet', duration=3)
     >>> D = np.abs(librosa.stft(y))
     >>> times = librosa.times_like(D, sr=sr)
     >>> fig, ax = plt.subplots(nrows=2, sharex=True)
@@ -398,7 +398,7 @@ def onset_backtrack(events: np.ndarray, energy: np.ndarray) -> np.ndarray:
     --------
     Backtrack the events using the onset envelope
 
-    >>> y, sr = librosa.load(librosa.ex('trumpet'), duration=3)
+    >>> y, sr = librosa.loadx('trumpet', duration=3)
     >>> oenv = librosa.onset.onset_strength(y=y, sr=sr)
     >>> times = librosa.times_like(oenv, sr=sr)
     >>> # Detect events without backtracking
@@ -547,7 +547,7 @@ def onset_strength_multi(
     First, load some audio and plot the spectrogram
 
     >>> import matplotlib.pyplot as plt
-    >>> y, sr = librosa.load(librosa.ex('choice'), duration=5)
+    >>> y, sr = librosa.loadx('choice', duration=5)
     >>> D = np.abs(librosa.stft(y))
     >>> fig, ax = plt.subplots(nrows=2, sharex=True)
     >>> img1 = librosa.display.specshow(D, vscale='dBFS',

--- a/librosa/segment.py
+++ b/librosa/segment.py
@@ -233,8 +233,8 @@ def cross_similarity(
     Find nearest neighbors in CQT space between two sequences
 
     >>> hop_length = 1024
-    >>> y_ref, sr = librosa.load(librosa.ex('pistachio'))
-    >>> y_comp, sr = librosa.load(librosa.ex('pistachio'), offset=10)
+    >>> y_ref, sr = librosa.loadx('pistachio')
+    >>> y_comp, sr = librosa.loadx('pistachio', offset=10)
     >>> chroma_ref = librosa.feature.chroma_cqt(y=y_ref, sr=sr, hop_length=hop_length)
     >>> chroma_comp = librosa.feature.chroma_cqt(y=y_comp, sr=sr, hop_length=hop_length)
     >>> # Use time-delay embedding to get a cleaner recurrence matrix
@@ -559,7 +559,7 @@ def recurrence_matrix(
     --------
     Find nearest neighbors in CQT space
 
-    >>> y, sr = librosa.load(librosa.ex('nutcracker'))
+    >>> y, sr = librosa.loadx('nutcracker')
     >>> hop_length = 1024
     >>> chroma = librosa.feature.chroma_cqt(y=y, sr=sr, hop_length=hop_length)
     >>> # Use time-delay embedding to get a cleaner recurrence matrix
@@ -765,7 +765,7 @@ def recurrence_to_lag(
 
     Examples
     --------
-    >>> y, sr = librosa.load(librosa.ex('nutcracker'))
+    >>> y, sr = librosa.loadx('nutcracker')
     >>> hop_length = 1024
     >>> chroma = librosa.feature.chroma_cqt(y=y, sr=sr, hop_length=hop_length)
     >>> chroma_stack = librosa.feature.stack_memory(chroma, n_steps=10, delay=3)
@@ -850,7 +850,7 @@ def lag_to_recurrence(
 
     Examples
     --------
-    >>> y, sr = librosa.load(librosa.ex('nutcracker'))
+    >>> y, sr = librosa.loadx('nutcracker')
     >>> hop_length = 1024
     >>> chroma = librosa.feature.chroma_cqt(y=y, sr=sr, hop_length=hop_length)
     >>> chroma_stack = librosa.feature.stack_memory(chroma, n_steps=10, delay=3)
@@ -935,7 +935,7 @@ def timelag_filter(function: _F, pad: bool = True, index: int = 0) -> _F:
     With default, parameters, this corresponds to a time window of about
     0.72 seconds.
 
-    >>> y, sr = librosa.load(librosa.ex('nutcracker'), duration=30)
+    >>> y, sr = librosa.loadx('nutcracker', duration=30)
     >>> chroma = librosa.feature.chroma_cqt(y=y, sr=sr)
     >>> chroma_stack = librosa.feature.stack_memory(chroma, n_steps=3, delay=3)
     >>> rec = librosa.segment.recurrence_matrix(chroma_stack)
@@ -1028,7 +1028,7 @@ def subsegment(
     --------
     Load audio, detect beat frames, and subdivide in twos by CQT
 
-    >>> y, sr = librosa.load(librosa.ex('choice'), duration=6.5)
+    >>> y, sr = librosa.loadx('choice', duration=6.5)
     >>> tempo, beats = librosa.beat.beat_track(y=y, sr=sr, hop_length=512)
     >>> beat_times = librosa.frames_to_time(beats, sr=sr, hop_length=512)
     >>> cqt = np.abs(librosa.cqt(y, sr=sr, bins_per_octave=36, n_bins=36*7, hop_length=512))
@@ -1114,7 +1114,7 @@ def agglomerative(
     --------
     Cluster by chroma similarity, break into 20 segments
 
-    >>> y, sr = librosa.load(librosa.ex('nutcracker'), duration=15)
+    >>> y, sr = librosa.loadx('nutcracker', duration=15)
     >>> chroma = librosa.feature.chroma_cqt(y=y, sr=sr)
     >>> bounds = librosa.segment.agglomerative(chroma, 20)
     >>> bound_times = librosa.frames_to_time(bounds, sr=sr)
@@ -1270,7 +1270,7 @@ def path_enhance(
     --------
     Use a 51-frame diagonal smoothing filter to enhance paths in a recurrence matrix
 
-    >>> y, sr = librosa.load(librosa.ex('nutcracker'))
+    >>> y, sr = librosa.loadx('nutcracker')
     >>> hop_length = 2048
     >>> chroma = librosa.feature.chroma_cqt(y=y, sr=sr, hop_length=hop_length)
     >>> chroma_stack = librosa.feature.stack_memory(chroma, n_steps=10, delay=3)

--- a/librosa/sequence.py
+++ b/librosa/sequence.py
@@ -298,7 +298,7 @@ def dtw(
     --------
     >>> import numpy as np
     >>> import matplotlib.pyplot as plt
-    >>> y, sr = librosa.load(librosa.ex('brahms'), offset=10, duration=15)
+    >>> y, sr = librosa.loadx('brahms', offset=10, duration=15)
     >>> X = librosa.feature.chroma_cens(y=y, sr=sr)
     >>> noise = np.random.rand(X.shape[0], 200)
     >>> Y = np.concatenate((noise, noise, X, noise), axis=1)
@@ -838,7 +838,7 @@ def rqa(
 
     >>> import numpy as np
     >>> import matplotlib.pyplot as plt
-    >>> y, sr = librosa.load(librosa.ex('nutcracker'), duration=30)
+    >>> y, sr = librosa.loadx('nutcracker', duration=30)
     >>> chroma = librosa.feature.chroma_cqt(y=y, sr=sr)
     >>> # Use time-delay embedding to reduce noise
     >>> chroma_stack = librosa.feature.stack_memory(chroma, n_steps=10, delay=3)
@@ -1589,7 +1589,7 @@ def viterbi_discriminative(
     >>> trans = librosa.sequence.transition_loop(25, 0.9)
 
     >>> # Load in audio and make features
-    >>> y, sr = librosa.load(librosa.ex('nutcracker'), duration=15)
+    >>> y, sr = librosa.loadx('nutcracker', duration=15)
     >>> # Suppress percussive elements
     >>> y = librosa.effects.harmonic(y, margin=4)
     >>> chroma = librosa.feature.chroma_cqt(y=y, sr=sr)

--- a/librosa/util/_nnls.py
+++ b/librosa/util/_nnls.py
@@ -120,7 +120,7 @@ def nnls(A: np.ndarray, B: np.ndarray, **kwargs: Any) -> np.ndarray:
     --------
     Approximate a magnitude spectrum from its mel spectrogram
 
-    >>> y, sr = librosa.load(librosa.ex('trumpet'), duration=3)
+    >>> y, sr = librosa.loadx('trumpet', duration=3)
     >>> S = np.abs(librosa.stft(y, n_fft=2048))
     >>> M = librosa.feature.melspectrogram(S=S, sr=sr, power=1)
     >>> mel_basis = librosa.filters.mel(sr=sr, n_fft=2048, n_mels=M.shape[0])

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -155,7 +155,7 @@ def frame(
     --------
     Extract 2048-sample frames from monophonic signal with a hop of 64 samples per frame
 
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> frames = librosa.util.frame(y, frame_length=2048, hop_length=64)
     >>> frames
     array([[-1.407e-03, -2.604e-02, ..., -1.795e-05, -8.108e-06],
@@ -178,7 +178,7 @@ def frame(
 
     Frame a stereo signal:
 
-    >>> y, sr = librosa.load(librosa.ex('trumpet', hq=True), mono=False)
+    >>> y, sr = librosa.loadx('trumpet', mono=False)
     >>> y.shape
     (2, 117601)
     >>> frames = librosa.util.frame(y, frame_length=2048, hop_length=64)
@@ -186,7 +186,7 @@ def frame(
 
     Carve an STFT into fixed-length patches of 32 frames with 50% overlap
 
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> S = np.abs(librosa.stft(y))
     >>> S.shape
     (1025, 230)
@@ -704,7 +704,7 @@ def axis_sort(
     Visualize NMF output for a spectrogram S
 
     >>> # Sort the columns of W by peak frequency bin
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> S = np.abs(librosa.stft(y))
     >>> W, H = librosa.decompose.decompose(S, n_components=64)
     >>> W_sort = librosa.util.axis_sort(W)
@@ -1354,7 +1354,7 @@ def peak_pick(
 
     Examples
     --------
-    >>> y, sr = librosa.load(librosa.ex('trumpet'))
+    >>> y, sr = librosa.loadx('trumpet')
     >>> onset_env = librosa.onset.onset_strength(y=y, sr=sr,
     ...                                          hop_length=512,
     ...                                          aggregate=np.median)
@@ -1696,7 +1696,7 @@ def sync(
     --------
     Beat-synchronous CQT spectra
 
-    >>> y, sr = librosa.load(librosa.ex('choice'))
+    >>> y, sr = librosa.loadx('choice')
     >>> tempo, beats = librosa.beat.beat_track(y=y, sr=sr, trim=False)
     >>> C = np.abs(librosa.cqt(y=y, sr=sr))
     >>> beats = librosa.util.fix_frames(beats)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -852,6 +852,30 @@ def test_load_options(filename, offset, duration, mono, dtype):
     assert np.issubdtype(dtype, y.dtype)
 
 
+@pytest.mark.parametrize("key", ["trumpet"])
+@pytest.mark.parametrize("sr", [8000, 22050, 44100])
+@pytest.mark.parametrize("mono", [False, True])
+@pytest.mark.network
+def test_loadx(key, sr, mono):
+    y, sr_loaded = librosa.loadx(key, sr=sr, mono=mono)
+
+    if sr is not None:
+        assert sr_loaded == sr
+
+    if mono:
+        assert y.ndim == 1
+    else:
+        assert y.ndim == 2
+
+    # Load the same file using the old way
+    hq = True
+    if mono and (sr is not None and sr <= 22050):
+        hq = False
+    y_old, sr_old = librosa.load(librosa.ex(key, hq=hq), sr=sr, mono=mono)
+    assert sr_loaded == sr_old
+    assert np.allclose(y_old, y)
+
+
 @pytest.mark.parametrize("sr", [8000, 11025])
 @pytest.mark.parametrize("dur", [0.25, 1.0])
 def test_get_duration_buffer(sr, dur):


### PR DESCRIPTION
#### Reference Issue
Fixes #2023 


#### What does this implement/fix? Explain your changes.
This PR adds a simple shortcut for `librosa.load(librosa.ex(...), ...)` with a bit of logic to infer whether `hq` is needed depending on sampling rate or mono/stereo.

The examples in docstrings and the gallery have been revised and simplified to use this new helper.

#### Any other comments?

I think it's pretty clear in the docstring that this function is really only intended for our own use.  If there's any way to make it clearer and limit the likelihood of broken copypasta from naive users, I'd be keen for feedback.

Otherwise, I think this should be mergeable when CI turns green.  I'll still do a copilot review to audit the example changes and make sure I didn't flub something.