### PR TITLE
Modernize types in `librosa._typing`

### DIFF
--- a/librosa/_typing.py
+++ b/librosa/_typing.py
@@ -1,53 +1,44 @@
-from __future__ import annotations
+# ruff: noqa: PYI047
 
 from collections.abc import Sequence
-from typing import Any, Callable, Generator, List, Literal, Never, Tuple, TypeVar, Union
+from typing import Any, Callable, Generator, Literal, Never
 
 import numpy as np
 import scipy.sparse as sp
 from numpy.typing import ArrayLike
 
 # RNG types
-SeedLike = Union[int, np.integer, Sequence[int], np.random.SeedSequence]
-RNGLike = Union[np.random.Generator, np.random.BitGenerator]
+type SeedLike = int | np.integer | Sequence[int] | np.random.SeedSequence
+type RNGLike = np.random.Generator | np.random.BitGenerator
 
 
-_WindowSpec = Union[str, Tuple[Any, ...], float, Callable[[int], np.ndarray], ArrayLike]
-_T = TypeVar("_T")
-_IterableLike = Union[List[_T], Tuple[_T, ...], Generator[_T, None, None]]
-_SequenceLike = Union[Sequence[_T], np.ndarray]
-_ScalarOrSequence = Union[_T, _SequenceLike[_T]]
+type _WindowSpec = str | tuple[Any, ...] | float | Callable[[int], np.ndarray] | ArrayLike
+type _IterableLike[T] = list[T] | tuple[T, ...] | Generator[T, None, None]
+type _SequenceLike[T] = Sequence[T] | np.ndarray
+type _ScalarOrSequence[T] = T | _SequenceLike[T]
 
 # The following definitions are copied from numpy/_typing/_scalars.py
 # (We don't import them directly from numpy because they're an implementation detail.)
 ###
 ### START COPIED CODE
 ###
-_CharLike_co = Union[str, bytes]
-# The 6 `<X>Like_co` type-aliases below represent all scalars that can be
+type _CharLike_co = str | bytes
+# The `<X>Like_co` type-aliases below represent all scalars that can be
 # coerced into `<X>` (with the casting rule `same_kind`)
-_BoolLike_co = Union[bool, np.bool_]
-_UIntLike_co = Union[_BoolLike_co, "np.unsignedinteger[Any]"]
-_IntLike_co = Union[_BoolLike_co, int, "np.integer[Any]"]
-_FloatLike_co = Union[_IntLike_co, float, "np.floating[Any]"]
-_ComplexLike_co = Union[_FloatLike_co, complex, "np.complexfloating[Any, Any]"]
-_TD64Like_co = Union[_IntLike_co, np.timedelta64]
-
-_NumberLike_co = Union[int, float, complex, "np.number[Any]", np.bool_]
-_ScalarLike_co = Union[
-    int,
-    float,
-    complex,
-    str,
-    bytes,
-    np.generic,
-]
+type _BoolLike_co = bool | np.bool
+type _UIntLike_co = bool | np.unsignedinteger | np.bool
+type _IntLike_co = int | np.integer | np.bool
+type _FloatLike_co = float | np.floating | np.integer | np.bool
+type _ComplexLike_co = complex | np.number | np.bool
+type _NumberLike_co = _ComplexLike_co
+type _TD64Like_co = int | np.timedelta64 | np.integer | np.bool
 # `_VoidLike_co` is technically not a scalar, but it's close enough
-_VoidLike_co = Union[Tuple[Any, ...], np.void]
+type _VoidLike_co = tuple[Any, ...] | np.void
+type _ScalarLike_co = complex | str | bytes | np.generic
 
 
 # Padding modes in general
-_ModeKind = Literal[
+type _ModeKind = Literal[
     "constant",
     "edge",
     "linear_ramp",
@@ -66,7 +57,7 @@ _ModeKind = Literal[
 
 # Padding modes for head/tail padding
 # These rule out padding modes that depend on the entire array
-_STFTPad = Literal[
+type _STFTPad = Literal[
     "constant",
     "edge",
     "linear_ramp",
@@ -75,9 +66,9 @@ _STFTPad = Literal[
     "empty",
 ]
 
-_PadMode = Union[_ModeKind, Callable[..., Any]]
+type _PadMode = _ModeKind | Callable[..., Any]
 
-_PadModeSTFT = Union[_STFTPad, Callable[..., Any]]
+type _PadModeSTFT = _STFTPad | Callable[..., Any]
 
 
 def _ensure_not_reachable(*, __arg: Never):
@@ -89,29 +80,18 @@ def _ensure_not_reachable(*, __arg: Never):
     """
     ...
 
-_SparseMatrix = Union[
-    sp.bsr_matrix,
-    sp.coo_matrix,
-    sp.csc_matrix,
-    sp.csr_matrix,
-    sp.dia_matrix,
-    sp.dok_matrix,
-    sp.lil_matrix,
-]
 
-_SparseArray = Union[
-    sp.bsr_array,
-    sp.coo_array,
-    sp.csc_array,
-    sp.csr_array,
-    sp.dia_array,
-    sp.dok_array,
-    sp.lil_array,
-]
+type _SparseMatrix = (
+    sp.bsr_matrix | sp.coo_matrix | sp.csc_matrix | sp.csr_matrix | sp.dia_matrix | sp.dok_matrix | sp.lil_matrix
+)
+
+type _SparseArray = (
+    sp.bsr_array | sp.coo_array | sp.csc_array | sp.csr_array | sp.dia_array | sp.dok_array | sp.lil_array
+)
 
 # matches the `interp` argument in `scipy.interpolate.interp1d` on all supported SciPy versions
 # https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.interp1d.html
-_InterpKind = Literal[
+type _InterpKind = Literal[
     "linear",
     "nearest",
     "nearest-up",
@@ -125,10 +105,10 @@ _InterpKind = Literal[
 
 
 # DCT normalization modes
-_DCTNorm = Literal["backward", "ortho", "forward"]
-_DCTType = Literal[1, 2, 3, 4]
+type _DCTNorm = Literal["backward", "ortho", "forward"]
+type _DCTType = Literal[1, 2, 3, 4]
 
 # More specialized number types
-_Real = Union[float, "np.integer[Any]", "np.floating[Any]"]
-_Complex = Union[_Real, "np.complexfloating[Any, Any]"]
-_Number = Union[complex, "np.number[Any]"]
+type _Real = float | np.integer[Any] | np.floating[Any]
+type _Complex = _Real | np.complexfloating[Any, Any]
+type _Number = complex | np.number[Any]

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -1842,7 +1842,7 @@ def chirp(
 
     method = "linear" if linear else "logarithmic"
     import scipy.signal
-    y: np.ndarray = scipy.signal.chirp(  # type: ignore[misc,call-overload]
+    y: np.ndarray = scipy.signal.chirp(  # type: ignore[call-overload]
         np.arange(int(duration * sr)) / sr,
         fmin,
         duration,


### PR DESCRIPTION
#### Reference Issue

None that as I'm aware of

#### What does this implement/fix? Explain your changes.

Since you now require `python>=3.12`, the fancy new PEP 695 `type` syntax can be used. Additionally, I synced the copied numpy type aliases with numpy, which have been improved since  ([numpy src](https://github.com/numpy/numpy/blob/c80693c5c1052e9355fe1a1fc6b3f57dec24c89c/numpy/_typing/_scalars.py)).
I also removed some unnecessary quotes around the numpy scalar types in `_typing.py`, because those are no longer needed since NumPy 1.23 if I remember correctly.

#### Any other comments?

The SciPy type aliases reminded me of https://github.com/scipy/scipy-stubs/issues/441. Is that something you'd be interested in here?

