### PR TITLE
Doc check modernizing

### DIFF
--- a/.github/environment-lint.yml
+++ b/.github/environment-lint.yml
@@ -13,14 +13,8 @@ dependencies:
   - matplotlib>=3.10.0
   - ruff
 
-  # Dependencies for velin
-  - numpydoc>=1.1.0
+  - numpydoc>=1.8.0
   - sphinx>=5.1.0
-  - pygments
-  - black
 
   # Stubs
   - scipy-stubs
-
-  - pip:
-    - velin

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -52,7 +52,7 @@ jobs:
     
     - name: Docstring formatting check  
       shell: bash -l {0}
-      run: python -m velin --check librosa
+      run: numpydoc lint librosa/**.py
     
     - name: Type check package
       shell: bash -l {0}

--- a/librosa/__init__.py
+++ b/librosa/__init__.py
@@ -19,7 +19,6 @@ Audio loading
     get_duration
     get_samplerate
 
-
 Time-domain processing
 ----------------------
 .. autosummary::
@@ -31,7 +30,6 @@ Time-domain processing
     mu_compress
     mu_expand
 
-
 Signal generation
 -----------------
 .. autosummary::
@@ -40,7 +38,6 @@ Signal generation
     clicks
     tone
     chirp
-
 
 Spectral representations
 ------------------------
@@ -64,7 +61,6 @@ Spectral representations
 
     magphase
 
-
 Phase recovery
 --------------
 .. autosummary::
@@ -72,7 +68,6 @@ Phase recovery
 
     griffinlim
     griffinlim_cqt
-
 
 Harmonics
 ---------
@@ -84,7 +79,6 @@ Harmonics
     f0_harmonics
 
     phase_vocoder
-
 
 Magnitude scaling
 -----------------
@@ -106,7 +100,6 @@ Magnitude scaling
 
     pcen
 
-
 Time unit conversion
 --------------------
 .. autosummary::
@@ -122,7 +115,6 @@ Time unit conversion
     blocks_to_frames
     blocks_to_samples
     blocks_to_time
-
 
 Frequency unit conversion
 -------------------------
@@ -151,7 +143,6 @@ Frequency unit conversion
     A4_to_tuning
     tuning_to_A4
 
-
 Music notation
 --------------
 .. autosummary::
@@ -174,7 +165,6 @@ Music notation
     pythagorean_intervals
     plimit_intervals
 
-
 Frequency range generation
 --------------------------
 .. autosummary::
@@ -185,7 +175,6 @@ Frequency range generation
     mel_frequencies
     tempo_frequencies
     fourier_tempo_frequencies
-
 
 Pitch and tuning
 ----------------
@@ -198,7 +187,6 @@ Pitch and tuning
     estimate_tuning
     pitch_tuning
     piptrack
-
 
 Miscellaneous
 -------------

--- a/librosa/beat.py
+++ b/librosa/beat.py
@@ -60,28 +60,28 @@ def beat_track(
     Parameters
     ----------
     y : np.ndarray [shape=(..., n)] or None
-        audio time series
+        Audio time series.
 
     sr : number > 0 [scalar]
-        sampling rate of ``y``
+        Sampling rate of ``y``.
 
     onset_envelope : np.ndarray [shape=(..., m)] or None
-        (optional) pre-computed onset strength envelope.
+        (Optional) pre-computed onset strength envelope.
 
     hop_length : int > 0 [scalar]
-        number of audio samples between successive ``onset_envelope`` values
+        Number of audio samples between successive ``onset_envelope`` values.
 
     start_bpm : float > 0 [scalar]
-        initial guess for the tempo estimator (in beats per minute)
+        Initial guess for the tempo estimator (in beats per minute).
 
     tightness : float [scalar]
-        tightness of beat distribution around tempo
+        Tightness of beat distribution around tempo.
 
     trim : bool [scalar]
-        trim leading/trailing beats with weak onsets
+        Trim leading/trailing beats with weak onsets.
 
     bpm : float [scalar] or np.ndarray [shape=(...)]
-        (optional) If provided, use ``bpm`` as the tempo instead of
+        (Optional) if provided, use ``bpm`` as the tempo instead of
         estimating it from ``onsets``.
 
         If multichannel, tempo estimates can be provided for all channels.
@@ -110,7 +110,7 @@ def beat_track(
     Returns
     -------
     tempo : float [scalar, non-negative] or np.ndarray
-        estimated global tempo (in beats per minute)
+        The estimated global tempo (in beats per minute).
 
         If multi-channel and ``bpm`` is not provided, a separate
         tempo will be returned for each channel.
@@ -120,7 +120,7 @@ def beat_track(
             In this case, the array will have a single element and be one-dimensional.
             This is to ensure consistent return types for multi-channel input.
     beats : np.ndarray
-        estimated beat event locations.
+        The estimated beat event locations.
 
         If `sparse=True` (default), beat locations are given in the specified units
         (default is frame indices).
@@ -292,19 +292,19 @@ def plp(
     Parameters
     ----------
     y : np.ndarray [shape=(..., n)] or None
-        audio time series. Multi-channel is supported.
+        Audio time series. Multi-channel is supported.
 
     sr : number > 0 [scalar]
-        sampling rate of ``y``
+        Sampling rate of ``y``.
 
     onset_envelope : np.ndarray [shape=(..., n)] or None
-        (optional) pre-computed onset strength envelope
+        (Optional) pre-computed onset strength envelope.
 
     hop_length : int > 0 [scalar]
-        number of audio samples between successive ``onset_envelope`` values
+        Number of audio samples between successive ``onset_envelope`` values.
 
     win_length : int > 0 [scalar]
-        number of frames to use for tempogram analysis.
+        Number of frames to use for tempogram analysis.
         By default, 384 frames (at ``sr=22050`` and ``hop_length=512``) corresponds
         to about 8.9 seconds.
 

--- a/librosa/beat.py
+++ b/librosa/beat.py
@@ -454,7 +454,7 @@ def plp(
 def __beat_tracker(
     onset_envelope: np.ndarray, bpm: np.ndarray, frame_rate: float, tightness: float, trim: bool
 ) -> np.ndarray:
-    """Tracks beats in an onset strength envelope.
+    """Track beats in an onset strength envelope.
 
     Parameters
     ----------

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -74,7 +74,7 @@ def load(
 
     Parameters
     ----------
-    path : string, int, pathlib.Path, soundfile.SoundFile, or file-like object
+    path : str, int, pathlib.Path, soundfile.SoundFile, or file-like object
         path to the input file.
 
         Any codec supported by `soundfile` will work.
@@ -253,7 +253,7 @@ def stream(
 
     Parameters
     ----------
-    path : string, int, sf.SoundFile, or file-like object
+    path : str, int, sf.SoundFile, or file-like object
         path to the input file to stream.
 
         Any codec supported by `soundfile` is permitted here.
@@ -987,8 +987,7 @@ def get_duration(
     center: bool = True,
     path: str | os.PathLike[Any] | None = None,
 ) -> float:
-    """Compute the duration (in seconds) of an audio time series,
-    feature matrix, or filename.
+    """Compute the duration (in seconds) of an audio time series, feature matrix, or filename.
 
     Examples
     --------
@@ -1033,7 +1032,7 @@ def get_duration(
     hop_length : int > 0 [ scalar]
         number of audio samples between columns of ``S``
 
-    center : boolean
+    center : bool
         - If ``True``, ``S[:, t]`` is centered at ``y[t * hop_length]``
         - If ``False``, then ``S[:, t]`` begins at ``y[t * hop_length]``
 
@@ -1090,7 +1089,7 @@ def get_samplerate(path: str | int | sf.SoundFile | BinaryIO) -> float:
 
     Parameters
     ----------
-    path : string, int, soundfile.SoundFile, or file-like
+    path : str, int, soundfile.SoundFile, or file-like
         The path to the file to be loaded
         As in ``load``, this can also be an integer or open file-handle
         that can be processed by `soundfile`.
@@ -1258,7 +1257,6 @@ def lpc(y: np.ndarray, *, order: int, axis: int = -1) -> np.ndarray:
     >>> ax.plot(y_hat, linestyle='--')
     >>> ax.legend(['y', 'y_hat'])
     >>> ax.set_title('LP Model Forward Prediction')
-
     """
     if not util.is_positive_int(order):
         raise ParameterError(f"order={order} must be an integer > 0")
@@ -1427,8 +1425,7 @@ def zero_crossings(
     zero_pos: bool = True,
     axis: int = -1,
 ) -> np.ndarray:
-    """Find the zero-crossings of a signal ``y``: indices ``i`` such that
-    ``sign(y[i]) != sign(y[j])``.
+    """Find the zero-crossings of a signal ``y``: indices ``i`` such that ``sign(y[i]) != sign(y[j])``.
 
     If ``y`` is multi-dimensional, then zero-crossings are computed along
     the specified ``axis``.
@@ -1448,10 +1445,10 @@ def zero_crossings(
         If callable, the threshold is scaled relative to
         ``ref_magnitude(np.abs(y))``.
 
-    pad : boolean
+    pad : bool
         If ``True``, then ``y[0]`` is considered a valid zero-crossing.
 
-    zero_pos : boolean
+    zero_pos : bool
         If ``True`` then the value 0 is interpreted as having positive sign.
 
         If ``False``, then 0, -1, and +1 all have distinct signs.
@@ -1461,7 +1458,7 @@ def zero_crossings(
 
     Returns
     -------
-    zero_crossings : np.ndarray [shape=y.shape, dtype=boolean]
+    zero_crossings : np.ndarray [shape=y.shape, dtype=bool]
         Indicator array of zero-crossings in ``y`` along the selected axis.
 
     Notes
@@ -1773,7 +1770,7 @@ def chirp(
         When both ``duration`` and ``length`` are defined,
         ``length`` takes priority.
 
-    linear : boolean
+    linear : bool
         - If ``True``, use a linear sweep, i.e., frequency changes linearly with time
         - If ``False``, use a exponential sweep.
 
@@ -1856,7 +1853,7 @@ def chirp(
 def mu_compress(
     x: np.ndarray | _FloatLike_co, *, mu: float = 255, quantize: bool = True
 ) -> np.ndarray:
-    """mu-law compression
+    """Compression by μ-law
 
     Given an input signal ``-1 <= x <= 1``, the mu-law compression
     is calculated by::
@@ -1948,7 +1945,7 @@ def mu_compress(
 def mu_expand(
     x: np.ndarray | _FloatLike_co, *, mu: float = 255.0, quantize: bool = True
 ) -> _ScalarOrSequence[_FloatLike_co]:
-    """mu-law expansion
+    """Expansion by μ-law
 
     This function is the inverse of ``mu_compress``. Given a mu-law compressed
     signal ``-1 <= x <= 1``, the mu-law expansion is calculated by::
@@ -1963,7 +1960,7 @@ def mu_expand(
     mu : positive number
         The compression parameter.  Values of the form ``2**n - 1``
         (e.g., 15, 31, 63, etc.) are most common.
-    quantize : boolean
+    quantize : bool
         If ``True``, the input is assumed to be quantized to
         ``1 + mu`` distinct integer values.
 

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -119,12 +119,12 @@ def cqt(
         If ``False``, do not scale the CQT. This is analogous to
         ``norm=None`` in FFT.
 
-    pad_mode : string
+    pad_mode : str
         Padding mode for centered frame analysis.
 
         See also: `librosa.stft` and `numpy.pad`.
 
-    res_type : string
+    res_type : str
         The resampling mode for recursive downsampling.
 
     dtype : np.dtype
@@ -280,12 +280,12 @@ def hybrid_cqt(
         If ``False``, do not scale the CQT. This is analogous to
         ``norm=None`` in FFT.
 
-    pad_mode : string
+    pad_mode : str
         Padding mode for centered frame analysis.
 
         See also: `librosa.stft` and `numpy.pad`.
 
-    res_type : string
+    res_type : str
         Resampling mode.  See `librosa.cqt` for details.
 
     dtype : np.dtype, optional
@@ -465,7 +465,7 @@ def pseudo_cqt(
         If ``False``, do not scale the CQT. This is analogous to
         ``norm=None`` in FFT.
 
-    pad_mode : string
+    pad_mode : str
         Padding mode for centered frame analysis.
 
         See also: `librosa.stft` and `numpy.pad`.
@@ -619,7 +619,7 @@ def icqt(
         If provided, the output ``y`` is zero-padded or clipped to exactly
         ``length`` samples.
 
-    res_type : string
+    res_type : str
         Resampling mode.
         See `librosa.resample` for supported modes.
 
@@ -883,12 +883,12 @@ def vqt(
         If ``False``, do not scale the VQT. This is analogous to
         ``norm=None`` in FFT.
 
-    pad_mode : string
+    pad_mode : str
         Padding mode for centered frame analysis.
 
         See also: `librosa.stft` and `numpy.pad`.
 
-    res_type : string
+    res_type : str
         The resampling mode for recursive downsampling.
 
     dtype : np.dtype
@@ -1236,8 +1236,7 @@ def griffinlim_cqt(
     rng: RNGLike | SeedLike | None = None,
     random_state: int | np.random.RandomState | np.random.Generator | Deprecated | None = Deprecated(),
 ) -> np.ndarray:
-    """Approximate constant-Q magnitude spectrogram inversion using the "fast" Griffin-Lim
-    algorithm.
+    """Approximate constant-Q magnitude spectrogram inversion using the "fast" Griffin-Lim algorithm.
 
     Given the magnitude of a constant-Q spectrogram (``C``), the algorithm randomly initializes
     phase estimates, and then alternates forward- and inverse-CQT operations. [#]_
@@ -1305,12 +1304,12 @@ def griffinlim_cqt(
         If ``False``, do not scale the CQT. This is analogous to ``norm=None``
         in FFT.
 
-    pad_mode : string
+    pad_mode : str
         Padding mode for centered frame analysis.
 
         See also: `librosa.stft` and `numpy.pad`.
 
-    res_type : string
+    res_type : str
         The resampling mode for recursive downsampling.
 
         See ``librosa.resample`` for a list of available options.

--- a/librosa/core/convert.py
+++ b/librosa/core/convert.py
@@ -113,8 +113,8 @@ def frames_to_samples(
 
     See Also
     --------
-    frames_to_time : convert frame indices to time values
-    samples_to_frames : convert sample indices to frame indices
+    frames_to_time : Convert frame indices to time values
+    samples_to_frames : Convert sample indices to frame indices
 
     Examples
     --------
@@ -197,8 +197,8 @@ def samples_to_frames(
 
     See Also
     --------
-    samples_to_time : convert sample indices to time values
-    frames_to_samples : convert frame indices to sample indices
+    samples_to_time : Convert sample indices to time values
+    frames_to_samples : Convert frame indices to sample indices
     """
     offset = 0
     if n_fft is not None:
@@ -269,8 +269,8 @@ def frames_to_time(
 
     See Also
     --------
-    time_to_frames : convert time values to frame indices
-    frames_to_samples : convert frame indices to sample indices
+    time_to_frames : Convert time values to frame indices
+    frames_to_samples : Convert frame indices to sample indices
 
     Examples
     --------
@@ -349,8 +349,8 @@ def time_to_frames(
 
     See Also
     --------
-    frames_to_time : convert frame indices to time values
-    time_to_samples : convert time values to sample indices
+    frames_to_time : Convert frame indices to time values
+    time_to_samples : Convert time values to sample indices
 
     Examples
     --------
@@ -400,8 +400,8 @@ def time_to_samples(
 
     See Also
     --------
-    time_to_frames : convert time values to frame indices
-    samples_to_time : convert sample indices to time values
+    time_to_frames : Convert time values to frame indices
+    samples_to_time : Convert sample indices to time values
 
     Examples
     --------
@@ -447,8 +447,8 @@ def samples_to_time(
 
     See Also
     --------
-    samples_to_frames : convert sample indices to frame indices
-    time_to_samples : convert time values to sample indices
+    samples_to_frames : Convert sample indices to frame indices
+    time_to_samples : Convert time values to sample indices
 
     Examples
     --------
@@ -515,7 +515,6 @@ def blocks_to_frames(
     ...                         frame_length=2048, hop_length=512)
     >>> for n, y in enumerate(stream):
     ...     n_frame = librosa.blocks_to_frames(n, block_length=16)
-
     """
     return block_length * np.asanyarray(blocks)[()]
 
@@ -577,7 +576,6 @@ def blocks_to_samples(
     >>> for n, y in enumerate(stream):
     ...     n_sample = librosa.blocks_to_samples(n, block_length=16,
     ...                                          hop_length=512)
-
     """
     frames = blocks_to_frames(blocks, block_length=block_length)
     return frames_to_samples(frames, hop_length=hop_length)
@@ -650,7 +648,6 @@ def blocks_to_time(
     >>> for n, y in enumerate(stream):
     ...     n_time = librosa.blocks_to_time(n, block_length=16,
     ...                                     hop_length=512, sr=sr)
-
     """
     samples = blocks_to_samples(
         blocks, block_length=block_length, hop_length=hop_length
@@ -1134,7 +1131,6 @@ def hz_to_note(
     >>> librosa.hz_to_note(440.0 * (2.0 ** np.linspace(0, 1, 12)),
     ...                    octave=False)
     ['A', 'A#', 'B', 'C', 'C#', 'D', 'E', 'F', 'F#', 'G', 'G#', 'A']
-
     """
     return midi_to_note(hz_to_midi(frequencies), **kwargs)
 
@@ -1429,8 +1425,7 @@ def A4_to_tuning(
 def A4_to_tuning(
     A4: _ScalarOrSequence[_FloatLike_co], *, bins_per_octave: int = 12
 ) -> np.floating[Any] | np.ndarray:
-    """Convert a reference pitch frequency (e.g., ``A4=435``) to a tuning
-    estimation, in fractions of a bin per octave.
+    """Convert a reference pitch frequency (e.g., ``A4=435``) to a tuning estimation, in fractions of a bin per octave.
 
     This is useful for determining the tuning deviation relative to
     A440 of a given frequency, assuming equal temperament. By default,
@@ -1499,9 +1494,7 @@ def tuning_to_A4(
 def tuning_to_A4(
     tuning: _ScalarOrSequence[_FloatLike_co], *, bins_per_octave: int = 12
 ) -> np.floating[Any] | np.ndarray:
-    """Convert a tuning deviation (from 0) in fractions of a bin per
-    octave (e.g., ``tuning=-0.1``) to a reference pitch frequency
-    relative to A440.
+    """Convert a tuning deviation (from 0) to a reference pitch frequency relative to A440.
 
     This is useful if you are working in a non-A440 tuning system
     to determine the reference pitch frequency given a tuning
@@ -1682,7 +1675,6 @@ def mel_frequencies(
              4188.417,   4573.636,   4994.285,   5453.621,
              5955.205,   6502.92 ,   7101.009,   7754.107,
              8467.272,   9246.028,  10096.408,  11025.   ])
-
     """
     # 'Center freqs' of mel bands - uniformly spaced between limits
     min_mel = hz_to_mel(fmin, htk=htk)
@@ -1697,8 +1689,7 @@ def mel_frequencies(
 def tempo_frequencies(
     n_bins: int, *, hop_length: int = 512, sr: float = 22050
 ) -> np.ndarray:
-    """Compute the frequencies (in beats per minute) corresponding
-    to an onset auto-correlation or tempogram matrix.
+    """Compute the frequencies (in beats per minute) corresponding to an onset auto-correlation or tempogram matrix.
 
     Parameters
     ----------
@@ -1735,8 +1726,7 @@ def tempo_frequencies(
 def fourier_tempo_frequencies(
     *, sr: float = 22050, win_length: int = 384, hop_length: int = 512
 ) -> np.ndarray:
-    """Compute the frequencies (in beats per minute) corresponding
-    to a Fourier tempogram matrix.
+    """Compute the frequencies (in beats per minute) corresponding to a Fourier tempogram matrix.
 
     Parameters
     ----------
@@ -2259,7 +2249,8 @@ def multi_frequency_weighting(
         One or more frequencies (in Hz)
     kinds : list or tuple or str
         An iterable of weighting kinds. e.g. `('Z', 'B')`, `'ZAD'`, `'C'`
-    **kwargs : keywords to pass to the weighting function.
+    **kwargs
+        Additional arguments to pass to the weighting function.
 
     Returns
     -------
@@ -2935,7 +2926,7 @@ def hz_to_svara_c(
     Sa : positive number
         Frequency (in Hz) of the reference Sa.
 
-    mela : int [1, 72] or string
+    mela : int [1, 72] or str
         The melakarta raga to use.
 
     abbr : bool
@@ -3120,8 +3111,7 @@ def hz_to_fjs(
     unison: str | None = None,
     unicode: bool = False,
 ) -> str | np.ndarray:
-    """Convert one or more frequencies (in Hz) from a just intonation
-    scale to notes in FJS notation.
+    """Convert one or more frequencies (in Hz) from a just intonation scale to notes in FJS notation.
 
     Parameters
     ----------
@@ -3168,7 +3158,6 @@ def hz_to_fjs(
     array(['A', 'B♭₅', 'B', 'C₅', 'C♯⁵', 'D', 'D♯⁵', 'E', 'F₅', 'F♯⁵', 'G₅',
        'G♯⁵', 'A', 'B♭₅', 'B', 'C₅', 'C♯⁵', 'D', 'D♯⁵', 'E', 'F₅', 'F♯⁵',
        'G₅', 'G♯⁵'], dtype='<U3')
-
     """
     if fmin is None:
         # mypy doesn't know that min can handle scalars

--- a/librosa/core/harmonic.py
+++ b/librosa/core/harmonic.py
@@ -322,8 +322,7 @@ def f0_harmonics(
     fill_value: float = 0,
     axis: int = -2,
 ) -> np.ndarray:
-    """Compute the energy at selected harmonics of a time-varying
-    fundamental frequency.
+    """Compute the energy at selected harmonics of a time-varying fundamental frequency.
 
     This function can be used to reduce a `frequency * time` representation
     to a `harmonic * time` representation, effectively normalizing out for

--- a/librosa/core/notation.py
+++ b/librosa/core/notation.py
@@ -321,7 +321,7 @@ def mela_to_svara(
 
     Returns
     -------
-    svara : list of strings
+    svara : list of str
 
         The svara names for each of the 12 pitch classes.
 
@@ -622,8 +622,7 @@ def __mode_to_key(signature: str, unicode: bool = True) -> str:
 
 @cache(level=10)
 def key_to_notes(key: str, *, unicode: bool = True, natural: bool= False) -> list[str]:
-    """List all 12 note names in the chromatic scale, as spelled according to
-    a given key (major or minor) or mode (see below for details and accepted abbreviations).
+    """List all 12 chromatic note names, as spelled according to a given key or mode.
 
     This function exists to resolve enharmonic equivalences between different
     spellings for the same pitch (e.g. C♯ vs D♭), and is primarily useful when producing
@@ -641,7 +640,7 @@ def key_to_notes(key: str, *, unicode: bool = True, natural: bool= False) -> lis
 
     Parameters
     ----------
-    key : string
+    key : str
         Must be in the form TONIC:key.  Tonic must be upper case (``CDEFGAB``),
         key must be lower-case
         (``major``, ``minor``, ``ionian``, ``dorian``, ``phrygian``, ``lydian``,
@@ -911,7 +910,6 @@ def key_to_degrees(key: str) -> np.ndarray:
 
     >>> librosa.key_to_degrees('A:min')
     array([ 9, 11,  0,  2,  4,  5,  7])
-
     """
     notes = dict(
         maj=np.array([0, 2, 4, 5, 7, 9, 11]), min=np.array([0, 2, 3, 5, 7, 8, 10])
@@ -940,8 +938,7 @@ def key_to_degrees(key: str) -> np.ndarray:
 
 @cache(level=10)
 def fifths_to_note(*, unison: str, fifths: int, unicode: bool = True) -> str:
-    """Calculate the note name for a given number of perfect fifths
-    from a specified unison.
+    """Calculate the note name for a given number of perfect fifths from a specified unison.
 
     This function is primarily intended as a utility routine for
     Functional Just System (FJS) notation conversions.
@@ -956,7 +953,7 @@ def fifths_to_note(*, unison: str, fifths: int, unicode: bool = True) -> str:
         The name of the starting (unison) note, e.g., 'C' or 'Bb'.
         Unicode accidentals are supported.
 
-    fifths : integer
+    fifths : int
         The number of perfect fifths to deviate from unison.
 
     unicode : bool
@@ -981,7 +978,6 @@ def fifths_to_note(*, unison: str, fifths: int, unicode: bool = True) -> str:
 
     >>> librosa.fifths_to_note(unison='Eb', fifths=11, unicode=False)
     'G#'
-
     """
     # Starting the circle of fifths at F makes accidentals easier to count
     COFMAP = "FCGDAEB"
@@ -1200,7 +1196,6 @@ def interval_to_fjs(
 
     >>> librosa.interval_to_fjs([3/2, 4/3, 5/3])
     array(['G', 'F', 'A⁵'], dtype='<U2')
-
     """
     # suppressing the type check here because mypy won't introspect through
     # numpy vectorization

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -112,8 +112,7 @@ def estimate_tuning(
 def pitch_tuning(
     frequencies: ArrayLike, *, resolution: float = 0.01, bins_per_octave: int = 12
 ) -> float:
-    """Given a collection of pitches, estimate its tuning offset
-    (in fractions of a bin) relative to A440=440.0Hz.
+    """Given a collection of pitches, estimate its tuning offset relative to A440=440.0Hz.
 
     Parameters
     ----------
@@ -219,18 +218,18 @@ def piptrack(
     hop_length : int > 0 [scalar] or None
         number of samples to hop
 
+    fmin : float > 0 [scalar]
+        lower frequency cutoff.
+
+    fmax : float > 0 [scalar]
+        upper frequency cutoff.
+
     threshold : float in `(0, 1)`
         A bin in spectrum ``S`` is considered a pitch when it is greater than
         ``threshold * ref(S)``.
 
         By default, ``ref(S)`` is taken to be ``max(S, axis=0)`` (the maximum value in
         each column).
-
-    fmin : float > 0 [scalar]
-        lower frequency cutoff.
-
-    fmax : float > 0 [scalar]
-        upper frequency cutoff.
 
     win_length : int <= n_fft [scalar]
         Each frame of audio is windowed by ``window``.
@@ -239,7 +238,7 @@ def piptrack(
 
         If unspecified, defaults to ``win_length = n_fft``.
 
-    window : string, tuple, number, function, or np.ndarray [shape=(n_fft,)]
+    window : str, tuple, number, function, or np.ndarray [shape=(n_fft,)]
         - a window specification (string, tuple, or number);
           see `scipy.signal.get_window`
         - a window function, such as `scipy.signal.windows.hann`
@@ -247,12 +246,12 @@ def piptrack(
 
         .. see also:: `filters.get_window`
 
-    center : boolean
+    center : bool
         - If ``True``, the signal ``y`` is padded so that frame
           ``t`` is centered at ``y[t * hop_length]``.
         - If ``False``, then frame ``t`` begins at ``y[t * hop_length]``
 
-    pad_mode : string
+    pad_mode : str
         If ``center=True``, the padding mode to use at the edges of the signal.
         By default, STFT uses zero-padding.
 
@@ -521,13 +520,13 @@ def yin(
         If ``None``, defaults to ``frame_length // 4``.
     trough_threshold : number > 0 [scalar]
         absolute threshold for peak estimation.
-    center : boolean
+    center : bool
         If ``True``, the signal `y` is padded so that frame
         ``D[:, t]`` is centered at `y[t * hop_length]`.
         If ``False``, then ``D[:, t]`` begins at ``y[t * hop_length]``.
         Defaults to ``True``,  which simplifies the alignment of ``D`` onto a
         time grid by means of ``librosa.core.frames_to_samples``.
-    pad_mode : string or function
+    pad_mode : str or function
         If ``center=True``, this argument is passed to ``np.pad`` for padding
         the edges of the signal ``y``. By default (``pad_mode="constant"``),
         ``y`` is padded on both sides with zeros.
@@ -698,13 +697,13 @@ def pyin(
     fill_na : None, float, or ``np.nan``
         default value for unvoiced frames of ``f0``.
         If ``None``, the unvoiced frames will contain a best guess value.
-    center : boolean
+    center : bool
         If ``True``, the signal ``y`` is padded so that frame
         ``D[:, t]`` is centered at ``y[t * hop_length]``.
         If ``False``, then ``D[:, t]`` begins at ``y[t * hop_length]``.
         Defaults to ``True``,  which simplifies the alignment of ``D`` onto a
         time grid by means of ``librosa.core.frames_to_samples``.
-    pad_mode : string or function
+    pad_mode : str or function
         If ``center=True``, this argument is passed to ``np.pad`` for padding
         the edges of the signal ``y``. By default (``pad_mode="constant"``),
         ``y`` is padded on both sides with zeros.
@@ -719,12 +718,13 @@ def pyin(
 
     Returns
     -------
-    f0: np.ndarray [shape=(..., n_frames)]
+    f0 : np.ndarray [shape=(..., n_frames)]
         time series of fundamental frequencies in Hertz.
-    voiced_flag: np.ndarray [shape=(..., n_frames)]
+    voiced_flag : np.ndarray [shape=(..., n_frames)]
         time series containing boolean flags indicating whether a frame is voiced or not.
-    voiced_prob: np.ndarray [shape=(..., n_frames)]
+    voiced_prob : np.ndarray [shape=(..., n_frames)]
         time series containing the probability that a frame is voiced.
+
     .. note:: If multi-channel input is provided, f0 and voicing are estimated separately for each channel.
 
     See Also

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -725,7 +725,8 @@ def pyin(
     voiced_prob : np.ndarray [shape=(..., n_frames)]
         time series containing the probability that a frame is voiced.
 
-    .. note:: If multi-channel input is provided, f0 and voicing are estimated separately for each channel.
+        .. note:: If multi-channel input is provided, f0 and voicing are estimated
+            separately for each channel.
 
     See Also
     --------

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -123,10 +123,10 @@ def stft(
 
         If unspecified, defaults to ``win_length = n_fft``.
 
-    window : string, tuple, number, function, or np.ndarray [shape=(n_fft,)]
+    window : str, tuple, number, function, or np.ndarray [shape=(n_fft,)]
         Either:
 
-        - a window specification (string, tuple, or number);
+        - a window specification (str, tuple, or number);
           see `scipy.signal.get_window`
         - a window function, such as `scipy.signal.windows.hann`
         - a vector or array of length ``n_fft``
@@ -136,7 +136,7 @@ def stft(
 
         .. see also:: `filters.get_window`
 
-    center : boolean
+    center : bool
         If ``True``, the signal ``y`` is padded so that frame
         ``D[:, t]`` is centered at ``y[t * hop_length]``.
 
@@ -153,7 +153,7 @@ def stft(
         Complex numeric type for ``D``.  Default is inferred to match the
         precision of the input signal.
 
-    pad_mode : string or function
+    pad_mode : str or function
         If ``center=True``, this argument is passed to `np.pad` for padding
         the edges of the signal ``y``. By default (``pad_mode="constant"``),
         ``y`` is padded on both sides with zeros.
@@ -441,15 +441,15 @@ def istft(
         However, if an odd frame length was used, you can specify the correct
         length by setting ``n_fft``.
 
-    window : string, tuple, number, function, np.ndarray [shape=(n_fft,)]
-        - a window specification (string, tuple, or number);
+    window : str, tuple, number, function, np.ndarray [shape=(n_fft,)]
+        - a window specification (str, tuple, or number);
           see `scipy.signal.get_window`
         - a window function, such as `scipy.signal.windows.hann`
         - a user-specified window vector of length ``n_fft``
 
         .. see also:: `filters.get_window`
 
-    center : boolean
+    center : bool
         - If ``True``, ``D`` is assumed to have centered frames.
         - If ``False``, ``D`` is assumed to have left-aligned frames.
 
@@ -696,8 +696,8 @@ def __reassign_frequencies(
         Window length. Defaults to ``n_fft``.
         See ``stft`` for details.
 
-    window : string, tuple, number, function, or np.ndarray [shape=(n_fft,)]
-        - a window specification (string, tuple, number);
+    window : str, tuple, number, function, or np.ndarray [shape=(n_fft,)]
+        - a window specification (str, tuple, number);
           see `scipy.signal.get_window`
         - a window function, such as `scipy.signal.windows.hann`
         - a user-specified window vector of length ``n_fft``
@@ -706,7 +706,7 @@ def __reassign_frequencies(
 
         .. see also:: `filters.get_window`
 
-    center : boolean
+    center : bool
         - If ``True``, the signal ``y`` is padded so that frame
           ``S[:, t]`` is centered at ``y[t * hop_length]``.
         - If ``False``, then ``S[:, t]`` begins at ``y[t * hop_length]``.
@@ -715,7 +715,7 @@ def __reassign_frequencies(
         Complex numeric type for ``S``. Default is inferred to match
         the numerical precision of the input signal.
 
-    pad_mode : string
+    pad_mode : str
         If ``center=True``, the padding mode to use at the edges of the signal.
         By default, STFT uses zero padding.
 
@@ -859,8 +859,8 @@ def __reassign_times(
         Window length. Defaults to ``n_fft``.
         See `stft` for details.
 
-    window : string, tuple, number, function, or np.ndarray [shape=(n_fft,)]
-        - a window specification (string, tuple, number);
+    window : str, tuple, number, function, or np.ndarray [shape=(n_fft,)]
+        - a window specification (str, tuple, number);
           see `scipy.signal.get_window`
         - a window function, such as `scipy.signal.windows.hann`
         - a user-specified window vector of length ``n_fft``
@@ -869,7 +869,7 @@ def __reassign_times(
 
         .. see also:: `filters.get_window`
 
-    center : boolean
+    center : bool
         - If ``True``, the signal ``y`` is padded so that frame
           ``S[:, t]`` is centered at ``y[t * hop_length]``.
         - If ``False``, then ``S[:, t]`` begins at ``y[t * hop_length]``.
@@ -878,7 +878,7 @@ def __reassign_times(
         Complex numeric type for ``S``. Default is inferred to match
         the precision of the input signal.
 
-    pad_mode : string
+    pad_mode : str
         If ``center=True``, the padding mode to use at the edges of the signal.
         By default, STFT uses zero padding.
 
@@ -1061,8 +1061,8 @@ def reassigned_spectrogram(
         Window length. Defaults to ``n_fft``.
         See `stft` for details.
 
-    window : string, tuple, number, function, or np.ndarray [shape=(n_fft,)]
-        - a window specification (string, tuple, number);
+    window : str, tuple, number, function, or np.ndarray [shape=(n_fft,)]
+        - a window specification (str, tuple, number);
           see `scipy.signal.get_window`
         - a window function, such as `scipy.signal.windows.hann`
         - a user-specified window vector of length ``n_fft``
@@ -1071,19 +1071,19 @@ def reassigned_spectrogram(
 
         .. see also:: `filters.get_window`
 
-    center : boolean
+    center : bool
         - If ``True`` (default), the signal ``y`` is padded so that frame
           ``S[:, t]`` is centered at ``y[t * hop_length]``. See `Notes` for
           recommended usage in this function.
         - If ``False``, then ``S[:, t]`` begins at ``y[t * hop_length]``.
 
-    reassign_frequencies : boolean
+    reassign_frequencies : bool
         - If ``True`` (default), the returned frequencies will be instantaneous
           frequency estimates.
         - If ``False``, the returned frequencies will be a read-only view of the
           STFT bin frequencies for all frames.
 
-    reassign_times : boolean
+    reassign_times : bool
         - If ``True`` (default), the returned times will be corrected
           (reassigned) time estimates for each bin.
         - If ``False``, the returned times will be a read-only view of the STFT
@@ -1096,14 +1096,14 @@ def reassigned_spectrogram(
         is provided, then only bins with zero power will be returned as
         `np.nan` (unless ``fill_nan=True``).
 
-    fill_nan : boolean
+    fill_nan : bool
         - If ``False`` (default), the frequency and time reassignments for bins
           below the power threshold provided in ``ref_power`` will be returned as
           `np.nan`.
         - If ``True``, the frequency and time reassignments for these bins will
           be returned as the bin center frequencies and frame times.
 
-    clip : boolean
+    clip : bool
         - If ``True`` (default), estimated frequencies outside the range
           `[0, 0.5 * sr]` or times outside the range `[0, len(y) / sr]` will be
           clipped to those ranges.
@@ -1114,7 +1114,7 @@ def reassigned_spectrogram(
         Complex numeric type for STFT calculation. Default is inferred to match
         the precision of the input signal.
 
-    pad_mode : string
+    pad_mode : str
         If ``center=True``, the padding mode to use at the edges of the signal.
         By default, STFT uses zero padding.
 
@@ -1293,8 +1293,7 @@ def reassigned_spectrogram(
 
 
 def magphase(D: np.ndarray, *, power: float = 1) -> tuple[np.ndarray, np.ndarray]:
-    """Separate a complex-valued spectrogram D into its magnitude (S)
-    and phase (P) components, so that ``D = S * P``.
+    """Separate a complex-valued spectrogram D into its magnitude (S) and phase (P) components, so that ``D = S * P``.
 
     Parameters
     ----------
@@ -1569,21 +1568,21 @@ def iirt(
     hop_length : int > 0 [scalar]
         Hop length, number samples between subsequent frames.
         If not supplied, defaults to ``win_length // 4``.
-    center : boolean
+    center : bool
         - If ``True``, the signal ``y`` is padded so that frame
           ``D[..., :, t]`` is centered at ``y[t * hop_length]``.
         - If ``False``, then `D[..., :, t]`` begins at ``y[t * hop_length]``
     tuning : float [scalar]
         Tuning deviation from A440 in fractions of a bin.
-    pad_mode : string
+    pad_mode : str
         If ``center=True``, the padding mode to use at the edges of the signal.
         By default, this function uses zero padding.
-    flayout : string
+    flayout : str
         - If `sos` (default), a series of second-order filters is used for filtering with `scipy.signal.sosfiltfilt`.
           Minimizes numerical precision errors for high-order filters, but is slower.
         - If `ba`, the standard difference equation is used for filtering with `scipy.signal.filtfilt`.
           Can be unstable for high-order filters.
-    res_type : string
+    res_type : str
         The resampling mode.  See `librosa.resample` for details.
     **kwargs : additional keyword arguments
         Additional arguments for `librosa.filters.semitone_filterbank`
@@ -2747,10 +2746,10 @@ def griffinlim(
         By default, this will be inferred from the shape of ``S`` as an even number.
         However, if an odd frame length was used, you can explicitly set ``n_fft``.
 
-    window : string, tuple, number, function, or np.ndarray [shape=(n_fft,)]
+    window : str, tuple, number, function, or np.ndarray [shape=(n_fft,)]
         A window specification as supported by `stft` or `istft`
 
-    center : boolean
+    center : bool
         If ``True``, the STFT is assumed to use centered frames.
         If ``False``, the STFT is assumed to use left-aligned frames.
 
@@ -2762,7 +2761,7 @@ def griffinlim(
         If provided, the output ``y`` is zero-padded or clipped to exactly ``length``
         samples.
 
-    pad_mode : string
+    pad_mode : str
         If ``center=True``, the padding mode to use at the edges of the signal.
         By default, STFT uses zero padding.
 
@@ -2982,20 +2981,20 @@ def _spectrogram(
 
         If unspecified, defaults to ``win_length = n_fft``.
 
-    window : string, tuple, number, function, or np.ndarray [shape=(n_fft,)]
-        - a window specification (string, tuple, or number);
+    window : str, tuple, number, function, or np.ndarray [shape=(n_fft,)]
+        - a window specification (str, tuple, or number);
           see `scipy.signal.get_window`
         - a window function, such as `scipy.signal.windows.hann`
         - a vector or array of length ``n_fft``
 
         .. see also:: `filters.get_window`
 
-    center : boolean
+    center : bool
         - If ``True``, the signal ``y`` is padded so that frame
           ``t`` is centered at ``y[t * hop_length]``.
         - If ``False``, then frame ``t`` begins at ``y[t * hop_length]``
 
-    pad_mode : string
+    pad_mode : str
         If ``center=True``, the padding mode to use at the edges of the signal.
         By default, STFT uses zero padding.
 

--- a/librosa/display.py
+++ b/librosa/display.py
@@ -202,11 +202,9 @@ class TimeFormatter(mplticker.Formatter):
         to `"h"` above 3600 seconds; to `"m"` between 60 and 3600 seconds; to
         `"s"` between 1 and 60 seconds; and to `"ms"` below 1 second.
 
-
     See Also
     --------
     matplotlib.ticker.Formatter
-
 
     Examples
     --------
@@ -376,6 +374,9 @@ class SvaraFormatter(mplticker.Formatter):
 
     Parameters
     ----------
+    Sa : number > 0
+        Frequency (in Hz) of Sa
+
     octave : bool
         If ``True``, display the octave number along with the note name.
 
@@ -386,8 +387,10 @@ class SvaraFormatter(mplticker.Formatter):
 
         If ``False``, ticks are only labeled if the span is less than 2 octaves
 
-    Sa : number > 0
-        Frequency (in Hz) of Sa
+    abbr : bool
+        If ``True``, use abbreviated svara names.
+
+        If ``False``, use full svara names.
 
     mela : str or int
         For Carnatic svara, the index or name of the melakarta raga in question
@@ -405,7 +408,6 @@ class SvaraFormatter(mplticker.Formatter):
     matplotlib.ticker.Formatter
     librosa.hz_to_svara_c
     librosa.hz_to_svara_h
-
 
     Examples
     --------
@@ -475,6 +477,12 @@ class FJSFormatter(mplticker.Formatter):
     ----------
     fmin : float
         The unison frequency for this axis
+
+    n_bins : int > 0
+        The number of frequency bins.
+
+    bins_per_octave : int > 0
+        The number of bins per octave.
 
     intervals : str or array of float in [1, 2)
         The interval specification for the frequency axis.
@@ -621,6 +629,17 @@ class LogHzFormatter(mplticker.Formatter):
 class ChromaFormatter(mplticker.Formatter):
     """A formatter for chroma axes
 
+    Parameters
+    ----------
+    key : str
+        The key in which to display pitch class labels.
+        See `core.midi_to_note` for supported values.
+
+    unicode : bool
+        If ``True``, use unicode symbols for accidentals.
+
+        If ``False``, use ASCII symbols for accidentals.
+
     See Also
     --------
     matplotlib.ticker.Formatter
@@ -654,15 +673,31 @@ class ChromaSvaraFormatter(mplticker.Formatter):
     """A formatter for chroma axes with svara instead of notes.
 
     If mela is given, Carnatic svara names will be used.
-
     Otherwise, Hindustani svara names will be used.
-
     If `Sa` is not given, it will default to 0 (equivalent to `C`).
+
+    Parameters
+    ----------
+    Sa : float or None
+        The MIDI note number corresponding to Sa. If ``None``, defaults to 0 (C).
+
+    mela : str, int, or None
+        For Carnatic svara, the index or name of the melakarta raga.
+        If ``None``, Hindustani svara names are used.
+
+    abbr : bool
+        If ``True``, use abbreviated svara names.
+
+        If ``False``, use full svara names.
+
+    unicode : bool
+        If ``True``, use unicode symbols for accidentals.
+
+        If ``False``, use ASCII symbols for accidentals.
 
     See Also
     --------
     ChromaFormatter
-
     """
 
     Sa: float
@@ -704,6 +739,23 @@ class ChromaSvaraFormatter(mplticker.Formatter):
 
 class ChromaFJSFormatter(mplticker.Formatter):
     """A formatter for chroma axes with functional just notation
+
+    Parameters
+    ----------
+    intervals : str or array of float in [1, 2)
+        The interval specification for the chroma axis.
+        See `core.interval_frequencies` for supported values.
+
+    unison : str
+        The unison (tonic) note name.
+
+    unicode : bool
+        If ``True``, use unicode symbols for accidentals.
+
+        If ``False``, use ASCII symbols for accidentals.
+
+    bins_per_octave : int or None
+        The number of bins per octave. If ``None``, inferred from ``intervals``.
 
     See Also
     --------
@@ -827,6 +879,9 @@ class AdaptiveWaveplot:
     transpose : bool
         If `True`, display the wave vertically instead of horizontally.
 
+    label : str or None
+        An optional label for the waveplot, used in legend entries.
+
     See Also
     --------
     waveshow
@@ -838,7 +893,7 @@ class AdaptiveWaveplot:
     max_samples: int
     transpose: bool
     cid: int | None
-    label_proxy_: WaveplotDecoy
+    label_proxy_: _WaveplotDecoy
 
     def __init__(
         self,
@@ -862,7 +917,7 @@ class AdaptiveWaveplot:
         self._ax_ref: weakref.ref[mplaxes.Axes] | None = None
 
         # This creates an invisible proxy artist to contain the label
-        self.label_proxy_ = WaveplotDecoy(self)
+        self.label_proxy_ = _WaveplotDecoy(self)
         self.label_proxy_.set_in_layout(False)
 
         if label is not None:
@@ -871,17 +926,35 @@ class AdaptiveWaveplot:
     # Preserve the old attribute API by exposing properties with same names
     @property
     def steps(self) -> Line2D | None:
-        """The step plot artist (Line2D), or None if garbage collected."""
+        """The step plot artist (Line2D), or None if garbage collected.
+
+        Returns
+        -------
+        Line2D or None
+            The step plot artist, or ``None`` if it has been garbage collected.
+        """
         return self._steps_ref()
 
     @property
     def envelope(self) -> PolyCollection | None:
-        """The envelope artist (PolyCollection), or None if garbage collected."""
+        """The envelope artist (PolyCollection), or None if garbage collected.
+
+        Returns
+        -------
+        PolyCollection or None
+            The envelope artist, or ``None`` if it has been garbage collected.
+        """
         return self._envelope_ref()
 
     @property
     def ax(self) -> mplaxes.Axes | None:
-        """The connected Axes, or None if not connected or garbage collected."""
+        """The connected Axes, or None if not connected or garbage collected.
+
+        Returns
+        -------
+        matplotlib.axes.Axes or None
+            The connected axes, or ``None`` if not connected or garbage collected.
+        """
         return None if self._ax_ref is None else self._ax_ref()
 
     def __del__(self) -> None:
@@ -998,7 +1071,7 @@ class AdaptiveWaveplot:
         ax.figure.canvas.draw_idle()
 
 
-class WaveplotDecoy(mlines.Line2D):
+class _WaveplotDecoy(mlines.Line2D):
     waveplot: AdaptiveWaveplot
 
     def __init__(self, parent_waveplot: AdaptiveWaveplot, *args: Any, **kwargs: Any):
@@ -1008,7 +1081,7 @@ class WaveplotDecoy(mlines.Line2D):
         self.waveplot = parent_waveplot  # Store reference to the parent wrapper
 
 
-class AdaptiveWaveplotHandler(HandlerBase):
+class _AdaptiveWaveplotHandler(HandlerBase):
     def create_artists(self, legend: Legend,
         orig_handle: Artist,
         xdescent: float,
@@ -1022,7 +1095,7 @@ class AdaptiveWaveplotHandler(HandlerBase):
         Matplotlib automatically passes the exact dimensions and coordinate
         transform (`trans`) needed to paint safely inside the legend key box.
         """
-        orig_handle = cast("WaveplotDecoy", orig_handle)
+        orig_handle = cast("_WaveplotDecoy", orig_handle)
         waveplot = orig_handle.waveplot
         ax = waveplot.ax
         if ax is not None:
@@ -1047,12 +1120,40 @@ class AdaptiveWaveplotHandler(HandlerBase):
 
 
 # Add our custom handler to the default legend handler map
-if WaveplotDecoy not in Legend.get_default_handler_map():
-    Legend.update_default_handler_map({WaveplotDecoy: AdaptiveWaveplotHandler()})
+if _WaveplotDecoy not in Legend.get_default_handler_map():
+    Legend.update_default_handler_map({_WaveplotDecoy: _AdaptiveWaveplotHandler()})
 
 
 class Transformf0(mtransforms.Transform):
-    """A utility class to handle f0-displacement for waveform visualizations."""
+    """A utility class to handle f0-displacement for waveform visualizations.
+
+    Parameters
+    ----------
+    f0 : np.ndarray
+        Array of fundamental frequency values (in Hz), one per frame.
+        Values may be NaN for unvoiced frames.
+
+    sr : number > 0
+        Audio sampling rate, used with ``hop_length`` to compute time stamps.
+
+    hop_length : int > 0
+        Number of audio samples between successive f0 frames.
+
+    bins_per_octave : int > 0
+        Number of bins per octave used for the pitch axis.
+
+    norm : float
+        Normalization factor applied to the pitch axis.
+
+    offset : float
+        Time offset (in seconds) applied to the frame time stamps.
+
+    transpose : bool
+        If ``True``, the time axis is the second dimension instead of the first.
+
+    is_inverted : bool
+        If ``True``, apply the inverse of the f0-displacement transformation.
+    """
 
     f0_interp: scipy.interpolate.interp1d
     norm: float
@@ -1150,7 +1251,13 @@ class Transformf0(mtransforms.Transform):
         return output
 
     def inverted(self) -> Transformf0:
-        """Return the inverse of this transformation."""
+        """Return the inverse of this transformation.
+
+        Returns
+        -------
+        Transformf0
+            A new ``Transformf0`` with ``is_inverted`` toggled.
+        """
         return Transformf0(
             f0=self.f0,
             sr=self.sr,
@@ -1358,24 +1465,13 @@ def specshow(
     data : np.ndarray [shape=(d, n)]
         Matrix to display (e.g., spectrogram)
 
-    sr : number > 0 [scalar]
-        Sample rate used to determine time scale in x-axis.
+    x_coords, y_coords : np.ndarray [shape=data.shape[0 or 1]]
+        Optional positioning coordinates of the input data.
+        These can be use to explicitly set the location of each
+        element ``data[i, j]``, e.g., for displaying beat-synchronous
+        features in natural time coordinates.
 
-    hop_length : int > 0 [scalar]
-        Hop length, also used to determine time scale in x-axis
-
-    n_fft : int > 0 or None
-        Number of samples per frame in STFT/spectrogram displays.
-        By default, this will be inferred from the shape of ``data``
-        as ``2 * (d - 1)``.
-        If ``data`` was generated using an odd frame length, the correct
-        value can be specified here.
-
-    win_length : int > 0 or None
-        The number of samples per window.
-        By default, this will be inferred to match ``n_fft``.
-        This is primarily useful for specifying odd window lengths in
-        Fourier tempogram displays.
+        If not provided, they are inferred from ``x_axis`` and ``y_axis``.
 
     x_axis, y_axis : None or str
         Range for the x- and y-axes.
@@ -1469,14 +1565,6 @@ def specshow(
             tempograms are calculated in the Frequency domain
             using `feature.fourier_tempogram`.
 
-    x_coords, y_coords : np.ndarray [shape=data.shape[0 or 1]]
-        Optional positioning coordinates of the input data.
-        These can be use to explicitly set the location of each
-        element ``data[i, j]``, e.g., for displaying beat-synchronous
-        features in natural time coordinates.
-
-        If not provided, they are inferred from ``x_axis`` and ``y_axis``.
-
     vscale : str
         Optional value transformation for `data`.  The following are supported:
 
@@ -1506,6 +1594,25 @@ def specshow(
             When using phase difference modes (`dphase` or `dphase_t`), the x and y coordinates must be provided
             via either the `x_axis` and `y_axis` parameters (e.g., `'time', 'fft'`), or explicitly by
             the `x_coords` and `y_coords` parameters.  All time-like and frequency-like axes are supported.
+
+    sr : number > 0 [scalar]
+        Sample rate used to determine time scale in x-axis.
+
+    hop_length : int > 0 [scalar]
+        Hop length, also used to determine time scale in x-axis
+
+    n_fft : int > 0 or None
+        Number of samples per frame in STFT/spectrogram displays.
+        By default, this will be inferred from the shape of ``data``
+        as ``2 * (d - 1)``.
+        If ``data`` was generated using an odd frame length, the correct
+        value can be specified here.
+
+    win_length : int > 0 or None
+        The number of samples per window.
+        By default, this will be inferred to match ``n_fft``.
+        This is primarily useful for specifying odd window lengths in
+        Fourier tempogram displays.
 
     fmin : float > 0 [scalar] or None
         Frequency of the lowest spectrogram bin.  Used for Mel, CQT, and VQT
@@ -1550,16 +1657,6 @@ def specshow(
     thaat : str, optional
         If using `chroma_h` display mode, specify the parent thaat.
 
-    intervals : str or array of floats in [1, 2), optional
-        If using an FJS notation (`chroma_fjs`, `vqt_fjs`), the interval specification.
-
-        See `core.interval_frequencies` for a description of supported values.
-
-    unison : str, optional
-        If using an FJS notation (`chroma_fjs`, `vqt_fjs`), the pitch name of the unison
-        interval.  If not provided, it will be inferred from `fmin` (for VQT display) or
-        assumed as `'C'` (for chroma display).
-
     auto_aspect : bool
         Axes will have 'equal' aspect if the horizontal and vertical dimensions
         cover the same extent and their types match.
@@ -1581,6 +1678,16 @@ def specshow(
 
         Setting `unicode=False` will use ASCII glyphs.  This can be helpful
         if your font does not support musical notation symbols.
+
+    intervals : str or array of floats in [1, 2), optional
+        If using an FJS notation (`chroma_fjs`, `vqt_fjs`), the interval specification.
+
+        See `core.interval_frequencies` for a description of supported values.
+
+    unison : str, optional
+        If using an FJS notation (`chroma_fjs`, `vqt_fjs`), the pitch name of the unison
+        interval.  If not provided, it will be inferred from `fmin` (for VQT display) or
+        assumed as `'C'` (for chroma display).
 
     top_db : float
         If using a decibel scale, how many dB below the peak to allow
@@ -2585,7 +2692,7 @@ def waveshow(
     sr : number > 0 [scalar]
         sampling rate of ``y`` (samples per second)
 
-    max_points : positive integer
+    max_points : int > 0
         Maximum number of samples to draw.  When the plot covers a time extent
         smaller than ``max_points / sr`` (default: 1/2 second), samples are drawn.
 
@@ -2620,13 +2727,10 @@ def waveshow(
 
         - `None`, 'none', or 'off': ticks and tick markers are hidden.
 
-    ax : matplotlib.axes.Axes or None
-        Axes to plot on instead of the default `plt.gca()`.
-
     offset : float
         Offset (in seconds) to start the waveform plot
 
-    marker : string
+    marker : str
         Marker symbol to use for sample values. (default: no markers)
 
         See Also: `matplotlib.markers`.
@@ -2639,7 +2743,7 @@ def waveshow(
 
         Default: 'post'
 
-    label : string [optional]
+    label : str or None
         The label string applied to this plot.
         Note that the label
 
@@ -2655,6 +2759,9 @@ def waveshow(
         .. note:: This mask is only used directly by the envelope display, and a raw sample
             display will not be masked.  The `mask` parameter is intended to be used by the
             `wavef0` function, and it is not recommended to be used directly by the user.
+
+    ax : matplotlib.axes.Axes or None
+        Axes to plot on instead of the default `plt.gca()`.
 
     invert : bool
         If `True`, invert the foreground and background of the display, so that the axes background

--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -89,18 +89,50 @@ def hpss(
     ----------
     y : np.ndarray [shape=(..., n)]
         audio time series. Multi-channel is supported.
-    kernel_size
-    power
-    mask
-    margin
-        See `librosa.decompose.hpss`
-    n_fft
-    hop_length
-    win_length
-    window
-    center
-    pad_mode
-        See `librosa.stft`
+
+    kernel_size : int or tuple (kernel_harmonic, kernel_percussive)
+        Kernel size(s) for the median filters.
+
+        - If scalar, the same size is used for both harmonic and percussive.
+        - If tuple, the first value specifies the width of the harmonic filter,
+          and the second value specifies the width of the percussive filter.
+
+    power : float > 0 [scalar]
+        Exponent for the Wiener filter when constructing soft mask matrices.
+
+    mask : bool
+        Return the masking matrices instead of components.
+
+    margin : float or tuple (margin_harmonic, margin_percussive)
+        Margin size(s) for the masks.
+
+        - If scalar, the same size is used for both harmonic and percussive.
+        - If tuple, the first value specifies the margin of the harmonic mask,
+          and the second value specifies the margin of the percussive mask.
+
+    n_fft : int > 0 [scalar]
+        Length of the windowed signal after padding with zeros.
+        The number of rows in the STFT matrix is ``(1 + n_fft/2)``.
+
+    hop_length : int or None
+        Number of audio samples between adjacent STFT columns.
+        If unspecified, defaults to ``win_length // 4``.
+
+    win_length : int or None
+        Each frame of audio is windowed by ``window`` of length ``win_length``
+        and then padded with zeros to match ``n_fft``.
+        If unspecified, defaults to ``win_length = n_fft``.
+
+    window : str, tuple, number, function, or np.ndarray [shape=(n_fft,)]
+        Window specification. See `scipy.signal.get_window` for supported values.
+
+    center : bool
+        If ``True``, the signal is padded so that frame ``t`` is centered
+        at ``y[t * hop_length]``.
+
+    pad_mode : str
+        Padding mode used when ``center=True``.
+        See `numpy.pad` for available modes.
 
     Returns
     -------
@@ -182,18 +214,50 @@ def harmonic(
     ----------
     y : np.ndarray [shape=(..., n)]
         audio time series. Multi-channel is supported.
-    kernel_size
-    power
-    mask
-    margin
-        See `librosa.decompose.hpss`
-    n_fft
-    hop_length
-    win_length
-    window
-    center
-    pad_mode
-        See `librosa.stft`
+
+    kernel_size : int or tuple (kernel_harmonic, kernel_percussive)
+        Kernel size(s) for the median filters.
+
+        - If scalar, the same size is used for both harmonic and percussive.
+        - If tuple, the first value specifies the width of the harmonic filter,
+          and the second value specifies the width of the percussive filter.
+
+    power : float > 0 [scalar]
+        Exponent for the Wiener filter when constructing soft mask matrices.
+
+    mask : bool
+        Return the masking matrices instead of components.
+
+    margin : float or tuple (margin_harmonic, margin_percussive)
+        Margin size(s) for the masks.
+
+        - If scalar, the same size is used for both harmonic and percussive.
+        - If tuple, the first value specifies the margin of the harmonic mask,
+          and the second value specifies the margin of the percussive mask.
+
+    n_fft : int > 0 [scalar]
+        Length of the windowed signal after padding with zeros.
+        The number of rows in the STFT matrix is ``(1 + n_fft/2)``.
+
+    hop_length : int or None
+        Number of audio samples between adjacent STFT columns.
+        If unspecified, defaults to ``win_length // 4``.
+
+    win_length : int or None
+        Each frame of audio is windowed by ``window`` of length ``win_length``
+        and then padded with zeros to match ``n_fft``.
+        If unspecified, defaults to ``win_length = n_fft``.
+
+    window : str, tuple, number, function, or np.ndarray [shape=(n_fft,)]
+        Window specification. See `scipy.signal.get_window` for supported values.
+
+    center : bool
+        If ``True``, the signal is padded so that frame ``t`` is centered
+        at ``y[t * hop_length]``.
+
+    pad_mode : str
+        Padding mode used when ``center=True``.
+        See `numpy.pad` for available modes.
 
     Returns
     -------
@@ -264,18 +328,50 @@ def percussive(
     ----------
     y : np.ndarray [shape=(..., n)]
         audio time series. Multi-channel is supported.
-    kernel_size
-    power
-    mask
-    margin
-        See `librosa.decompose.hpss`
-    n_fft
-    hop_length
-    win_length
-    window
-    center
-    pad_mode
-        See `librosa.stft`
+
+    kernel_size : int or tuple (kernel_harmonic, kernel_percussive)
+        Kernel size(s) for the median filters.
+
+        - If scalar, the same size is used for both harmonic and percussive.
+        - If tuple, the first value specifies the width of the harmonic filter,
+          and the second value specifies the width of the percussive filter.
+
+    power : float > 0 [scalar]
+        Exponent for the Wiener filter when constructing soft mask matrices.
+
+    mask : bool
+        Return the masking matrices instead of components.
+
+    margin : float or tuple (margin_harmonic, margin_percussive)
+        Margin size(s) for the masks.
+
+        - If scalar, the same size is used for both harmonic and percussive.
+        - If tuple, the first value specifies the margin of the harmonic mask,
+          and the second value specifies the margin of the percussive mask.
+
+    n_fft : int > 0 [scalar]
+        Length of the windowed signal after padding with zeros.
+        The number of rows in the STFT matrix is ``(1 + n_fft/2)``.
+
+    hop_length : int or None
+        Number of audio samples between adjacent STFT columns.
+        If unspecified, defaults to ``win_length // 4``.
+
+    win_length : int or None
+        Each frame of audio is windowed by ``window`` of length ``win_length``
+        and then padded with zeros to match ``n_fft``.
+        If unspecified, defaults to ``win_length = n_fft``.
+
+    window : str, tuple, number, function, or np.ndarray [shape=(n_fft,)]
+        Window specification. See `scipy.signal.get_window` for supported values.
+
+    center : bool
+        If ``True``, the signal is padded so that frame ``t`` is centered
+        at ``y[t * hop_length]``.
+
+    pad_mode : str
+        Padding mode used when ``center=True``.
+        See `numpy.pad` for available modes.
 
     Returns
     -------
@@ -347,11 +443,11 @@ def time_stretch(y: np.ndarray, *, rate: float, **kwargs: Any) -> np.ndarray:
     See Also
     --------
     pitch_shift :
-        pitch shifting
+        Pitch shifting
     librosa.phase_vocoder :
-        spectrogram phase vocoder
+        Spectrogram phase vocoder
     pyrubberband.pyrb.time_stretch :
-        high-quality time stretching using RubberBand
+        High-quality time stretching using RubberBand
 
     Examples
     --------
@@ -415,7 +511,7 @@ def pitch_shift(
     bins_per_octave : int > 0 [scalar]
         how many steps per octave
 
-    res_type : string
+    res_type : str
         Resample type. By default, 'soxr_hq' is used.
 
         See `librosa.resample` for more information.
@@ -435,11 +531,11 @@ def pitch_shift(
     See Also
     --------
     time_stretch :
-        time stretching
+        Time stretching
     librosa.phase_vocoder :
-        spectrogram phase vocoder
+        Spectrogram phase vocoder
     pyrubberband.pyrb.pitch_shift :
-        high-quality pitch shifting using RubberBand
+        High-quality pitch shifting using RubberBand
 
     Examples
     --------
@@ -490,7 +586,7 @@ def remix(
         An iterable (list-like or generator) where the ``i``th item
         ``intervals[i]`` indicates the start and end (in samples)
         of a slice of ``y``.
-    align_zeros : boolean
+    align_zeros : bool
         If ``True``, interval boundaries are mapped to the closest
         zero-crossing in ``y``.  If ``y`` is stereo, zero-crossings
         are computed after converting to mono.
@@ -821,7 +917,7 @@ def preemphasis(
 
         By default ``zi`` is initialized as ``2*y[0] - y[1]``.
 
-    return_zf : boolean
+    return_zf : bool
         If ``True``, return the final filter state.
         If ``False``, only return the pre-emphasized signal.
 
@@ -942,7 +1038,7 @@ def deemphasis(
         value corresponds to the transformation of the default initialization of ``zi`` in ``preemphasis()``,
         ``2*x[0] - x[1]``.
 
-    return_zf : boolean
+    return_zf : bool
         If ``True``, return the final filter state.
         If ``False``, only return the pre-emphasized signal.
 

--- a/librosa/feature/inverse.py
+++ b/librosa/feature/inverse.py
@@ -351,7 +351,8 @@ def mfcc_to_audio(
         samples.
     dtype : np.dtype
         Real numeric type for the time-domain signal.  Default is 32-bit float.
-    **kwargs : additional keyword arguments for Mel filter bank parameters
+    **kwargs
+        additional keyword arguments for Mel filter bank parameters
     fmin : float >= 0 [scalar]
         lowest frequency (in Hz)
     fmax : float >= 0 [scalar]

--- a/librosa/feature/inverse.py
+++ b/librosa/feature/inverse.py
@@ -45,7 +45,8 @@ def mel_to_stft(
         number of FFT components in the resulting STFT
     power : float > 0 [scalar]
         Exponent for the magnitude melspectrogram
-    **kwargs : additional keyword arguments for Mel filter bank parameters
+    **kwargs :
+        additional keyword arguments for Mel filter bank parameters
     fmin : float >= 0 [scalar]
         lowest frequency (in Hz)
     fmax : float >= 0 [scalar]
@@ -148,12 +149,12 @@ def mel_to_audio(
         The hop length of the STFT.  If not provided, it will default to ``n_fft // 4``
     win_length : None or int > 0
         The window length of the STFT.  By default, it will equal ``n_fft``
-    window : string, tuple, number, function, or np.ndarray [shape=(n_fft,)]
+    window : str, tuple, number, function, or np.ndarray [shape=(n_fft,)]
         A window specification as supported by `stft` or `istft`
-    center : boolean
+    center : bool
         If `True`, the STFT is assumed to use centered frames.
         If `False`, the STFT is assumed to use left-aligned frames.
-    pad_mode : string
+    pad_mode : str
         If ``center=True``, the padding mode to use at the edges of the signal.
         By default, STFT uses zero padding.
     power : float > 0 [scalar]
@@ -165,7 +166,8 @@ def mel_to_audio(
         samples.
     dtype : np.dtype
         Real numeric type for the time-domain signal.  Default is 32-bit float.
-    **kwargs : additional keyword arguments for Mel filter bank parameters
+    **kwargs :
+        additional keyword arguments for Mel filter bank parameters
     fmin : float >= 0 [scalar]
         lowest frequency (in Hz)
     fmax : float >= 0 [scalar]
@@ -218,8 +220,7 @@ def mfcc_to_mel(
     ref: float = 1.0,
     lifter: float = 0,
 ) -> np.ndarray:
-    """Invert Mel-frequency cepstral coefficients to approximate a Mel power
-    spectrogram.
+    """Invert Mel-frequency cepstral coefficients to approximate a Mel power spectrogram.
 
     This inversion proceeds in two steps:
 
@@ -321,7 +322,8 @@ def mfcc_to_audio(
     lifter : number >= 0
         If ``lifter>0``, apply inverse liftering (inverse cepstral filtering)::
             M[n, :] <- M[n, :] / (1 + sin(pi * (n + 1) / lifter)) * lifter / 2
-    **kwargs : additional keyword arguments to pass through to `mel_to_audio`
+    **kwargs
+        additional keyword arguments to pass through to `mel_to_audio`
     M : np.ndarray [shape=(..., n_mels, n), non-negative]
         The spectrogram as produced by `feature.melspectrogram`
     sr : number > 0 [scalar]
@@ -332,12 +334,12 @@ def mfcc_to_audio(
         The hop length of the STFT.  If not provided, it will default to ``n_fft // 4``
     win_length : None or int > 0
         The window length of the STFT.  By default, it will equal ``n_fft``
-    window : string, tuple, number, function, or np.ndarray [shape=(n_fft,)]
+    window : str, tuple, number, function, or np.ndarray [shape=(n_fft,)]
         A window specification as supported by `stft` or `istft`
-    center : boolean
+    center : bool
         If `True`, the STFT is assumed to use centered frames.
         If `False`, the STFT is assumed to use left-aligned frames.
-    pad_mode : string
+    pad_mode : str
         If ``center=True``, the padding mode to use at the edges of the signal.
         By default, STFT uses zero padding.
     power : float > 0 [scalar]

--- a/librosa/feature/rhythm.py
+++ b/librosa/feature/rhythm.py
@@ -78,7 +78,7 @@ def tempogram(
         If `True`, onset autocorrelation windows are centered.
         If `False`, windows are left-aligned.
 
-    window : string, function, number, tuple, or np.ndarray [shape=(win_length,)]
+    window : str, function, number, tuple, or np.ndarray [shape=(win_length,)]
         A window specification as in `stft`.
 
     norm : {np.inf, -np.inf, 0, float > 0, None}
@@ -201,8 +201,7 @@ def fourier_tempogram(
     center: bool = True,
     window: _WindowSpec = "hann",
 ) -> np.ndarray:
-    """Compute the Fourier tempogram: the short-time Fourier transform of the
-    onset strength envelope. [#]_
+    """Compute the Fourier tempogram: the short-time Fourier transform of the onset strength envelope. [#]_
 
     .. [#] Grosche, Peter, Meinard Müller, and Frank Kurth.
         "Cyclic tempogram - A mid-level tempo representation for music signals."
@@ -226,7 +225,7 @@ def fourier_tempogram(
     center : bool
         If `True`, onset windows are centered.
         If `False`, windows are left-aligned.
-    window : string, function, number, tuple, or np.ndarray [shape=(win_length,)]
+    window : str, function, number, tuple, or np.ndarray [shape=(win_length,)]
         A window specification as in `stft`.
 
     Returns
@@ -576,6 +575,9 @@ def tempogram_ratio(
     factors : np.ndarray
         Multiples of the fundamental tempo (bpm) to estimate.
         If not provided, the factors are as specified above.
+    aggregate : callable [optional]
+        Aggregation function for estimating global tempogram ratio.
+        If `None`, then ratios are estimated independently for each frame.
     prior : scipy.stats.rv_continuous [optional]
         A prior distribution over tempo (in beats per minute).
         By default, a pseudo-log-normal prior is used.
@@ -583,10 +585,7 @@ def tempogram_ratio(
     center : bool
         If `True`, onset windows are centered.
         If `False`, windows are left-aligned.
-    aggregate : callable [optional]
-        Aggregation function for estimating global tempogram ratio.
-        If `None`, then ratios are estimated independently for each frame.
-    window : string, function, number, tuple, or np.ndarray [shape=(win_length,)]
+    window : str, function, number, tuple, or np.ndarray [shape=(win_length,)]
         A window specification as in `stft`.
     kind : str
         Interpolation mode for measuring tempogram ratios
@@ -708,7 +707,7 @@ def hybrid_tempogram(
         Window length for analysis
     center : bool
         Whether to center the frames
-    window : string, tuple, number, function, or np.ndarray [shape=(win_length,)]
+    window : str, tuple, number, function, or np.ndarray [shape=(win_length,)]
         A window specification as supported by `scipy.signal.get_window`
         and `librosa.filters.get_window`.
     **kwargs : additional keyword arguments

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -96,17 +96,17 @@ def spectral_centroid(
         The window will be of length ``win_length`` and then padded
         with zeros to match ``n_fft``.
         If unspecified, defaults to ``win_length = n_fft``.
-    window : string, tuple, number, function, or np.ndarray [shape=(n_fft,)]
-        - a window specification (string, tuple, or number);
+    window : str, tuple, number, function, or np.ndarray [shape=(n_fft,)]
+        - a window specification (str, tuple, or number);
           see `scipy.signal.get_window`
         - a window function, such as `scipy.signal.windows.hann`
         - a vector or array of length ``n_fft``
         .. see also:: `librosa.filters.get_window`
-    center : boolean
+    center : bool
         - If `True`, the signal ``y`` is padded so that frame
           `t` is centered at ``y[t * hop_length]``.
         - If `False`, then frame ``t`` begins at ``y[t * hop_length]``
-    pad_mode : string
+    pad_mode : str
         If ``center=True``, the padding mode to use at the edges of the signal.
         By default, STFT uses zero padding.
 
@@ -234,17 +234,17 @@ def spectral_bandwidth(
         The window will be of length ``win_length`` and then padded
         with zeros to match ``n_fft``.
         If unspecified, defaults to ``win_length = n_fft``.
-    window : string, tuple, number, function, or np.ndarray [shape=(n_fft,)]
-        - a window specification (string, tuple, or number);
+    window : str, tuple, number, function, or np.ndarray [shape=(n_fft,)]
+        - a window specification (str, tuple, or number);
           see `scipy.signal.get_window`
         - a window function, such as `scipy.signal.windows.hann`
         - a vector or array of length ``n_fft``
         .. see also:: `librosa.filters.get_window`
-    center : boolean
+    center : bool
         - If `True`, the signal ``y`` is padded so that frame
           ``t`` is centered at ``y[t * hop_length]``.
         - If ``False``, then frame ``t`` begins at ``y[t * hop_length]``
-    pad_mode : string
+    pad_mode : str
         If ``center=True``, the padding mode to use at the edges of the signal.
         By default, STFT uses zero padding.
     freq : None or np.ndarray [shape=(d,) or shape=(..., d, t)]
@@ -402,17 +402,17 @@ def spectral_contrast(
         The window will be of length `win_length` and then padded
         with zeros to match ``n_fft``.
         If unspecified, defaults to ``win_length = n_fft``.
-    window : string, tuple, number, function, or np.ndarray [shape=(n_fft,)]
-        - a window specification (string, tuple, or number);
+    window : str, tuple, number, function, or np.ndarray [shape=(n_fft,)]
+        - a window specification (str, tuple, or number);
           see `scipy.signal.get_window`
         - a window function, such as `scipy.signal.windows.hann`
         - a vector or array of length ``n_fft``
         .. see also:: `librosa.filters.get_window`
-    center : boolean
+    center : bool
         - If `True`, the signal ``y`` is padded so that frame
           ``t`` is centered at ``y[t * hop_length]``.
         - If `False`, then frame ``t`` begins at ``y[t * hop_length]``
-    pad_mode : string
+    pad_mode : str
         If ``center=True``, the padding mode to use at the edges of the signal.
         By default, STFT uses zero padding.
     freq : None or np.ndarray [shape=(d,)]
@@ -571,17 +571,17 @@ def spectral_rolloff(
         The window will be of length `win_length` and then padded
         with zeros to match ``n_fft``.
         If unspecified, defaults to ``win_length = n_fft``.
-    window : string, tuple, number, function, or np.ndarray [shape=(n_fft,)]
-        - a window specification (string, tuple, or number);
+    window : str, tuple, number, function, or np.ndarray [shape=(n_fft,)]
+        - a window specification (str, tuple, or number);
           see `scipy.signal.get_window`
         - a window function, such as `scipy.signal.windows.hann`
         - a vector or array of length ``n_fft``
         .. see also:: `librosa.filters.get_window`
-    center : boolean
+    center : bool
         - If `True`, the signal ``y`` is padded so that frame
           ``t`` is centered at ``y[t * hop_length]``.
         - If `False`, then frame ``t`` begins at ``y[t * hop_length]``
-    pad_mode : string
+    pad_mode : str
         If ``center=True``, the padding mode to use at the edges of the signal.
         By default, STFT uses zero padding.
     freq : None or np.ndarray [shape=(d,) or shape=(..., d, t)]
@@ -724,17 +724,17 @@ def spectral_flatness(
         The window will be of length `win_length` and then padded
         with zeros to match ``n_fft``.
         If unspecified, defaults to ``win_length = n_fft``.
-    window : string, tuple, number, function, or np.ndarray [shape=(n_fft,)]
-        - a window specification (string, tuple, or number);
+    window : str, tuple, number, function, or np.ndarray [shape=(n_fft,)]
+        - a window specification (str, tuple, or number);
           see `scipy.signal.get_window`
         - a window function, such as `scipy.signal.windows.hann`
         - a vector or array of length ``n_fft``
         .. see also:: `librosa.filters.get_window`
-    center : boolean
+    center : bool
         - If `True`, the signal ``y`` is padded so that frame
           ``t`` is centered at ``y[t * hop_length]``.
         - If `False`, then frame `t` begins at ``y[t * hop_length]``
-    pad_mode : string
+    pad_mode : str
         If ``center=True``, the padding mode to use at the edges of the signal.
         By default, STFT uses zero padding.
     amin : float > 0 [scalar]
@@ -771,7 +771,6 @@ def spectral_flatness(
     >>> S_power = S ** 2
     >>> librosa.feature.spectral_flatness(S=S_power, power=1.0)
     array([[0.001, 0.   , ..., 0.218, 0.184]], dtype=float32)
-
     """
     if amin <= 0:
         raise ParameterError("amin must be strictly positive")
@@ -814,9 +813,10 @@ def rms(
     pad_mode: _PadMode = "constant",
     dtype: DTypeLike = np.float32,
 ) -> np.ndarray:
-    """Compute root-mean-square (RMS) value for each frame, either from the
-    audio samples ``y`` or from a spectrogram ``S``.
+    """Compute root-mean-square (RMS) value for each frame.
 
+    Input can be given either as a time series ``y`` or as a
+    spectrogram magnitude ``S``.
     Computing the RMS value from audio samples is faster as it doesn't require
     a STFT calculation. However, using a spectrogram will give a more accurate
     representation of energy over time because its frames can be windowed,
@@ -877,7 +877,6 @@ def rms(
     >>> S = librosa.magphase(librosa.stft(y, window=np.ones, center=False))[0]
     >>> librosa.feature.rms(S=S)
     >>> plt.show()
-
     """
     if y is not None:
         if center:
@@ -931,8 +930,7 @@ def poly_features(
     order: int = 1,
     freq: np.ndarray | None = None,
 ) -> np.ndarray:
-    """Get coefficients of fitting an nth-order polynomial to the columns
-    of a spectrogram.
+    """Get coefficients of fitting an nth-order polynomial to the columns of a spectrogram.
 
     Parameters
     ----------
@@ -951,17 +949,17 @@ def poly_features(
         The window will be of length `win_length` and then padded
         with zeros to match ``n_fft``.
         If unspecified, defaults to ``win_length = n_fft``.
-    window : string, tuple, number, function, or np.ndarray [shape=(n_fft,)]
-        - a window specification (string, tuple, or number);
+    window : str, tuple, number, function, or np.ndarray [shape=(n_fft,)]
+        - a window specification (str, tuple, or number);
           see `scipy.signal.get_window`
         - a window function, such as `scipy.signal.windows.hann`
         - a vector or array of length ``n_fft``
         .. see also:: `librosa.filters.get_window`
-    center : boolean
+    center : bool
         - If `True`, the signal ``y`` is padded so that frame
           `t` is centered at ``y[t * hop_length]``.
         - If `False`, then frame ``t`` begins at ``y[t * hop_length]``
-    pad_mode : string
+    pad_mode : str
         If ``center=True``, the padding mode to use at the edges of the signal.
         By default, STFT uses zero padding.
     order : int > 0
@@ -1083,7 +1081,8 @@ def zero_crossing_rate(
         If `True`, frames are centered by padding the edges of ``y``.
         This is similar to the padding in `librosa.stft`,
         but uses edge-value copies instead of zero-padding.
-    **kwargs : additional keyword arguments to pass to `librosa.zero_crossings`
+    **kwargs
+        additional keyword arguments to pass to `librosa.zero_crossings`
     threshold : float >= 0
         If specified, values where ``-threshold <= y <= threshold`` are
         clipped to 0.
@@ -1091,7 +1090,7 @@ def zero_crossing_rate(
         If numeric, the threshold is scaled relative to ``ref_magnitude``.
         If callable, the threshold is scaled relative to
         ``ref_magnitude(np.abs(y))``.
-    zero_pos : boolean
+    zero_pos : bool
         If ``True`` then the value 0 is interpreted as having positive sign.
         If ``False``, then 0, -1, and +1 all have distinct signs.
     axis : int
@@ -1180,26 +1179,28 @@ def chroma_stft(
         The window will be of length `win_length` and then padded
         with zeros to match ``n_fft``.
         If unspecified, defaults to ``win_length = n_fft``.
-    window : string, tuple, number, function, or np.ndarray [shape=(n_fft,)]
-        - a window specification (string, tuple, or number);
+    window : str, tuple, number, function, or np.ndarray [shape=(n_fft,)]
+        - a window specification (str, tuple, or number);
           see `scipy.signal.get_window`
         - a window function, such as `scipy.signal.windows.hann`
         - a vector or array of length ``n_fft``
         .. see also:: `librosa.filters.get_window`
-    center : boolean
+    center : bool
         - If `True`, the signal ``y`` is padded so that frame
           ``t`` is centered at ``y[t * hop_length]``.
         - If `False`, then frame ``t`` begins at ``y[t * hop_length]``
-    pad_mode : string
+    pad_mode : str
         If ``center=True``, the padding mode to use at the edges of the signal.
         By default, STFT uses zero padding.
-    tuning : float [scalar] or None.
+    tuning : float [scalar] or None
         Deviation from A440 tuning in fractional chroma bins.
         If `None`, it is automatically estimated.
     n_chroma : int > 0 [scalar]
         Number of chroma bins to produce (12 by default).
-    **kwargs : additional keyword arguments to parameterize chroma filters.
+    **kwargs
+        additional keyword arguments to parameterize chroma filters.
     ctroct : float > 0 [scalar]
+        See `octwidth`
     octwidth : float > 0 or None [scalar]
         ``ctroct`` and ``octwidth`` specify a dominance window:
         a Gaussian weighting centered on ``ctroct`` (in octs, A0 = 27.5Hz)
@@ -1328,7 +1329,7 @@ def chroma_cqt(
     threshold : float
         Pre-normalization energy threshold.  Values below the
         threshold are discarded, resulting in a sparse chromagram.
-    tuning : float [scalar] or None.
+    tuning : float [scalar] or None
         Deviation (in fractions of a CQT bin) from A440 tuning
     n_chroma : int > 0
         Number of chroma bins to produce
@@ -1336,11 +1337,11 @@ def chroma_cqt(
         Number of octaves to analyze above ``fmin``
     window : None or np.ndarray
         Optional window parameter to `filters.cq_to_chroma`
-    bins_per_octave : int > 0, optional
-        Number of bins per octave in the CQT.
         Must be an integer multiple of ``n_chroma``.
         Default: 36 (3 bins per semitone)
         If `None`, it will match ``n_chroma``.
+    bins_per_octave : int > 0, optional
+        Number of bins per octave in the CQT.
     cqt_mode : ['full', 'hybrid']
         Constant-Q transform mode
 
@@ -1469,21 +1470,21 @@ def chroma_cens(
     fmin : float > 0
         minimum frequency to analyze in the CQT.
         Default: `C1 ~= 32.7 Hz`
-    norm : int > 0, +-np.inf, or None
-        Column-wise normalization of the chromagram.
-    tuning : float [scalar] or None.
+    tuning : float [scalar] or None
         Deviation (in fractions of a CQT bin) from A440 tuning
     n_chroma : int > 0
         Number of chroma bins to produce
     n_octaves : int > 0
         Number of octaves to analyze above ``fmin``
-    window : None or np.ndarray
-        Optional window parameter to `filters.cq_to_chroma`
     bins_per_octave : int > 0
         Number of bins per octave in the CQT.
         Default: 36
     cqt_mode : ['full', 'hybrid']
         Constant-Q transform mode
+    window : None or np.ndarray
+        Optional window parameter to `filters.cq_to_chroma`
+    norm : int > 0, +-np.inf, or None
+        Column-wise normalization of the chromagram.
     win_len_smooth : int > 0 or None
         Length of temporal smoothing window. `None` disables temporal smoothing.
         Default: 41
@@ -1610,7 +1611,7 @@ def chroma_vqt(
         minimum frequency to analyze in the CQT.
         Default: `C1 ~= 32.7 Hz`
     intervals : str or array of floats in [1, 2)
-        Either a string specification for an interval set, e.g.,
+        Either a str specification for an interval set, e.g.,
         `'equal'`, `'pythagorean'`, `'ji3'`, etc. or an array of
         intervals expressed as numbers between 1 and 2.
         .. see also:: librosa.interval_frequencies
@@ -1746,7 +1747,7 @@ def tonnetz(
     threshold : float
         Pre-normalization energy threshold.  Values below the
         threshold are discarded, resulting in a sparse chromagram.
-    tuning : float [scalar] or None.
+    tuning : float [scalar] or None
         Deviation (in fractions of a CQT bin) from A440 tuning
     n_chroma : int > 0
         Number of chroma bins to produce
@@ -1880,9 +1881,10 @@ def mfcc(
             M[n, :] <- M[n, :] * (1 + sin(pi * (n + 1) / lifter) * lifter / 2)
         Setting ``lifter >= 2 * n_mfcc`` emphasizes the higher-order coefficients.
         As ``lifter`` increases, the coefficient weighting becomes approximately linear.
-    mel_norm : `norm` argument to `melspectrogram`
-    **kwargs : additional keyword arguments to `melspectrogram`
-        if operating on time series input
+    mel_norm : float, 'slaney', or None
+        `norm` argument to `melspectrogram`
+    **kwargs
+        additional keyword arguments to `melspectrogram` if operating on time series input
     n_fft : int > 0 [scalar]
         length of the FFT window
     hop_length : int > 0 [scalar]
@@ -1893,17 +1895,17 @@ def mfcc(
         The window will be of length `win_length` and then padded
         with zeros to match ``n_fft``.
         If unspecified, defaults to ``win_length = n_fft``.
-    window : string, tuple, number, function, or np.ndarray [shape=(n_fft,)]
-        - a window specification (string, tuple, or number);
+    window : str, tuple, number, function, or np.ndarray [shape=(n_fft,)]
+        - a window specification (str, tuple, or number);
         see `scipy.signal.get_window`
         - a window function, such as `scipy.signal.windows.hann`
         - a vector or array of length ``n_fft``
         .. see also:: `librosa.filters.get_window`
-    center : boolean
+    center : bool
         - If `True`, the signal ``y`` is padded so that frame
         ``t`` is centered at ``y[t * hop_length]``.
         - If `False`, then frame ``t`` begins at ``y[t * hop_length]``
-    pad_mode : string
+    pad_mode : str
         If ``center=True``, the padding mode to use at the edges of the signal.
         By default, STFT uses zero padding.
     power : float > 0 [scalar]
@@ -2064,23 +2066,24 @@ def melspectrogram(
         The window will be of length `win_length` and then padded
         with zeros to match ``n_fft``.
         If unspecified, defaults to ``win_length = n_fft``.
-    window : string, tuple, number, function, or np.ndarray [shape=(n_fft,)]
-        - a window specification (string, tuple, or number);
+    window : str, tuple, number, function, or np.ndarray [shape=(n_fft,)]
+        - a window specification (str, tuple, or number);
           see `scipy.signal.get_window`
         - a window function, such as `scipy.signal.windows.hann`
         - a vector or array of length ``n_fft``
         .. see also:: `librosa.filters.get_window`
-    center : boolean
+    center : bool
         - If `True`, the signal ``y`` is padded so that frame
           ``t`` is centered at ``y[t * hop_length]``.
         - If `False`, then frame ``t`` begins at ``y[t * hop_length]``
-    pad_mode : string
+    pad_mode : str
         If ``center=True``, the padding mode to use at the edges of the signal.
         By default, STFT uses zero padding.
     power : float > 0 [scalar]
         Exponent for the magnitude melspectrogram.
         e.g., 1 for energy, 2 for power, etc.
-    **kwargs : additional keyword arguments for Mel filter bank parameters
+    **kwargs
+        additional keyword arguments for Mel filter bank parameters
     n_mels : int > 0 [scalar]
         number of Mel bands to generate
     fmin : float >= 0 [scalar]

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -1911,7 +1911,8 @@ def mfcc(
     power : float > 0 [scalar]
         Exponent applied to the spectrum before calculating the melspectrogram when the input is a time signal,
         e.g. 1 for magnitude, 2 for power **(default)**, etc.
-    **kwargs : additional keyword arguments for Mel filter bank parameters
+    **kwargs
+        additional keyword arguments for Mel filter bank parameters
     n_mels : int > 0 [scalar]
         number of Mel bands to generate
     fmin : float >= 0 [scalar]

--- a/librosa/feature/utils.py
+++ b/librosa/feature/utils.py
@@ -27,8 +27,7 @@ def delta(
     mode: Literal["interp", "nearest", "mirror", "constant", "wrap"] = "interp",
     **kwargs: Any,
 ) -> np.ndarray:
-    r"""Compute delta features: local estimate of the derivative
-    of the input data along the selected axis.
+    r"""Compute delta features: local estimate of the derivative of the input data along the selected axis.
 
     Delta features are computed Savitsky-Golay filtering.
 
@@ -135,8 +134,7 @@ def delta(
 def stack_memory(
     data: np.ndarray, *, n_steps: int = 2, delay: int = 1, **kwargs: Any
 ) -> np.ndarray:
-    """Short-term history embedding: vertically concatenate a data
-    vector or matrix with delayed copies of itself.
+    """Short-term history embedding: concatenate an array with delayed copies of itself.
 
     Each column ``data[:, i]`` is mapped to::
 

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -284,6 +284,7 @@ def chroma(
         Tuning deviation from A440 in fractions of a chroma bin.
 
     ctroct : float > 0 [scalar]
+        Center of the octave dominance window (in octaves, A0 = 27.5 Hz).
 
     octwidth : float > 0 or None [scalar]
         ``ctroct`` and ``octwidth`` specify a dominance window:
@@ -612,14 +613,14 @@ def wavelet(
     sr : number > 0 [scalar]
         Audio sampling rate
 
-    window : string, tuple, number, or function
+    window : str, tuple, number, or function
         Windowing function to apply to filters.
 
     filter_scale : float > 0 [scalar]
         Scale of filter windows.
         Small values (<1) use shorter windows for higher temporal resolution.
 
-    pad_fft : boolean
+    pad_fft : bool
         Center-pad all filters up to the nearest integral power of 2.
 
         By default, padding is done with zeros, but this can be overridden
@@ -629,12 +630,12 @@ def wavelet(
         Type of norm to use for basis function normalization.
         See librosa.util.normalize
 
-    gamma : number >= 0
-        Bandwidth offset for variable-Q transforms.
-
     dtype : np.dtype
         The data type of the output basis.
         By default, uses 64-bit (single precision) complex floating point.
+
+    gamma : number >= 0
+        Bandwidth offset for variable-Q transforms.
 
     alpha : number > 0 [optional]
         Optional pre-computed relative bandwidth parameter.
@@ -743,8 +744,7 @@ def cq_to_chroma(
     base_c: bool = True,
     dtype: DTypeLike = np.float32,
 ) -> np.ndarray:
-    """Construct a linear transformation matrix to map Constant-Q bins
-    onto chroma bins (i.e., pitch classes).
+    """Construct a linear transformation matrix to map Constant-Q bins onto chroma bins.
 
     Parameters
     ----------
@@ -876,7 +876,7 @@ def window_bandwidth(window: _WindowSpec, n: int = 1000) -> float:
 
     Parameters
     ----------
-    window : callable or string
+    window : callable or str
         A window function, or the name of a window function,
         e.g.: `scipy.signal.hann` or `'boxcar'`
     n : int > 0
@@ -920,7 +920,7 @@ def get_window(window: _WindowSpec, Nx: int, *, fftbins: bool = True) -> np.ndar
 
     Parameters
     ----------
-    window : string, tuple, number, callable, or list-like
+    window : str, tuple, number, callable, or list-like
         The window specification:
 
         - If string, it's the name of the window function (e.g., `'hann'`)
@@ -1020,7 +1020,7 @@ def _multirate_fb(
         The type of IIR filter to design
         See `scipy.signal.iirdesign` for details.
 
-    flayout : string
+    flayout : str
         Valid `output` argument for `scipy.signal.iirdesign`.
 
         - If `ba`, returns numerators/denominators of the transfer functions,
@@ -1161,8 +1161,7 @@ def semitone_filterbank(
     flayout: Literal["ba", "sos"] = "ba",
     **kwargs: Any,
 ) -> tuple[list[Any], np.ndarray]:
-    r"""Construct a multi-rate bank of infinite-impulse response (IIR)
-    band-pass filters at user-defined center frequencies and sample rates.
+    r"""Construct a multi-rate IIR band-pass filter bank at specified center frequencies and sample rates.
 
     By default, these center frequencies are set equal to the 88 fundamental
     frequencies of the grand piano keyboard, according to a pitch tuning standard
@@ -1191,7 +1190,7 @@ def semitone_filterbank(
         in equal temperament).
     sample_rates : np.ndarray [shape=(n,), dtype=float]
         Sample rates of each filter in the multirate filterbank.
-    flayout : string
+    flayout : str
         - If `ba`, the standard difference equation is used for filtering with `scipy.signal.filtfilt`.
           Can be unstable for high-order filters.
         - If `sos`, a series of second-order filters is used for filtering with `scipy.signal.sosfiltfilt`.
@@ -1283,7 +1282,7 @@ def window_sumsquare(
 
     Parameters
     ----------
-    window : string, tuple, number, callable, or list-like
+    window : str, tuple, number, callable, or list-like
         Window specification, as in `get_window`
     n_frames : int > 0
         The number of analysis frames
@@ -1355,7 +1354,7 @@ def diagonal_filter(
 
     Parameters
     ----------
-    window : string, tuple, number, callable, or list-like
+    window : str, tuple, number, callable, or list-like
         The window function to use for the filter.
 
         See `get_window` for details.

--- a/librosa/onset.py
+++ b/librosa/onset.py
@@ -62,10 +62,6 @@ def onset_detect(
     hop_length : int > 0 [scalar]
         hop length (in samples)
 
-    units : {'frames', 'samples', 'time'}
-        The units to encode detected onset events in.
-        By default, 'frames' are used.
-
     backtrack : bool
         If ``True``, detected onset events are backtracked to the nearest
         preceding minimum of ``energy``.
@@ -77,6 +73,10 @@ def onset_detect(
     energy : np.ndarray [shape=(m,)] (optional)
         An energy function to use for backtracking detected onset events.
         If none is provided, then ``onset_envelope`` is used.
+
+    units : {'frames', 'samples', 'time'}
+        The units to encode detected onset events in.
+        By default, 'frames' are used.
 
     normalize : bool
         If ``True`` (default), normalize the onset envelope to have minimum of 0 and
@@ -121,9 +121,9 @@ def onset_detect(
 
     See Also
     --------
-    onset_strength : compute onset strength per-frame
-    onset_backtrack : backtracking onset events
-    librosa.util.peak_pick : pick peaks from a time series
+    onset_strength : Compute onset strength per-frame
+    onset_backtrack : Backtracking onset events
+    librosa.util.peak_pick : Pick peaks from a time series
 
     Examples
     --------
@@ -368,8 +368,7 @@ def onset_strength(
 
 
 def onset_backtrack(events: np.ndarray, energy: np.ndarray) -> np.ndarray:
-    """Backtrack detected onset events to the nearest preceding local
-    minimum of an energy function.
+    """Backtrack detected onset events to the nearest preceding local minimum of an energy function.
 
     This function can be used to roll back the timing of detected onsets
     from a detected peak amplitude to the preceding minimum.

--- a/librosa/sequence.py
+++ b/librosa/sequence.py
@@ -1343,12 +1343,12 @@ def viterbi(
 
     Returns
     -------
-    Either ``states`` or ``(states, logp)``:
     states : np.ndarray [shape=(..., n_steps,)]
         The most likely state sequence.
         If ``prob`` contains multiple channels of input, then each channel is
         decoded independently.
-    logp : scalar [float] or np.ndarray
+
+    logp : scalar [float] or np.ndarray, optional
         If ``return_logp=True``, the log probability of ``states`` given
         the observations.
 

--- a/librosa/sequence.py
+++ b/librosa/sequence.py
@@ -1547,7 +1547,6 @@ def viterbi_discriminative(
 
     Returns
     -------
-    Either ``states`` or ``(states, logp)``:
     states : np.ndarray [shape=(..., n_steps,)]
         The most likely state sequence.
         If ``prob`` contains multiple input channels,
@@ -1826,7 +1825,6 @@ def viterbi_binary(
 
     Returns
     -------
-    Either ``states`` or ``(states, logp)``:
     states : np.ndarray [shape=(..., n_states, n_steps)]
         The most likely state sequence.
     logp : np.ndarray [shape=(..., n_states,)]

--- a/librosa/util/decorators.py
+++ b/librosa/util/decorators.py
@@ -28,6 +28,20 @@ def moved(
     """Mark functions as moved/renamed.
 
     Using the decorated (old) function will result in a warning.
+
+    Parameters
+    ----------
+    moved_from : str
+        The old location of the function
+    version : str
+        The version in which the function was moved
+    version_removed : str
+        The version in which the old alias will be removed
+
+    Returns
+    -------
+    decorator : Callable
+        A decorator that can be applied to the old function name
     """
 
     def __wrapper(func: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
@@ -53,6 +67,18 @@ def deprecated(
     """Mark a function as deprecated.
 
     Using the decorated (old) function will result in a warning.
+
+    Parameters
+    ----------
+    version : str
+        The version in which the function was deprecated
+    version_removed : str
+        The version in which the function will be removed
+
+    Returns
+    -------
+    decorator : Callable
+        A decorator that can be applied to the deprecated function
     """
 
     def __wrapper(func: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
@@ -83,6 +109,31 @@ def vectorize(
 
     This function is not quite a decorator, but is used as a wrapper
     to np.vectorize that preserves scalar behavior.
+
+    Parameters
+    ----------
+    otypes : str or list of dtype, optional
+        The output data type(s).  This is required if the function returns
+        a scalar.  If the function returns an array, this is optional.
+    doc : str, optional
+        The docstring for the vectorized function.  If None, the original
+        function's docstring will be used.
+    excluded : list of int or str, optional
+        List of argument indices or names to exclude from vectorization.
+    cache : bool, optional
+        If True, cache the results of the function calls.  This can speed up
+        repeated calls with the same arguments, but may consume more memory.
+    signature : str, optional
+        The signature of the function for generalized ufunc behavior.
+
+    Returns
+    -------
+    decorator : Callable
+        A decorator that can be applied to the function to vectorize it.
+
+    See Also
+    --------
+    np.vectorize : The underlying vectorization function from NumPy.
     """
 
     def __wrapper(function):

--- a/librosa/util/deprecation.py
+++ b/librosa/util/deprecation.py
@@ -29,11 +29,13 @@ def rename_kw(
     Parameters
     ----------
     old_name : str
-    old_value
-        The name and value of the old argument
+        The name of the old argument
+    old_value : Any
+        The value of the old argument
     new_name : str
-    new_value
-        The name and value of the new argument
+        The name of the new argument
+    new_value : Any
+        The value of the new argument
     version_deprecated : str
         The version at which the old name became deprecated
     version_removed : str
@@ -41,14 +43,13 @@ def rename_kw(
 
     Returns
     -------
-    value
+    value : Any
         - ``new_value`` if ``old_value`` of type `Deprecated`
         - ``old_value`` otherwise
 
     Warnings
     --------
     if ``old_value`` is not of type `Deprecated`
-
     """
     if isinstance(old_value, Deprecated):
         return new_value

--- a/librosa/util/files.py
+++ b/librosa/util/files.py
@@ -218,12 +218,12 @@ def find_files(
 
         Default: ``['aac', 'au', 'flac', 'm4a', 'mp3', 'ogg', 'wav']``
 
-    recurse : boolean
+    recurse : bool
         If ``True``, then all subfolders of ``directory`` will be searched.
 
         Otherwise, only ``directory`` will be searched.
 
-    case_sensitive : boolean
+    case_sensitive : bool
         If ``False``, files matching upper-case version of
         extensions will be included.
 

--- a/librosa/util/matching.py
+++ b/librosa/util/matching.py
@@ -254,6 +254,7 @@ def match_events(
         Array of events (eg, times, sample or frame indices) to
         match against.
     left : bool
+        See `right`
     right : bool
         If ``False``, then matched events cannot be to the left (or right)
         of source events.

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -306,6 +306,7 @@ def valid_audio(y: np.ndarray) -> bool:
 
 def valid_int(x: float, *, cast: Callable[[float], float] | None = None) -> int:
     """Ensure that an input value is integer-typed.
+
     This is primarily useful for ensuring integrable-valued
     array indices.
 
@@ -342,10 +343,12 @@ def is_positive_int(x: float) -> bool:
     Parameters
     ----------
     x : number
+        A scalar value to check
 
     Returns
     -------
     positive : bool
+        True if x is a positive integer, False otherwise
     """
     # Check type first to catch None values.
     return isinstance(x, (int, np.integer)) and (x > 0)
@@ -628,7 +631,7 @@ def fix_frames(
         Minimum allowed frame index
     x_max : int >= 0 or None
         Maximum allowed frame index
-    pad : boolean
+    pad : bool
         If ``True``, then ``frames`` is expanded to span the full range
         ``[x_min, x_max]``
 
@@ -752,7 +755,7 @@ def axis_sort(
         - ``axis=0`` to sort rows by peak column index
         - ``axis=1`` to sort columns by peak row index
 
-    index : boolean [scalar]
+    index : bool [scalar]
         If true, returns the index array as well as the permuted data.
 
     value : function
@@ -1556,6 +1559,7 @@ def buf_to_float(
     x: np.ndarray, *, n_bytes: int = 2, dtype: DTypeLike = np.float32
 ) -> np.ndarray:
     """Convert an integer buffer to floating point values.
+
     This is primarily useful when loading integer-valued wav data
     into numpy arrays.
 
@@ -1602,7 +1606,7 @@ def index_to_slice(
     step : None or int
         Step size for each slice.  If `None`, then the default
         step of 1 is used.
-    pad : boolean
+    pad : bool
         If `True`, pad ``idx`` to span the range ``idx_min:idx_max``.
 
     Returns
@@ -1668,7 +1672,7 @@ def sync(
         an iterable collection of slice objects.
     aggregate : function
         aggregation function (default: `np.mean`)
-    pad : boolean
+    pad : bool
         If `True`, ``idx`` is padded to span the full range ``[0, data.shape[axis]]``
     axis : int
         The axis along which to aggregate data
@@ -1955,8 +1959,7 @@ def tiny(x: complex | np.ndarray) -> np.floating[Any]:
 
 
 def fill_off_diagonal(x: np.ndarray, *, radius: float, value: float = 0) -> None:
-    """Set all cells of a matrix to a given ``value``
-    if they lie outside a constraint region.
+    """Set all array entries to ``value`` if they lie outside a constraint region.
 
     In this case, the constraint region is the
     Sakoe-Chiba band which runs with a fixed ``radius``
@@ -2025,8 +2028,7 @@ def fill_off_diagonal(x: np.ndarray, *, radius: float, value: float = 0) -> None
 def cyclic_gradient(
     data: np.ndarray, *, edge_order: Literal[1, 2] = 1, axis: int = -1
 ) -> np.ndarray:
-    """Estimate the gradient of a function over a uniformly sampled,
-    periodic domain.
+    """Estimate the gradient of a function over a uniformly sampled, periodic domain.
 
     This is essentially the same as `np.gradient`, except that edge effects
     are handled by wrapping the observations (i.e. assuming periodicity)
@@ -2176,9 +2178,9 @@ def shear(
     ----------
     X : np.ndarray [ndim=2] or scipy.sparse array/matrix
         The array/matrix to be sheared
-    factor : integer
+    factor : int
         The shear factor: ``X[:, n] -> np.roll(X[:, n], factor * n)``
-    axis : integer
+    axis : int
         The axis along which to shear
 
     Returns
@@ -2227,7 +2229,7 @@ def stack(arrays: list[np.ndarray], *, axis: int = 0) -> np.ndarray:
     ----------
     arrays : list
         one or more `np.ndarray`
-    axis : integer
+    axis : int
         The target axis along which to stack.  ``axis=0`` creates a new first axis,
         and ``axis=-1`` creates a new last axis.
 
@@ -2444,8 +2446,7 @@ def __count_unique(x):
 
 
 def count_unique(data: np.ndarray, *, axis: int = -1) -> np.ndarray:
-    """Count the number of unique values in a multi-dimensional array
-    along a given axis.
+    """Count the number of unique values along a given axis.
 
     Parameters
     ----------
@@ -2495,8 +2496,7 @@ def __is_unique(x):
 
 
 def is_unique(data: np.ndarray, *, axis: int = -1) -> np.ndarray:
-    """Determine if the input array consists of all unique values
-    along a given axis.
+    """Determine if the input consists of all unique values along a given axis.
 
     Parameters
     ----------
@@ -2753,15 +2753,15 @@ def interp_broadcast(
     op : function [optional]
         A broadcast operation performed on the two interpolated arrays.
         Default: ``np.multiply``.
-    axis : int
-        The axis of interpolation.
-        Default: ``-2``
     kind : str
         Interpolation type.  See ``scipy.interpolate.interp1d``.
         Default: ``"linear"``
     fill_value : float
         The value to fill when extrapolating beyond the observed range.
         Default: ``0``
+    axis : int
+        The axis of interpolation.
+        Default: ``-2``
 
     Returns
     -------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,16 +44,18 @@ checks = [
     "ES01", # No extended summary
     "EX01", # No examples section
     "SA01", # No See Also section
+    "SA02", # Punctuation in See Also section is not that important
     "GL01", # Docstring starting on the same line as open quotes?
     "PR08", # Capitalization of parameter descriptions is not that important
     "PR09", # Punctuation of parameter descriptions is not that important
     "RT02", # It's useful to include shape descriptions in return types
     "SA04", # See Also descriptions are not that important
+    "RT04", # Capitalization in return descriptions is not that important
     "RT05", # Punctuation in return descriptions is not that important
     "SS03", # Punctuation in summary is not that important
 ]
 exclude = [
-    "^_.*",  # Private functions and classes
+    "_.*",  # Private functions and classes
 ]
 exclude_files = [
     '.*/__init__.py',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,9 +55,12 @@ checks = [
     "SS03", # Punctuation in summary is not that important
 ]
 exclude = [
-    "_.*",  # Private functions and classes
+    # Exclude all private functions and classes (those beginning with _) in all
+    # submodules:
+    ".*/_.*",
 ]
 exclude_files = [
     '.*/__init__.py',
     '.*/version.py',
+    '.*/_typing.py',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,14 +53,18 @@ checks = [
     "RT04", # Capitalization in return descriptions is not that important
     "RT05", # Punctuation in return descriptions is not that important
     "SS03", # Punctuation in summary is not that important
+    "GL08", # @overload stubs and internal helpers do not need docstrings
+    "SS01", # Module-level docstrings use autosummary format, not numpydoc
 ]
 exclude = [
-    # Exclude all private functions and classes (those beginning with _) in all
-    # submodules:
-    ".*/_.*",
+    # Exclude module-level docstrings (autosummary format, not numpydoc):
+    "^[^.]+$",
+    # Exclude all private functions and classes (those beginning with _):
+    "\\._",
 ]
 exclude_files = [
     '.*/__init__.py',
     '.*/version.py',
     '.*/_typing.py',
+    '.*/_cache.py',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,16 @@ checks = [
     "ES01", # No extended summary
     "EX01", # No examples section
     "SA01", # No See Also section
+    "GL01", # Docstring starting on the same line as open quotes?
+    "PR08", # Capitalization of parameter descriptions is not that important
+    "PR09", # Punctuation of parameter descriptions is not that important
+    "RT02", # It's useful to include shape descriptions in return types
+    "SA04", # See Also descriptions are not that important
+    "RT05", # Punctuation in return descriptions is not that important
+    "SS03", # Punctuation in summary is not that important
+]
+exclude = [
+    "^_.*",  # Private functions and classes
 ]
 exclude_files = [
     '.*/__init__.py',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,15 @@ convention = "numpy"
 
 [tool.ruff.lint.flake8-bugbear]
 extend-immutable-calls = ["librosa.util.deprecation.Deprecated"]
+
+[tool.numpydoc_validation]
+checks = [
+    "all",
+    "ES01", # No extended summary
+    "EX01", # No examples section
+    "SA01", # No See Also section
+]
+exclude_files = [
+    '.*/__init__.py',
+    '.*/version.py',
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = 'setuptools.build_meta'
 line-length = 119
 
 [tool.ruff.lint]
-select = ["E", "F", "S", "D", "W", "I", "PYI", "Q", "B", "SIM", "RUF", "TC"]
+select = ["E", "F", "S", "D", "W", "I", "PYI", "Q", "B", "SIM", "RUF", "TC", "NPY"]
 ignore = [
     "D107",  # This only affects inherited classes for us
     "D203",  # Blank line before class docstring is silly

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ checks = [
     "SS03", # Punctuation in summary is not that important
     "GL08", # @overload stubs and internal helpers do not need docstrings
     "SS01", # Module-level docstrings use autosummary format, not numpydoc
+    "PR02", # We can have extra parameter names included, eg when using **kwargs
 ]
 exclude = [
     # Exclude module-level docstrings (autosummary format, not numpydoc):

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,7 @@ librosa =
 
 [options.extras_require]
 docs =
-    numpydoc
+    numpydoc >= 1.8.0
     sphinx != 1.3.1
     sphinx_rtd_theme>=1.2.0
     matplotlib >= 3.10.0


### PR DESCRIPTION
#### Reference Issue
Fixes #2046 


#### What does this implement/fix? Explain your changes.
This PR is an attempt to migrate away from velin and toward ruff+numpydoc for docstring validation in CI.

#### Any other comments?

I've disabled quite a few rules here, mostly due to personal taste.  (E.g., hobgoblinning around punctuation of parameter descriptions.)

There are some deeper issues in numpydoc that may take some effort to sort out properly.  Specifically having to do with:

1. Module-level docstrings / autosummary
2. Missing documentation in `@overload`ed functions
3. Proper rule implementation for skipping private functions.

I think (3) is fixable, but I'm not sure about (1) and (2).  I may end up just using this as a one-time audit and then scrapping most of the rules from CI.  That said, as a one-time audit, it is turning up a few things that velin had previously missed, so this is probably a worthwhile exercise.
