### PR TITLE
reformat `**/__init__.pyi` re-exports

### DIFF
--- a/librosa/__init__.pyi
+++ b/librosa/__init__.pyi
@@ -1,308 +1,106 @@
 from . import beat, core, decompose, display, effects, feature, filters, onset, segment, sequence, util
 from ._cache import cache as cache
-from .core import (
-    A4_to_tuning as A4_to_tuning,
-)
-from .core import (
-    A_weighting as A_weighting,
-)
-from .core import (
-    B_weighting as B_weighting,
-)
-from .core import (
-    C_weighting as C_weighting,
-)
-from .core import (
-    D_weighting as D_weighting,
-)
-from .core import (
-    Z_weighting as Z_weighting,
-)
-from .core import (
-    amplitude_to_db as amplitude_to_db,
-)
-from .core import (
-    autocorrelate as autocorrelate,
-)
-from .core import (
-    blocks_to_frames as blocks_to_frames,
-)
-from .core import (
-    blocks_to_samples as blocks_to_samples,
-)
-from .core import (
-    blocks_to_time as blocks_to_time,
-)
-from .core import (
-    chirp as chirp,
-)
-from .core import (
-    clicks as clicks,
-)
-from .core import (
-    cqt as cqt,
-)
-from .core import (
-    cqt_frequencies as cqt_frequencies,
-)
-from .core import (
-    db_to_amplitude as db_to_amplitude,
-)
-from .core import (
-    db_to_power as db_to_power,
-)
-from .core import (
-    estimate_tuning as estimate_tuning,
-)
-from .core import (
-    f0_harmonics as f0_harmonics,
-)
-from .core import (
-    fft_frequencies as fft_frequencies,
-)
-from .core import (
-    fifths_to_note as fifths_to_note,
-)
-from .core import (
-    fmt as fmt,
-)
-from .core import (
-    fourier_tempo_frequencies as fourier_tempo_frequencies,
-)
-from .core import (
-    frames_to_samples as frames_to_samples,
-)
-from .core import (
-    frames_to_time as frames_to_time,
-)
-from .core import (
-    frequency_weighting as frequency_weighting,
-)
-from .core import (
-    get_duration as get_duration,
-)
-from .core import (
-    get_samplerate as get_samplerate,
-)
-from .core import (
-    griffinlim as griffinlim,
-)
-from .core import (
-    griffinlim_cqt as griffinlim_cqt,
-)
-from .core import (
-    hybrid_cqt as hybrid_cqt,
-)
-from .core import (
-    hz_to_fjs as hz_to_fjs,
-)
-from .core import (
-    hz_to_mel as hz_to_mel,
-)
-from .core import (
-    hz_to_midi as hz_to_midi,
-)
-from .core import (
-    hz_to_note as hz_to_note,
-)
-from .core import (
-    hz_to_octs as hz_to_octs,
-)
-from .core import (
-    hz_to_svara_c as hz_to_svara_c,
-)
-from .core import (
-    hz_to_svara_h as hz_to_svara_h,
-)
-from .core import (
-    icqt as icqt,
-)
-from .core import (
-    iirt as iirt,
-)
-from .core import (
-    interp_harmonics as interp_harmonics,
-)
-from .core import (
-    interval_frequencies as interval_frequencies,
-)
-from .core import (
-    interval_to_fjs as interval_to_fjs,
-)
-from .core import (
-    istft as istft,
-)
-from .core import (
-    key_to_degrees as key_to_degrees,
-)
-from .core import (
-    key_to_notes as key_to_notes,
-)
-from .core import (
-    list_mela as list_mela,
-)
-from .core import (
-    list_thaat as list_thaat,
-)
-from .core import (
-    load as load,
-)
-from .core import (
-    loadx as loadx,
-)
-from .core import (
-    lpc as lpc,
-)
-from .core import (
-    magphase as magphase,
-)
-from .core import (
-    mel_frequencies as mel_frequencies,
-)
-from .core import (
-    mel_to_hz as mel_to_hz,
-)
-from .core import (
-    mela_to_degrees as mela_to_degrees,
-)
-from .core import (
-    mela_to_svara as mela_to_svara,
-)
-from .core import (
-    midi_to_hz as midi_to_hz,
-)
-from .core import (
-    midi_to_note as midi_to_note,
-)
-from .core import (
-    midi_to_svara_c as midi_to_svara_c,
-)
-from .core import (
-    midi_to_svara_h as midi_to_svara_h,
-)
-from .core import (
-    mu_compress as mu_compress,
-)
-from .core import (
-    mu_expand as mu_expand,
-)
-from .core import (
-    multi_frequency_weighting as multi_frequency_weighting,
-)
-from .core import (
-    note_to_hz as note_to_hz,
-)
-from .core import (
-    note_to_midi as note_to_midi,
-)
-from .core import (
-    note_to_svara_c as note_to_svara_c,
-)
-from .core import (
-    note_to_svara_h as note_to_svara_h,
-)
-from .core import (
-    octs_to_hz as octs_to_hz,
-)
-from .core import (
-    pcen as pcen,
-)
-from .core import (
-    perceptual_weighting as perceptual_weighting,
-)
-from .core import (
-    phase_vocoder as phase_vocoder,
-)
-from .core import (
-    piptrack as piptrack,
-)
-from .core import (
-    pitch_tuning as pitch_tuning,
-)
-from .core import (
-    plimit_intervals as plimit_intervals,
-)
-from .core import (
-    power_to_db as power_to_db,
-)
-from .core import (
-    pseudo_cqt as pseudo_cqt,
-)
-from .core import (
-    pyin as pyin,
-)
-from .core import (
-    pythagorean_intervals as pythagorean_intervals,
-)
-from .core import (
-    reassigned_spectrogram as reassigned_spectrogram,
-)
-from .core import (
-    resample as resample,
-)
-from .core import (
-    salience as salience,
-)
-from .core import (
-    samples_like as samples_like,
-)
-from .core import (
-    samples_to_frames as samples_to_frames,
-)
-from .core import (
-    samples_to_time as samples_to_time,
-)
-from .core import (
-    stft as stft,
-)
-from .core import (
-    stream as stream,
-)
-from .core import (
-    tempo_frequencies as tempo_frequencies,
-)
-from .core import (
-    thaat_to_degrees as thaat_to_degrees,
-)
-from .core import (
-    time_to_frames as time_to_frames,
-)
-from .core import (
-    time_to_samples as time_to_samples,
-)
-from .core import (
-    times_like as times_like,
-)
-from .core import (
-    to_mono as to_mono,
-)
-from .core import (
-    to_multi as to_multi,
-)
-from .core import (
-    to_stereo as to_stereo,
-)
-from .core import (
-    tone as tone,
-)
-from .core import (
-    tuning_to_A4 as tuning_to_A4,
-)
-from .core import (
-    vqt as vqt,
-)
-from .core import (
-    yin as yin,
-)
-from .core import (
-    zero_crossings as zero_crossings,
-)
-from .util.exceptions import (
-    LibrosaError as LibrosaError,
-)
-from .util.exceptions import (
-    ParameterError as ParameterError,
-)
+from .core import A4_to_tuning as A4_to_tuning
+from .core import A_weighting as A_weighting
+from .core import B_weighting as B_weighting
+from .core import C_weighting as C_weighting
+from .core import D_weighting as D_weighting
+from .core import Z_weighting as Z_weighting
+from .core import amplitude_to_db as amplitude_to_db
+from .core import autocorrelate as autocorrelate
+from .core import blocks_to_frames as blocks_to_frames
+from .core import blocks_to_samples as blocks_to_samples
+from .core import blocks_to_time as blocks_to_time
+from .core import chirp as chirp
+from .core import clicks as clicks
+from .core import cqt as cqt
+from .core import cqt_frequencies as cqt_frequencies
+from .core import db_to_amplitude as db_to_amplitude
+from .core import db_to_power as db_to_power
+from .core import estimate_tuning as estimate_tuning
+from .core import f0_harmonics as f0_harmonics
+from .core import fft_frequencies as fft_frequencies
+from .core import fifths_to_note as fifths_to_note
+from .core import fmt as fmt
+from .core import fourier_tempo_frequencies as fourier_tempo_frequencies
+from .core import frames_to_samples as frames_to_samples
+from .core import frames_to_time as frames_to_time
+from .core import frequency_weighting as frequency_weighting
+from .core import get_duration as get_duration
+from .core import get_samplerate as get_samplerate
+from .core import griffinlim as griffinlim
+from .core import griffinlim_cqt as griffinlim_cqt
+from .core import hybrid_cqt as hybrid_cqt
+from .core import hz_to_fjs as hz_to_fjs
+from .core import hz_to_mel as hz_to_mel
+from .core import hz_to_midi as hz_to_midi
+from .core import hz_to_note as hz_to_note
+from .core import hz_to_octs as hz_to_octs
+from .core import hz_to_svara_c as hz_to_svara_c
+from .core import hz_to_svara_h as hz_to_svara_h
+from .core import icqt as icqt
+from .core import iirt as iirt
+from .core import interp_harmonics as interp_harmonics
+from .core import interval_frequencies as interval_frequencies
+from .core import interval_to_fjs as interval_to_fjs
+from .core import istft as istft
+from .core import key_to_degrees as key_to_degrees
+from .core import key_to_notes as key_to_notes
+from .core import list_mela as list_mela
+from .core import list_thaat as list_thaat
+from .core import load as load
+from .core import loadx as loadx
+from .core import lpc as lpc
+from .core import magphase as magphase
+from .core import mel_frequencies as mel_frequencies
+from .core import mel_to_hz as mel_to_hz
+from .core import mela_to_degrees as mela_to_degrees
+from .core import mela_to_svara as mela_to_svara
+from .core import midi_to_hz as midi_to_hz
+from .core import midi_to_note as midi_to_note
+from .core import midi_to_svara_c as midi_to_svara_c
+from .core import midi_to_svara_h as midi_to_svara_h
+from .core import mu_compress as mu_compress
+from .core import mu_expand as mu_expand
+from .core import multi_frequency_weighting as multi_frequency_weighting
+from .core import note_to_hz as note_to_hz
+from .core import note_to_midi as note_to_midi
+from .core import note_to_svara_c as note_to_svara_c
+from .core import note_to_svara_h as note_to_svara_h
+from .core import octs_to_hz as octs_to_hz
+from .core import pcen as pcen
+from .core import perceptual_weighting as perceptual_weighting
+from .core import phase_vocoder as phase_vocoder
+from .core import piptrack as piptrack
+from .core import pitch_tuning as pitch_tuning
+from .core import plimit_intervals as plimit_intervals
+from .core import power_to_db as power_to_db
+from .core import pseudo_cqt as pseudo_cqt
+from .core import pyin as pyin
+from .core import pythagorean_intervals as pythagorean_intervals
+from .core import reassigned_spectrogram as reassigned_spectrogram
+from .core import resample as resample
+from .core import salience as salience
+from .core import samples_like as samples_like
+from .core import samples_to_frames as samples_to_frames
+from .core import samples_to_time as samples_to_time
+from .core import stft as stft
+from .core import stream as stream
+from .core import tempo_frequencies as tempo_frequencies
+from .core import thaat_to_degrees as thaat_to_degrees
+from .core import time_to_frames as time_to_frames
+from .core import time_to_samples as time_to_samples
+from .core import times_like as times_like
+from .core import to_mono as to_mono
+from .core import to_multi as to_multi
+from .core import to_stereo as to_stereo
+from .core import tone as tone
+from .core import tuning_to_A4 as tuning_to_A4
+from .core import vqt as vqt
+from .core import yin as yin
+from .core import zero_crossings as zero_crossings
+from .util.exceptions import LibrosaError as LibrosaError
+from .util.exceptions import ParameterError as ParameterError
 from .util.files import cite as cite
 from .util.files import ex as ex
 from .util.files import example as example

--- a/librosa/core/__init__.pyi
+++ b/librosa/core/__init__.pyi
@@ -1,297 +1,99 @@
-from .audio import (
-    autocorrelate as autocorrelate,
-)
-from .audio import (
-    chirp as chirp,
-)
-from .audio import (
-    clicks as clicks,
-)
-from .audio import (
-    get_duration as get_duration,
-)
-from .audio import (
-    get_samplerate as get_samplerate,
-)
-from .audio import (
-    load as load,
-)
-from .audio import (
-    loadx as loadx,
-)
-from .audio import (
-    lpc as lpc,
-)
-from .audio import (
-    mu_compress as mu_compress,
-)
-from .audio import (
-    mu_expand as mu_expand,
-)
-from .audio import (
-    resample as resample,
-)
-from .audio import (
-    stream as stream,
-)
-from .audio import (
-    to_mono as to_mono,
-)
-from .audio import (
-    to_multi as to_multi,
-)
-from .audio import (
-    to_stereo as to_stereo,
-)
-from .audio import (
-    tone as tone,
-)
-from .audio import (
-    zero_crossings as zero_crossings,
-)
-from .constantq import (
-    cqt as cqt,
-)
-from .constantq import (
-    griffinlim_cqt as griffinlim_cqt,
-)
-from .constantq import (
-    hybrid_cqt as hybrid_cqt,
-)
-from .constantq import (
-    icqt as icqt,
-)
-from .constantq import (
-    pseudo_cqt as pseudo_cqt,
-)
-from .constantq import (
-    vqt as vqt,
-)
-from .convert import (
-    A4_to_tuning as A4_to_tuning,
-)
-from .convert import (
-    A_weighting as A_weighting,
-)
-from .convert import (
-    B_weighting as B_weighting,
-)
-from .convert import (
-    C_weighting as C_weighting,
-)
-from .convert import (
-    D_weighting as D_weighting,
-)
-from .convert import (
-    Z_weighting as Z_weighting,
-)
-from .convert import (
-    blocks_to_frames as blocks_to_frames,
-)
-from .convert import (
-    blocks_to_samples as blocks_to_samples,
-)
-from .convert import (
-    blocks_to_time as blocks_to_time,
-)
-from .convert import (
-    cqt_frequencies as cqt_frequencies,
-)
-from .convert import (
-    fft_frequencies as fft_frequencies,
-)
-from .convert import (
-    fourier_tempo_frequencies as fourier_tempo_frequencies,
-)
-from .convert import (
-    frames_to_samples as frames_to_samples,
-)
-from .convert import (
-    frames_to_time as frames_to_time,
-)
-from .convert import (
-    frequency_weighting as frequency_weighting,
-)
-from .convert import (
-    hz_to_fjs as hz_to_fjs,
-)
-from .convert import (
-    hz_to_mel as hz_to_mel,
-)
-from .convert import (
-    hz_to_midi as hz_to_midi,
-)
-from .convert import (
-    hz_to_note as hz_to_note,
-)
-from .convert import (
-    hz_to_octs as hz_to_octs,
-)
-from .convert import (
-    hz_to_svara_c as hz_to_svara_c,
-)
-from .convert import (
-    hz_to_svara_h as hz_to_svara_h,
-)
-from .convert import (
-    mel_frequencies as mel_frequencies,
-)
-from .convert import (
-    mel_to_hz as mel_to_hz,
-)
-from .convert import (
-    midi_to_hz as midi_to_hz,
-)
-from .convert import (
-    midi_to_note as midi_to_note,
-)
-from .convert import (
-    midi_to_svara_c as midi_to_svara_c,
-)
-from .convert import (
-    midi_to_svara_h as midi_to_svara_h,
-)
-from .convert import (
-    multi_frequency_weighting as multi_frequency_weighting,
-)
-from .convert import (
-    note_to_hz as note_to_hz,
-)
-from .convert import (
-    note_to_midi as note_to_midi,
-)
-from .convert import (
-    note_to_svara_c as note_to_svara_c,
-)
-from .convert import (
-    note_to_svara_h as note_to_svara_h,
-)
-from .convert import (
-    octs_to_hz as octs_to_hz,
-)
-from .convert import (
-    samples_like as samples_like,
-)
-from .convert import (
-    samples_to_frames as samples_to_frames,
-)
-from .convert import (
-    samples_to_time as samples_to_time,
-)
-from .convert import (
-    tempo_frequencies as tempo_frequencies,
-)
-from .convert import (
-    time_to_frames as time_to_frames,
-)
-from .convert import (
-    time_to_samples as time_to_samples,
-)
-from .convert import (
-    times_like as times_like,
-)
-from .convert import (
-    tuning_to_A4 as tuning_to_A4,
-)
-from .harmonic import (
-    f0_harmonics as f0_harmonics,
-)
-from .harmonic import (
-    interp_harmonics as interp_harmonics,
-)
-from .harmonic import (
-    salience as salience,
-)
-from .intervals import (
-    interval_frequencies as interval_frequencies,
-)
-from .intervals import (
-    plimit_intervals as plimit_intervals,
-)
-from .intervals import (
-    pythagorean_intervals as pythagorean_intervals,
-)
-from .notation import (
-    fifths_to_note as fifths_to_note,
-)
-from .notation import (
-    interval_to_fjs as interval_to_fjs,
-)
-from .notation import (
-    key_to_degrees as key_to_degrees,
-)
-from .notation import (
-    key_to_notes as key_to_notes,
-)
-from .notation import (
-    list_mela as list_mela,
-)
-from .notation import (
-    list_thaat as list_thaat,
-)
-from .notation import (
-    mela_to_degrees as mela_to_degrees,
-)
-from .notation import (
-    mela_to_svara as mela_to_svara,
-)
-from .notation import (
-    thaat_to_degrees as thaat_to_degrees,
-)
-from .pitch import (
-    estimate_tuning as estimate_tuning,
-)
-from .pitch import (
-    piptrack as piptrack,
-)
-from .pitch import (
-    pitch_tuning as pitch_tuning,
-)
-from .pitch import (
-    pyin as pyin,
-)
-from .pitch import (
-    yin as yin,
-)
-from .spectrum import (
-    amplitude_to_db as amplitude_to_db,
-)
-from .spectrum import (
-    db_to_amplitude as db_to_amplitude,
-)
-from .spectrum import (
-    db_to_power as db_to_power,
-)
-from .spectrum import (
-    fmt as fmt,
-)
-from .spectrum import (
-    griffinlim as griffinlim,
-)
-from .spectrum import (
-    iirt as iirt,
-)
-from .spectrum import (
-    istft as istft,
-)
-from .spectrum import (
-    magphase as magphase,
-)
-from .spectrum import (
-    pcen as pcen,
-)
-from .spectrum import (
-    perceptual_weighting as perceptual_weighting,
-)
-from .spectrum import (
-    phase_vocoder as phase_vocoder,
-)
-from .spectrum import (
-    power_to_db as power_to_db,
-)
-from .spectrum import (
-    reassigned_spectrogram as reassigned_spectrogram,
-)
-from .spectrum import (
-    stft as stft,
-)
+from .audio import autocorrelate as autocorrelate
+from .audio import chirp as chirp
+from .audio import clicks as clicks
+from .audio import get_duration as get_duration
+from .audio import get_samplerate as get_samplerate
+from .audio import load as load
+from .audio import loadx as loadx
+from .audio import lpc as lpc
+from .audio import mu_compress as mu_compress
+from .audio import mu_expand as mu_expand
+from .audio import resample as resample
+from .audio import stream as stream
+from .audio import to_mono as to_mono
+from .audio import to_multi as to_multi
+from .audio import to_stereo as to_stereo
+from .audio import tone as tone
+from .audio import zero_crossings as zero_crossings
+from .constantq import cqt as cqt
+from .constantq import griffinlim_cqt as griffinlim_cqt
+from .constantq import hybrid_cqt as hybrid_cqt
+from .constantq import icqt as icqt
+from .constantq import pseudo_cqt as pseudo_cqt
+from .constantq import vqt as vqt
+from .convert import A4_to_tuning as A4_to_tuning
+from .convert import A_weighting as A_weighting
+from .convert import B_weighting as B_weighting
+from .convert import C_weighting as C_weighting
+from .convert import D_weighting as D_weighting
+from .convert import Z_weighting as Z_weighting
+from .convert import blocks_to_frames as blocks_to_frames
+from .convert import blocks_to_samples as blocks_to_samples
+from .convert import blocks_to_time as blocks_to_time
+from .convert import cqt_frequencies as cqt_frequencies
+from .convert import fft_frequencies as fft_frequencies
+from .convert import fourier_tempo_frequencies as fourier_tempo_frequencies
+from .convert import frames_to_samples as frames_to_samples
+from .convert import frames_to_time as frames_to_time
+from .convert import frequency_weighting as frequency_weighting
+from .convert import hz_to_fjs as hz_to_fjs
+from .convert import hz_to_mel as hz_to_mel
+from .convert import hz_to_midi as hz_to_midi
+from .convert import hz_to_note as hz_to_note
+from .convert import hz_to_octs as hz_to_octs
+from .convert import hz_to_svara_c as hz_to_svara_c
+from .convert import hz_to_svara_h as hz_to_svara_h
+from .convert import mel_frequencies as mel_frequencies
+from .convert import mel_to_hz as mel_to_hz
+from .convert import midi_to_hz as midi_to_hz
+from .convert import midi_to_note as midi_to_note
+from .convert import midi_to_svara_c as midi_to_svara_c
+from .convert import midi_to_svara_h as midi_to_svara_h
+from .convert import multi_frequency_weighting as multi_frequency_weighting
+from .convert import note_to_hz as note_to_hz
+from .convert import note_to_midi as note_to_midi
+from .convert import note_to_svara_c as note_to_svara_c
+from .convert import note_to_svara_h as note_to_svara_h
+from .convert import octs_to_hz as octs_to_hz
+from .convert import samples_like as samples_like
+from .convert import samples_to_frames as samples_to_frames
+from .convert import samples_to_time as samples_to_time
+from .convert import tempo_frequencies as tempo_frequencies
+from .convert import time_to_frames as time_to_frames
+from .convert import time_to_samples as time_to_samples
+from .convert import times_like as times_like
+from .convert import tuning_to_A4 as tuning_to_A4
+from .harmonic import f0_harmonics as f0_harmonics
+from .harmonic import interp_harmonics as interp_harmonics
+from .harmonic import salience as salience
+from .intervals import interval_frequencies as interval_frequencies
+from .intervals import plimit_intervals as plimit_intervals
+from .intervals import pythagorean_intervals as pythagorean_intervals
+from .notation import fifths_to_note as fifths_to_note
+from .notation import interval_to_fjs as interval_to_fjs
+from .notation import key_to_degrees as key_to_degrees
+from .notation import key_to_notes as key_to_notes
+from .notation import list_mela as list_mela
+from .notation import list_thaat as list_thaat
+from .notation import mela_to_degrees as mela_to_degrees
+from .notation import mela_to_svara as mela_to_svara
+from .notation import thaat_to_degrees as thaat_to_degrees
+from .pitch import estimate_tuning as estimate_tuning
+from .pitch import piptrack as piptrack
+from .pitch import pitch_tuning as pitch_tuning
+from .pitch import pyin as pyin
+from .pitch import yin as yin
+from .spectrum import amplitude_to_db as amplitude_to_db
+from .spectrum import db_to_amplitude as db_to_amplitude
+from .spectrum import db_to_power as db_to_power
+from .spectrum import fmt as fmt
+from .spectrum import griffinlim as griffinlim
+from .spectrum import iirt as iirt
+from .spectrum import istft as istft
+from .spectrum import magphase as magphase
+from .spectrum import pcen as pcen
+from .spectrum import perceptual_weighting as perceptual_weighting
+from .spectrum import phase_vocoder as phase_vocoder
+from .spectrum import power_to_db as power_to_db
+from .spectrum import reassigned_spectrogram as reassigned_spectrogram
+from .spectrum import stft as stft

--- a/librosa/feature/__init__.pyi
+++ b/librosa/feature/__init__.pyi
@@ -1,60 +1,24 @@
-from . import (
-    inverse as inverse,
-)
+from . import inverse as inverse
 from .rhythm import fourier_tempogram as fourier_tempogram
 from .rhythm import hybrid_tempogram as hybrid_tempogram
 from .rhythm import metrogram as metrogram
 from .rhythm import tempo as tempo
 from .rhythm import tempogram as tempogram
 from .rhythm import tempogram_ratio as tempogram_ratio
-from .spectral import (
-    chroma_cens as chroma_cens,
-)
-from .spectral import (
-    chroma_cqt as chroma_cqt,
-)
-from .spectral import (
-    chroma_stft as chroma_stft,
-)
-from .spectral import (
-    chroma_vqt as chroma_vqt,
-)
-from .spectral import (
-    melspectrogram as melspectrogram,
-)
-from .spectral import (
-    mfcc as mfcc,
-)
-from .spectral import (
-    poly_features as poly_features,
-)
-from .spectral import (
-    rms as rms,
-)
-from .spectral import (
-    spectral_bandwidth as spectral_bandwidth,
-)
-from .spectral import (
-    spectral_centroid as spectral_centroid,
-)
-from .spectral import (
-    spectral_contrast as spectral_contrast,
-)
-from .spectral import (
-    spectral_flatness as spectral_flatness,
-)
-from .spectral import (
-    spectral_rolloff as spectral_rolloff,
-)
-from .spectral import (
-    tonnetz as tonnetz,
-)
-from .spectral import (
-    zero_crossing_rate as zero_crossing_rate,
-)
-from .utils import (
-    delta as delta,
-)
-from .utils import (
-    stack_memory as stack_memory,
-)
+from .spectral import chroma_cens as chroma_cens
+from .spectral import chroma_cqt as chroma_cqt
+from .spectral import chroma_stft as chroma_stft
+from .spectral import chroma_vqt as chroma_vqt
+from .spectral import melspectrogram as melspectrogram
+from .spectral import mfcc as mfcc
+from .spectral import poly_features as poly_features
+from .spectral import rms as rms
+from .spectral import spectral_bandwidth as spectral_bandwidth
+from .spectral import spectral_centroid as spectral_centroid
+from .spectral import spectral_contrast as spectral_contrast
+from .spectral import spectral_flatness as spectral_flatness
+from .spectral import spectral_rolloff as spectral_rolloff
+from .spectral import tonnetz as tonnetz
+from .spectral import zero_crossing_rate as zero_crossing_rate
+from .utils import delta as delta
+from .utils import stack_memory as stack_memory

--- a/librosa/util/__init__.pyi
+++ b/librosa/util/__init__.pyi
@@ -1,37 +1,15 @@
 from . import decorators, exceptions
-from ._nnls import (
-    nnls as nnls,
-)
-from .deprecation import (
-    Deprecated as Deprecated,
-)
-from .deprecation import (
-    rename_kw as rename_kw,
-)
-from .files import (
-    cite as cite,
-)
-from .files import (
-    ex as ex,
-)
-from .files import (
-    example as example,
-)
-from .files import (
-    example_info as example_info,
-)
-from .files import (
-    find_files as find_files,
-)
-from .files import (
-    list_examples as list_examples,
-)
-from .matching import (
-    match_events as match_events,
-)
-from .matching import (
-    match_intervals as match_intervals,
-)
+from ._nnls import nnls as nnls
+from .deprecation import Deprecated as Deprecated
+from .deprecation import rename_kw as rename_kw
+from .files import cite as cite
+from .files import ex as ex
+from .files import example as example
+from .files import example_info as example_info
+from .files import find_files as find_files
+from .files import list_examples as list_examples
+from .matching import match_events as match_events
+from .matching import match_intervals as match_intervals
 from .utils import MAX_MEM_BLOCK as MAX_MEM_BLOCK
 from .utils import abs2 as abs2
 from .utils import axis_sort as axis_sort


### PR DESCRIPTION
Ruff doesn't complain about these trailing commas, but I think that without them, things are more readable. The juicy - diff is also just nice I suppose.

Great use of `.pyi` stubs btw.