### PR TITLE
more helpful failure mode in loadx

### DIFF
--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -445,7 +445,12 @@ def loadx(key: str, *, hq: Optional[bool] = None, **kwargs: Any) -> Tuple[np.nda
         else:
             hq = False
 
-    path = example(key, hq=hq)
+    try:
+        path = example(key, hq=hq)
+    except ParameterError as exc:
+        raise ParameterError(f"Could not load example with key '{key}'.  "
+                             "Did you mean to use librosa.load instead of loadx?") from exc
+
     return load(path, **kwargs)
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -876,6 +876,11 @@ def test_loadx(key, sr, mono):
     assert np.allclose(y_old, y)
 
 
+@pytest.mark.xfail(raises=librosa.ParameterError)
+def test_loadx_fail():
+    librosa.loadx("not an example.ogg")
+
+
 @pytest.mark.parametrize("sr", [8000, 11025])
 @pytest.mark.parametrize("dur", [0.25, 1.0])
 def test_get_duration_buffer(sr, dur):


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR just puts a slightly nicer error message on loadx when the given key fails to resolve.  This should help stem off any erroneous copypasta if someone tries to do something like:

```python
librosa.loadx("file.mp3")
```

#### Any other comments?

CI green ⇒ merge