### PR TITLE
Multichannel db

### DIFF
--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -2046,7 +2046,7 @@ def amplitude_to_db(
 
     magnitude = np.abs(S)
 
-    if axes is None:
+    if axes == "auto":
         if magnitude.ndim >= 2:
             axes = (-2, -1)
         elif magnitude.ndim == 1:

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1719,7 +1719,7 @@ def power_to_db(
     ref: float | Callable = ...,
     amin: float = ...,
     top_db: float | None = ...,
-    axes : None | Literal["auto"] | int | Sequence[int] = None,
+    axes: None | Literal["auto"] | int | tuple[int] = ...,
 ) -> np.floating[Any]: ...
 
 
@@ -1730,7 +1730,7 @@ def power_to_db(
     ref: float | Callable = ...,
     amin: float = ...,
     top_db: float | None = ...,
-    axes : None | Literal["auto"] | int | Sequence[int] = None,
+    axes: None | Literal["auto"] | int | tuple[int] = ...,
 ) -> np.ndarray: ...
 
 
@@ -1741,7 +1741,7 @@ def power_to_db(
     ref: float | Callable = ...,
     amin: float = ...,
     top_db: float | None = ...,
-    axes : None | Literal["auto"] | int | Sequence[int] = None,
+    axes: None | Literal["auto"] | int | tuple[int] = ...,
 ) -> np.floating[Any] | np.ndarray: ...
 
 
@@ -1752,7 +1752,7 @@ def power_to_db(
     ref: float | Callable = 1.0,
     amin: float = 1e-10,
     top_db: float | None = 80.0,
-    axes : None | Literal["auto"] | int | Sequence[int] = "auto",
+    axes: None | Literal["auto"] | int | tuple[int] = "auto",
 ) -> np.floating[Any] | np.ndarray:
     """Convert a power spectrogram (amplitude squared) to decibel (dB) units
 
@@ -1771,7 +1771,7 @@ def power_to_db(
 
         Zeros in the output correspond to positions where ``S == ref``.
 
-        If callable, the reference value is computed as ``ref(S)``.
+        If callable, the reference value is computed as ``ref(S, axis=axes, keepdims=True)``.
 
     amin : float > 0 [scalar]
         minimum threshold for ``abs(S)`` and ``ref``
@@ -1780,7 +1780,7 @@ def power_to_db(
         threshold the output at ``top_db`` below the peak:
         ``max(10 * log10(S/ref)) - top_db``
 
-    axes : None, "auto", int, or list of int
+    axes: None, "auto", int, or tuple of int
         Axis or axes along which to compute the reference value (if `ref` is callable).
         If `auto`, then axes will be inferred as the trailing dimensions of `S`:
             - If `S` is scalar, then `axes=None`
@@ -1955,7 +1955,7 @@ def amplitude_to_db(
     ref: float | Callable = ...,
     amin: float = ...,
     top_db: float | None = ...,
-    axes : None | Literal["auto"] | int | Sequence[int] = None,
+    axes: None | Literal["auto"] | int | tuple[int] = ...,
 ) -> np.floating[Any]: ...
 
 
@@ -1966,7 +1966,7 @@ def amplitude_to_db(
     ref: float | Callable = ...,
     amin: float = ...,
     top_db: float | None = ...,
-    axes : None | Literal["auto"] | int | Sequence[int] = None,
+    axes: None | Literal["auto"] | int | tuple[int] = ...,
 ) -> np.ndarray: ...
 
 
@@ -1977,7 +1977,7 @@ def amplitude_to_db(
     ref: float | Callable = ...,
     amin: float = ...,
     top_db: float | None = ...,
-    axes : None | Literal["auto"] | int | Sequence[int] = None,
+    axes: None | Literal["auto"] | int | tuple[int] = ...,
 ) -> np.floating[Any] | np.ndarray: ...
 
 
@@ -1988,7 +1988,7 @@ def amplitude_to_db(
     ref: float | Callable = 1.0,
     amin: float = 1e-5,
     top_db: float | None = 80.0,
-    axes : None | Literal["auto"] | int | Sequence[int] = "auto",
+    axes: None | Literal["auto"] | int | tuple[int] = "auto",
 ) -> np.floating[Any] | np.ndarray:
     """Convert an amplitude spectrogram to dB-scaled spectrogram.
 
@@ -2005,7 +2005,7 @@ def amplitude_to_db(
         ``20 * log10(S / ref)``.
         Zeros in the output correspond to positions where ``S == ref``.
 
-        If callable, the reference value is computed as ``ref(S)``.
+        If callable, the reference value is computed as ``ref(S, axis=axes, keepdims=True)``.
 
     amin : float > 0 [scalar]
         minimum threshold for ``S`` and ``ref``
@@ -2014,7 +2014,7 @@ def amplitude_to_db(
         threshold the output at ``top_db`` below the peak:
         ``max(20 * log10(S/ref)) - top_db``
 
-    axes : None, "auto", int, or list of int
+    axes : None, "auto", int, or tuple of int
         Axis or axes along which to compute the reference value (if `ref` is callable).
         If `auto`, then axes will be inferred as the trailing dimensions of `S`:
             - If `S` is scalar, then `axes=None`

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1887,7 +1887,7 @@ def power_to_db(
     if top_db is not None:
         if top_db < 0:
             raise ParameterError("top_db must be non-negative")
-        log_spec = np.maximum(log_spec, log_spec.max() - top_db)
+        log_spec = np.maximum(log_spec, log_spec.max(axis=axes, keepdims=True) - top_db)
 
     return log_spec[()]
 

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -19,7 +19,7 @@ from . import convert
 from .audio import resample
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Literal
+    from typing import Any, Callable, Literal, Sequence
 
     from numpy.typing import DTypeLike
 
@@ -1719,6 +1719,7 @@ def power_to_db(
     ref: float | Callable = ...,
     amin: float = ...,
     top_db: float | None = ...,
+    axes : None | int | Sequence[int] = None,
 ) -> np.floating[Any]: ...
 
 
@@ -1729,6 +1730,7 @@ def power_to_db(
     ref: float | Callable = ...,
     amin: float = ...,
     top_db: float | None = ...,
+    axes : None | int | Sequence[int] = None,
 ) -> np.ndarray: ...
 
 
@@ -1739,6 +1741,7 @@ def power_to_db(
     ref: float | Callable = ...,
     amin: float = ...,
     top_db: float | None = ...,
+    axes : None | int | Sequence[int] = None,
 ) -> np.floating[Any] | np.ndarray: ...
 
 
@@ -1749,6 +1752,7 @@ def power_to_db(
     ref: float | Callable = 1.0,
     amin: float = 1e-10,
     top_db: float | None = 80.0,
+    axes : None | int | Sequence[int] = None,
 ) -> np.floating[Any] | np.ndarray:
     """Convert a power spectrogram (amplitude squared) to decibel (dB) units
 
@@ -1775,6 +1779,12 @@ def power_to_db(
     top_db : float >= 0 [scalar]
         threshold the output at ``top_db`` below the peak:
         ``max(10 * log10(S/ref)) - top_db``
+
+    axes : None, int, or list of int
+        Axis or axes along which to compute the reference value (if `ref` is callable).
+        If `None`, then axes will be inferred as the trailing dimensions of `S`:
+            - If `S` is 1D, then `axes=(-1,)`
+            - If `S` is >=2D, then `axes=(-2, -1)`
 
     Returns
     -------
@@ -1853,9 +1863,21 @@ def power_to_db(
     else:
         magnitude = S
 
+    if axes is None:
+        # Single-channel (1D/2D) vs Multichannel (3D+)
+        axes = (-2, -1) if magnitude.ndim > 1 else (-1,)
+
     if callable(ref):
         # User supplied a function to calculate reference power
-        ref_value = ref(magnitude)
+        try:
+            # Happy path: Array API standard compliant (np.max, np.mean, xp.max)
+            ref_value = ref(magnitude, axis=axes, keepdims=True)
+        except TypeError as e:
+            # Fallback: Catch built-in `max` or non-compliant custom functions
+            raise ParameterError(
+                "The provided reference function must support 'axis' and "
+                "'keepdims' arguments for proper multichannel processing. "
+            ) from e
     else:
         ref_value = np.abs(ref)
 
@@ -1930,6 +1952,7 @@ def amplitude_to_db(
     ref: float | Callable = ...,
     amin: float = ...,
     top_db: float | None = ...,
+    axes : None | int | Sequence[int] = None,
 ) -> np.floating[Any]: ...
 
 
@@ -1940,6 +1963,7 @@ def amplitude_to_db(
     ref: float | Callable = ...,
     amin: float = ...,
     top_db: float | None = ...,
+    axes : None | int | Sequence[int] = None,
 ) -> np.ndarray: ...
 
 
@@ -1950,6 +1974,7 @@ def amplitude_to_db(
     ref: float | Callable = ...,
     amin: float = ...,
     top_db: float | None = ...,
+    axes : None | int | Sequence[int] = None,
 ) -> np.floating[Any] | np.ndarray: ...
 
 
@@ -1960,6 +1985,7 @@ def amplitude_to_db(
     ref: float | Callable = 1.0,
     amin: float = 1e-5,
     top_db: float | None = 80.0,
+    axes : None | int | Sequence[int] = None,
 ) -> np.floating[Any] | np.ndarray:
     """Convert an amplitude spectrogram to dB-scaled spectrogram.
 
@@ -1984,6 +2010,12 @@ def amplitude_to_db(
     top_db : float >= 0 [scalar]
         threshold the output at ``top_db`` below the peak:
         ``max(20 * log10(S/ref)) - top_db``
+
+    axes : None, int, or list of int
+        Axis or axes along which to compute the reference value (if `ref` is callable).
+        If `None`, then axes will be inferred as the trailing dimensions of `S`:
+            - If `S` is 1D, then `axes=(-1,)`
+            - If `S` is >=2D, then `axes=(-2, -1)`
 
     Returns
     -------
@@ -2010,9 +2042,21 @@ def amplitude_to_db(
 
     magnitude = np.abs(S)
 
+    if axes is None:
+        # Single-channel (1D/2D) vs Multichannel (3D+)
+        axes = (-2, -1) if magnitude.ndim > 1 else (-1,)
+
     if callable(ref):
         # User supplied a function to calculate reference power
-        ref_value = ref(magnitude)
+        try:
+            # Happy path: Array API standard compliant (np.max, np.mean, xp.max)
+            ref_value = ref(magnitude, axis=axes, keepdims=True)
+        except TypeError as e:
+            # Fallback: Catch built-in `max` or non-compliant custom functions
+            raise ParameterError(
+                "The provided reference function must support 'axis' and "
+                "'keepdims' arguments for proper multichannel processing. "
+            ) from e
     else:
         ref_value = np.abs(ref)
 

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1719,7 +1719,7 @@ def power_to_db(
     ref: float | Callable = ...,
     amin: float = ...,
     top_db: float | None = ...,
-    axes : None | int | Sequence[int] = None,
+    axes : None | Literal["auto"] | int | Sequence[int] = None,
 ) -> np.floating[Any]: ...
 
 
@@ -1730,7 +1730,7 @@ def power_to_db(
     ref: float | Callable = ...,
     amin: float = ...,
     top_db: float | None = ...,
-    axes : None | int | Sequence[int] = None,
+    axes : None | Literal["auto"] | int | Sequence[int] = None,
 ) -> np.ndarray: ...
 
 
@@ -1741,7 +1741,7 @@ def power_to_db(
     ref: float | Callable = ...,
     amin: float = ...,
     top_db: float | None = ...,
-    axes : None | int | Sequence[int] = None,
+    axes : None | Literal["auto"] | int | Sequence[int] = None,
 ) -> np.floating[Any] | np.ndarray: ...
 
 
@@ -1752,7 +1752,7 @@ def power_to_db(
     ref: float | Callable = 1.0,
     amin: float = 1e-10,
     top_db: float | None = 80.0,
-    axes : None | int | Sequence[int] = None,
+    axes : None | Literal["auto"] | int | Sequence[int] = "auto",
 ) -> np.floating[Any] | np.ndarray:
     """Convert a power spectrogram (amplitude squared) to decibel (dB) units
 
@@ -1780,9 +1780,9 @@ def power_to_db(
         threshold the output at ``top_db`` below the peak:
         ``max(10 * log10(S/ref)) - top_db``
 
-    axes : None, int, or list of int
+    axes : None, "auto", int, or list of int
         Axis or axes along which to compute the reference value (if `ref` is callable).
-        If `None`, then axes will be inferred as the trailing dimensions of `S`:
+        If `auto`, then axes will be inferred as the trailing dimensions of `S`:
             - If `S` is scalar, then `axes=None`
             - If `S` is 1D, then `axes=(-1,)`
             - If `S` is >=2D, then `axes=(-2, -1)`
@@ -1864,7 +1864,7 @@ def power_to_db(
     else:
         magnitude = S
 
-    if axes is None:
+    if axes == "auto":
         if magnitude.ndim >= 2:
             axes = (-2, -1)
         elif magnitude.ndim == 1:
@@ -1955,7 +1955,7 @@ def amplitude_to_db(
     ref: float | Callable = ...,
     amin: float = ...,
     top_db: float | None = ...,
-    axes : None | int | Sequence[int] = None,
+    axes : None | Literal["auto"] | int | Sequence[int] = None,
 ) -> np.floating[Any]: ...
 
 
@@ -1966,7 +1966,7 @@ def amplitude_to_db(
     ref: float | Callable = ...,
     amin: float = ...,
     top_db: float | None = ...,
-    axes : None | int | Sequence[int] = None,
+    axes : None | Literal["auto"] | int | Sequence[int] = None,
 ) -> np.ndarray: ...
 
 
@@ -1977,7 +1977,7 @@ def amplitude_to_db(
     ref: float | Callable = ...,
     amin: float = ...,
     top_db: float | None = ...,
-    axes : None | int | Sequence[int] = None,
+    axes : None | Literal["auto"] | int | Sequence[int] = None,
 ) -> np.floating[Any] | np.ndarray: ...
 
 
@@ -1988,7 +1988,7 @@ def amplitude_to_db(
     ref: float | Callable = 1.0,
     amin: float = 1e-5,
     top_db: float | None = 80.0,
-    axes : None | int | Sequence[int] = None,
+    axes : None | Literal["auto"] | int | Sequence[int] = "auto",
 ) -> np.floating[Any] | np.ndarray:
     """Convert an amplitude spectrogram to dB-scaled spectrogram.
 
@@ -2014,9 +2014,10 @@ def amplitude_to_db(
         threshold the output at ``top_db`` below the peak:
         ``max(20 * log10(S/ref)) - top_db``
 
-    axes : None, int, or list of int
+    axes : None, "auto", int, or list of int
         Axis or axes along which to compute the reference value (if `ref` is callable).
-        If `None`, then axes will be inferred as the trailing dimensions of `S`:
+        If `auto`, then axes will be inferred as the trailing dimensions of `S`:
+            - If `S` is scalar, then `axes=None`
             - If `S` is 1D, then `axes=(-1,)`
             - If `S` is >=2D, then `axes=(-2, -1)`
 

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1783,6 +1783,7 @@ def power_to_db(
     axes : None, int, or list of int
         Axis or axes along which to compute the reference value (if `ref` is callable).
         If `None`, then axes will be inferred as the trailing dimensions of `S`:
+            - If `S` is scalar, then `axes=None`
             - If `S` is 1D, then `axes=(-1,)`
             - If `S` is >=2D, then `axes=(-2, -1)`
 
@@ -1864,16 +1865,18 @@ def power_to_db(
         magnitude = S
 
     if axes is None:
-        # Single-channel (1D/2D) vs Multichannel (3D+)
-        axes = (-2, -1) if magnitude.ndim > 1 else (-1,)
+        if magnitude.ndim >= 2:
+            axes = (-2, -1)
+        elif magnitude.ndim == 1:
+            axes = (-1,)
+        else:
+            axes = None
 
     if callable(ref):
-        # User supplied a function to calculate reference power
         try:
-            # Happy path: Array API standard compliant (np.max, np.mean, xp.max)
+            # Compute the reference value along the specified axes, keeping dimensions for broadcasting
             ref_value = ref(magnitude, axis=axes, keepdims=True)
         except TypeError as e:
-            # Fallback: Catch built-in `max` or non-compliant custom functions
             raise ParameterError(
                 "The provided reference function must support 'axis' and "
                 "'keepdims' arguments for proper multichannel processing. "
@@ -2043,16 +2046,18 @@ def amplitude_to_db(
     magnitude = np.abs(S)
 
     if axes is None:
-        # Single-channel (1D/2D) vs Multichannel (3D+)
-        axes = (-2, -1) if magnitude.ndim > 1 else (-1,)
+        if magnitude.ndim >= 2:
+            axes = (-2, -1)
+        elif magnitude.ndim == 1:
+            axes = (-1,)
+        else:
+            axes = None
 
     if callable(ref):
-        # User supplied a function to calculate reference power
         try:
-            # Happy path: Array API standard compliant (np.max, np.mean, xp.max)
+            # Compute the reference value along the specified axes, keeping dimensions for broadcasting
             ref_value = ref(magnitude, axis=axes, keepdims=True)
         except TypeError as e:
-            # Fallback: Catch built-in `max` or non-compliant custom functions
             raise ParameterError(
                 "The provided reference function must support 'axis' and "
                 "'keepdims' arguments for proper multichannel processing. "

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -2069,7 +2069,7 @@ def amplitude_to_db(
     out_array = magnitude if isinstance(magnitude, np.ndarray) else None
     power = np.square(magnitude, out=out_array)
 
-    db: np.ndarray = power_to_db(power, ref=ref_value**2, amin=amin**2, top_db=top_db)
+    db: np.ndarray = power_to_db(power, ref=ref_value**2, amin=amin**2, top_db=top_db, axes=axes)
     return db[()]
 
 

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1779,6 +1779,8 @@ def power_to_db(
     top_db : float >= 0 [scalar]
         threshold the output at ``top_db`` below the peak:
         ``max(10 * log10(S/ref)) - top_db``
+        For multi-channel inputs, with `axes='auto'`, peaks
+        are calculated independently for each channel.
 
     axes: None, "auto", int, or tuple of int
         Axis or axes along which to compute the reference value (if `ref` is callable).
@@ -1879,7 +1881,7 @@ def power_to_db(
         except TypeError as e:
             raise ParameterError(
                 "The provided reference function must support 'axis' and "
-                "'keepdims' arguments for proper multichannel processing. "
+                "'keepdims' arguments for proper multichannel processing."
             ) from e
     else:
         ref_value = np.abs(ref)
@@ -2013,6 +2015,8 @@ def amplitude_to_db(
     top_db : float >= 0 [scalar]
         threshold the output at ``top_db`` below the peak:
         ``max(20 * log10(S/ref)) - top_db``
+        For multi-channel inputs, with `axes='auto'`, peaks
+        are calculated independently for each channel.
 
     axes : None, "auto", int, or tuple of int
         Axis or axes along which to compute the reference value (if `ref` is callable).
@@ -2053,8 +2057,6 @@ def amplitude_to_db(
             axes = (-1,)
         else:
             axes = None
-    else:
-        axes = axes
 
     if callable(ref):
         try:
@@ -2063,7 +2065,7 @@ def amplitude_to_db(
         except TypeError as e:
             raise ParameterError(
                 "The provided reference function must support 'axis' and "
-                "'keepdims' arguments for proper multichannel processing. "
+                "'keepdims' arguments for proper multichannel processing."
             ) from e
     else:
         ref_value = np.abs(ref)

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -19,7 +19,7 @@ from . import convert
 from .audio import resample
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Literal, Sequence
+    from typing import Any, Callable, Literal
 
     from numpy.typing import DTypeLike
 
@@ -1719,7 +1719,7 @@ def power_to_db(
     ref: float | Callable = ...,
     amin: float = ...,
     top_db: float | None = ...,
-    axes: None | Literal["auto"] | int | tuple[int] = ...,
+    axes: None | Literal["auto"] | int | tuple[int, ...] = ...,
 ) -> np.floating[Any]: ...
 
 
@@ -1730,7 +1730,7 @@ def power_to_db(
     ref: float | Callable = ...,
     amin: float = ...,
     top_db: float | None = ...,
-    axes: None | Literal["auto"] | int | tuple[int] = ...,
+    axes: None | Literal["auto"] | int | tuple[int, ...] = ...,
 ) -> np.ndarray: ...
 
 
@@ -1741,7 +1741,7 @@ def power_to_db(
     ref: float | Callable = ...,
     amin: float = ...,
     top_db: float | None = ...,
-    axes: None | Literal["auto"] | int | tuple[int] = ...,
+    axes: None | Literal["auto"] | int | tuple[int, ...] = ...,
 ) -> np.floating[Any] | np.ndarray: ...
 
 
@@ -1752,7 +1752,7 @@ def power_to_db(
     ref: float | Callable = 1.0,
     amin: float = 1e-10,
     top_db: float | None = 80.0,
-    axes: None | Literal["auto"] | int | tuple[int] = "auto",
+    axes: None | Literal["auto"] | int | tuple[int, ...] = "auto",
 ) -> np.floating[Any] | np.ndarray:
     """Convert a power spectrogram (amplitude squared) to decibel (dB) units
 
@@ -1955,7 +1955,7 @@ def amplitude_to_db(
     ref: float | Callable = ...,
     amin: float = ...,
     top_db: float | None = ...,
-    axes: None | Literal["auto"] | int | tuple[int] = ...,
+    axes: None | Literal["auto"] | int | tuple[int, ...] = ...,
 ) -> np.floating[Any]: ...
 
 
@@ -1966,7 +1966,7 @@ def amplitude_to_db(
     ref: float | Callable = ...,
     amin: float = ...,
     top_db: float | None = ...,
-    axes: None | Literal["auto"] | int | tuple[int] = ...,
+    axes: None | Literal["auto"] | int | tuple[int, ...] = ...,
 ) -> np.ndarray: ...
 
 
@@ -1977,7 +1977,7 @@ def amplitude_to_db(
     ref: float | Callable = ...,
     amin: float = ...,
     top_db: float | None = ...,
-    axes: None | Literal["auto"] | int | tuple[int] = ...,
+    axes: None | Literal["auto"] | int | tuple[int, ...] = ...,
 ) -> np.floating[Any] | np.ndarray: ...
 
 
@@ -1988,7 +1988,7 @@ def amplitude_to_db(
     ref: float | Callable = 1.0,
     amin: float = 1e-5,
     top_db: float | None = 80.0,
-    axes: None | Literal["auto"] | int | tuple[int] = "auto",
+    axes: None | Literal["auto"] | int | tuple[int, ...] = "auto",
 ) -> np.floating[Any] | np.ndarray:
     """Convert an amplitude spectrogram to dB-scaled spectrogram.
 
@@ -2053,6 +2053,8 @@ def amplitude_to_db(
             axes = (-1,)
         else:
             axes = None
+    else:
+        axes = axes
 
     if callable(ref):
         try:
@@ -2069,7 +2071,9 @@ def amplitude_to_db(
     out_array = magnitude if isinstance(magnitude, np.ndarray) else None
     power = np.square(magnitude, out=out_array)
 
-    db: np.ndarray = power_to_db(power, ref=ref_value**2, amin=amin**2, top_db=top_db, axes=axes)
+    db: np.ndarray = power_to_db(power, ref=ref_value**2,
+                                 amin=amin**2, top_db=top_db,
+                                 axes=axes)
     return db[()]
 
 

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -1854,11 +1854,6 @@ def mfcc(
 ) -> np.ndarray:
     """Mel-frequency cepstral coefficients (MFCCs)
 
-    .. warning:: If multi-channel audio input ``y`` is provided, the MFCC
-        calculation will depend on the peak loudness (in decibels) across
-        all channels.  The result may differ from independent MFCC calculation
-        of each channel.
-
     Parameters
     ----------
     y : np.ndarray [shape=(..., n,)] or None

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1737,7 +1737,7 @@ def test_power_to_db_scalar():
     assert np.isclose(librosa.power_to_db(2), 3.0103)
 
 
-@pytest.mark.xfail(raises=librosa.ParameterError)
+@pytest.mark.raises(librosa.ParameterError)
 def test_power_to_db_bad_reducer():
     x = np.ones((10,10))
     def mymax(z, axis=None):
@@ -1747,7 +1747,7 @@ def test_power_to_db_bad_reducer():
     librosa.power_to_db(x, ref=mymax)
 
 
-@pytest.mark.xfail(raises=librosa.ParameterError)
+@pytest.mark.raises(librosa.ParameterError)
 def test_amplitude_to_db_bad_reducer():
     x = np.ones((10,10))
     def mymax(z, axis=None):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1737,6 +1737,26 @@ def test_power_to_db_scalar():
     assert np.isclose(librosa.power_to_db(2), 3.0103)
 
 
+@pytest.mark.xfail(raises=librosa.ParameterError)
+def test_power_to_db_bad_reducer():
+    x = np.ones((10,10))
+    def mymax(z, axis=None):
+        # A bad reducer that does not support keepdims
+        return np.max(z, axis=axis)
+
+    librosa.power_to_db(x, ref=mymax)
+
+
+@pytest.mark.xfail(raises=librosa.ParameterError)
+def test_amplitude_to_db_bad_reducer():
+    x = np.ones((10,10))
+    def mymax(z, axis=None):
+        # A bad reducer that does not support keepdims
+        return np.max(z, axis=axis)
+
+    librosa.amplitude_to_db(x, ref=mymax)
+
+
 def test_db_to_amplitude_scalar():
     assert np.isclose(librosa.db_to_amplitude(0), 1)
     assert np.isclose(librosa.db_to_amplitude(6.0206), 2)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1737,24 +1737,24 @@ def test_power_to_db_scalar():
     assert np.isclose(librosa.power_to_db(2), 3.0103)
 
 
-@pytest.mark.raises(librosa.ParameterError)
 def test_power_to_db_bad_reducer():
     x = np.ones((10,10))
     def mymax(z, axis=None):
         # A bad reducer that does not support keepdims
         return np.max(z, axis=axis)
 
-    librosa.power_to_db(x, ref=mymax)
+    with pytest.raises(librosa.ParameterError):
+        librosa.power_to_db(x, ref=mymax)
 
 
-@pytest.mark.raises(librosa.ParameterError)
 def test_amplitude_to_db_bad_reducer():
     x = np.ones((10,10))
     def mymax(z, axis=None):
         # A bad reducer that does not support keepdims
         return np.max(z, axis=axis)
 
-    librosa.amplitude_to_db(x, ref=mymax)
+    with pytest.raises(librosa.ParameterError):
+        librosa.amplitude_to_db(x, ref=mymax)
 
 
 def test_db_to_amplitude_scalar():

--- a/tests/test_multichannel.py
+++ b/tests/test_multichannel.py
@@ -666,7 +666,6 @@ def test_mfcc_multi(s_multi):
     assert not np.allclose(Call[0], Call[1])
 
 
-#@pytest.mark.skip(reason="power_to_db leaks information across channels")
 def test_mfcc_multi_time(y_multi):
     y, sr = y_multi
 

--- a/tests/test_multichannel.py
+++ b/tests/test_multichannel.py
@@ -666,21 +666,21 @@ def test_mfcc_multi(s_multi):
     assert not np.allclose(Call[0], Call[1])
 
 
-@pytest.mark.skip(reason="power_to_db leaks information across channels")
+#@pytest.mark.skip(reason="power_to_db leaks information across channels")
 def test_mfcc_multi_time(y_multi):
     y, sr = y_multi
 
     # compare each channel
-    C0 = librosa.feature.mfcc(y=y[0])
-    C1 = librosa.feature.mfcc(y=y[1])
-    Call = librosa.feature.mfcc(y=y)
-
-    # Check each channel
-    assert np.allclose(C0, Call[0])
-    assert np.allclose(C1, Call[1])
+    C0 = librosa.feature.mfcc(y=y[0], sr=sr)
+    C1 = librosa.feature.mfcc(y=y[1], sr=sr)
+    Call = librosa.feature.mfcc(y=y, sr=sr)
 
     # Verify that they're not all the same
     assert not np.allclose(Call[0], Call[1])
+
+    # Check each channel
+    assert np.allclose(C0, Call[0]), np.max(np.abs(C0 - Call[0]))
+    assert np.allclose(C1, Call[1]), np.max(np.abs(C1 - Call[1]))
 
 
 def test_melspectrogram_multi(s_multi):


### PR DESCRIPTION
#### Reference Issue
Fixes #1778 

#### What does this implement/fix? Explain your changes.
This PR adds channel-independent processing for decibel conversion.  This is implemented by adding target axes to `*_to_db` functions, which are inferred (for ndim>1) as `axes=(-2,-1)`.

This ensures, for example, that calculating mfcc's on multichannel inputs produces identical results to channel-independent calculation.

#### Any other comments?

I had initially planned on exposing the target axes through the api (e.g. in `mfcc`).  I think I'll walk this back though.  I think it's generally more correct to handle this channel-independently (as in this PR now by default).  It's still possible for a user to pass in a precalculated dB spectrum, and if they really want things the way they were before, they can compute the dB scale with `axes=(-3,-2,-1)` (or whatever) up front.  We shouldn't make it too easy for users to do the wrong thing here.

I opted against implementing this ref targeting for `zero_crossings`, at least for now, as it's doing some pretty different things than db scaling.

The one lingering question for me here is how best to handle trimming and splitting.  Probably I just need to think on that a bit more, but i wanted to get this PR off the ground first to make sure the rest of the tests are working properly.