### PR TITLE
Improve `ndarray` return types

### DIFF
--- a/librosa/_typing.py
+++ b/librosa/_typing.py
@@ -112,3 +112,7 @@ type _DCTType = Literal[1, 2, 3, 4]
 type _Real = float | np.integer[Any] | np.floating[Any]
 type _Complex = _Real | np.complexfloating[Any, Any]
 type _Number = complex | np.number[Any]
+
+# Shape-typing
+type _Array1D[ScalarT: np.generic] = np.ndarray[tuple[int], np.dtype[ScalarT]]
+type _Array2D[ScalarT: np.generic] = np.ndarray[tuple[int, int], np.dtype[ScalarT]]

--- a/librosa/beat.py
+++ b/librosa/beat.py
@@ -25,7 +25,7 @@ from .util.exceptions import ParameterError
 if TYPE_CHECKING:
     import scipy.stats
 
-    from ._typing import _FloatLike_co
+    from ._typing import _Array1D, _FloatLike_co
 
 __all__ = ["beat_track", "plp"]
 
@@ -453,7 +453,7 @@ def plp(
 
 def __beat_tracker(
     onset_envelope: np.ndarray, bpm: np.ndarray, frame_rate: float, tightness: float, trim: bool
-) -> np.ndarray:
+) -> _Array1D[np.bool]:
     """Track beats in an onset strength envelope.
 
     Parameters

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -3,7 +3,7 @@
 """Core IO, DSP and utility functions."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, overload
 
 import lazy_loader as lazy
 import numpy as np
@@ -22,9 +22,9 @@ if TYPE_CHECKING:
     import os
     from typing import Any, BinaryIO, Callable, Generator
 
-    from numpy.typing import DTypeLike
+    from numpy.typing import DTypeLike, NDArray
 
-    from .._typing import _FloatLike_co, _IntLike_co, _ScalarOrSequence, _SequenceLike
+    from .._typing import _Array1D, _FloatLike_co, _IntLike_co, _SequenceLike
 
 
 # Lazy-load optional dependencies
@@ -1384,7 +1384,7 @@ def __lpc(
 
 
 @stencil  # type: ignore
-def _zc_stencil(x: np.ndarray, threshold: float, zero_pos: bool) -> np.ndarray:
+def _zc_stencil(x: np.ndarray, threshold: float, zero_pos: bool) -> NDArray[np.bool]:
     """Stencil to compute zero crossings"""
     x0 = x[0]
     if -threshold <= x0 <= threshold:
@@ -1409,7 +1409,7 @@ def _zc_wrapper(
     x: np.ndarray,
     threshold: float,
     zero_pos: bool,
-    y: np.ndarray,
+    y: NDArray[np.bool],
 ) -> None:  # pragma: no cover
     """Vectorized wrapper for zero crossing stencil"""
     y[:] = _zc_stencil(x, threshold, zero_pos)
@@ -1424,7 +1424,7 @@ def zero_crossings(
     pad: bool = True,
     zero_pos: bool = True,
     axis: int = -1,
-) -> np.ndarray:
+) -> NDArray[np.bool]:
     """Find the zero-crossings of a signal ``y``: indices ``i`` such that ``sign(y[i]) != sign(y[j])``.
 
     If ``y`` is multi-dimensional, then zero-crossings are computed along
@@ -1536,7 +1536,7 @@ def clicks(
     click_duration: float = 0.1,
     click: np.ndarray | None = None,
     length: int | None = None,
-) -> np.ndarray:
+) -> NDArray[np.float32]:
     """Construct a "click track".
 
     This returns a signal with the signal ``click`` sound placed at
@@ -1670,7 +1670,7 @@ def tone(
     length: int | None = None,
     duration: float | None = None,
     phi: float | None = None,
-) -> np.ndarray:
+) -> _Array1D[np.float64]:
     """Construct a pure tone (cosine) signal at a given frequency.
 
     Parameters
@@ -1744,7 +1744,7 @@ def chirp(
     duration: float | None = None,
     linear: bool = False,
     phi: float | None = None,
-) -> np.ndarray:
+) -> _Array1D[np.float64]:
     """Construct a "chirp" or "sine-sweep" signal.
 
     The chirp sweeps from frequency ``fmin`` to ``fmax`` (in Hz).
@@ -1942,9 +1942,13 @@ def mu_compress(
     return x_comp
 
 
+@overload
+def mu_expand(x: _FloatLike_co, *, mu: float = 255.0, quantize: bool = True) -> np.floating: ...
+@overload
+def mu_expand(x: np.ndarray, *, mu: float = 255.0, quantize: bool = True) -> np.ndarray: ...
 def mu_expand(
     x: np.ndarray | _FloatLike_co, *, mu: float = 255.0, quantize: bool = True
-) -> _ScalarOrSequence[_FloatLike_co]:
+) -> np.ndarray | np.floating:
     """Expansion by μ-law
 
     This function is the inverse of ``mu_compress``. Given a mu-law compressed
@@ -2028,5 +2032,5 @@ def mu_expand(
             f"Inverse mu-law input x={x} must be in the range [-1, +1]."
         )
 
-    y: _ScalarOrSequence[_FloatLike_co] = np.sign(x) / mu * (np.power(1 + mu, np.abs(x)) - 1)
+    y: np.ndarray | np.floating = np.sign(x) / mu * (np.power(1 + mu, np.abs(x)) - 1)
     return y

--- a/librosa/core/convert.py
+++ b/librosa/core/convert.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, overload
+from typing import TYPE_CHECKING, cast, overload
 
 import numpy as np
 
@@ -1388,7 +1388,7 @@ def fft_frequencies(*, sr: float = 22050, n_fft: int = 2048) -> _Array1D[np.floa
              5512.5  ,   6890.625,   8268.75 ,   9646.875,  11025.   ])
     """
     # the return dtype was unnecessarily broad in the numpy<2.5 dtype stubs
-    return np.fft.rfftfreq(n=n_fft, d=1.0 / sr)  # type:ignore[return-value]
+    return cast("_Array1D[np.float64]", np.fft.rfftfreq(n=n_fft, d=1.0 / sr))
 
 
 def cqt_frequencies(

--- a/librosa/core/convert.py
+++ b/librosa/core/convert.py
@@ -13,11 +13,13 @@ from ..util.exceptions import ParameterError
 from . import notation
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from typing import Any, Callable, Iterable, Sized
 
     import numpy.typing as npt
 
     from .._typing import (
+        _Array1D,
         _FloatLike_co,
         _IntLike_co,
         _IterableLike,
@@ -75,24 +77,20 @@ __all__ = [
 @overload
 def frames_to_samples(
     frames: _IntLike_co, *, hop_length: int = 512, n_fft: int | None = None
-) -> np.integer[Any]: ...
-
-
+) -> np.int_: ...
 @overload
 def frames_to_samples(
     frames: _SequenceLike[_IntLike_co],
     *,
     hop_length: int = 512,
     n_fft: int | None = None,
-) -> np.ndarray: ...
-
-
+) -> npt.NDArray[np.int_]: ...
 def frames_to_samples(
     frames: _ScalarOrSequence[_IntLike_co],
     *,
     hop_length: int = 512,
     n_fft: int | None = None,
-) -> np.integer[Any] | np.ndarray:
+) -> np.int_ | npt.NDArray[np.int_]:
     """Convert frame indices to audio sample indices.
 
     Parameters
@@ -134,33 +132,20 @@ def frames_to_samples(
 @overload
 def samples_to_frames(
     samples: _IntLike_co, *, hop_length: int = ..., n_fft: int | None = ...
-) -> np.integer[Any]: ...
-
-
+) -> np.int_: ...
 @overload
 def samples_to_frames(
     samples: _SequenceLike[_IntLike_co],
     *,
     hop_length: int = ...,
     n_fft: int | None = ...,
-) -> np.ndarray: ...
-
-
-@overload
-def samples_to_frames(
-    samples: _ScalarOrSequence[_IntLike_co],
-    *,
-    hop_length: int = ...,
-    n_fft: int | None = ...,
-) -> np.integer[Any] | np.ndarray: ...
-
-
+) -> npt.NDArray[np.int_]: ...
 def samples_to_frames(
     samples: _ScalarOrSequence[_IntLike_co],
     *,
     hop_length: int = 512,
     n_fft: int | None = None,
-) -> np.integer[Any] | np.ndarray:
+) -> np.int_ | npt.NDArray[np.int_]:
     """Convert sample indices into STFT frames.
 
     Examples
@@ -217,9 +202,7 @@ def frames_to_time(
     sr: float = ...,
     hop_length: int = ...,
     n_fft: int | None = ...,
-) -> np.floating[Any]: ...
-
-
+) -> np.float64: ...
 @overload
 def frames_to_time(
     frames: _SequenceLike[_IntLike_co],
@@ -227,26 +210,14 @@ def frames_to_time(
     sr: float = ...,
     hop_length: int = ...,
     n_fft: int | None = ...,
-) -> np.ndarray: ...
-
-
-@overload
-def frames_to_time(
-    frames: _ScalarOrSequence[_IntLike_co],
-    *,
-    sr: float = ...,
-    hop_length: int = ...,
-    n_fft: int | None = ...,
-) -> np.floating[Any] | np.ndarray: ...
-
-
+) -> npt.NDArray[np.float64]: ...
 def frames_to_time(
     frames: _ScalarOrSequence[_IntLike_co],
     *,
     sr: float = 22050,
     hop_length: int = 512,
     n_fft: int | None = None,
-) -> np.floating[Any] | np.ndarray:
+) -> np.float64 | npt.NDArray[np.float64]:
     """Convert frame counts to time (seconds).
 
     Parameters
@@ -292,9 +263,7 @@ def time_to_frames(
     sr: float = ...,
     hop_length: int = ...,
     n_fft: int | None = ...,
-) -> np.integer[Any]: ...
-
-
+) -> np.int_: ...
 @overload
 def time_to_frames(
     times: _SequenceLike[_FloatLike_co],
@@ -302,26 +271,14 @@ def time_to_frames(
     sr: float = ...,
     hop_length: int = ...,
     n_fft: int | None = ...,
-) -> np.ndarray: ...
-
-
-@overload
-def time_to_frames(
-    times: _ScalarOrSequence[_FloatLike_co],
-    *,
-    sr: float = ...,
-    hop_length: int = ...,
-    n_fft: int | None = ...,
-) -> np.integer[Any] | np.ndarray: ...
-
-
+) -> npt.NDArray[np.int_]: ...
 def time_to_frames(
     times: _ScalarOrSequence[_FloatLike_co],
     *,
     sr: float = 22050,
     hop_length: int = 512,
     n_fft: int | None = None,
-) -> np.integer[Any] | np.ndarray:
+) -> np.int_ | npt.NDArray[np.int_]:
     """Convert time stamps into STFT frames.
 
     Parameters
@@ -368,24 +325,14 @@ def time_to_frames(
 
 
 @overload
-def time_to_samples(times: _FloatLike_co, *, sr: float = ...) -> np.integer[Any]: ...
-
-
+def time_to_samples(times: _FloatLike_co, *, sr: float = ...) -> np.int_: ...
 @overload
 def time_to_samples(
     times: _SequenceLike[_FloatLike_co], *, sr: float = ...
-) -> np.ndarray: ...
-
-
-@overload
-def time_to_samples(
-    times: _ScalarOrSequence[_FloatLike_co], *, sr: float = ...
-) -> np.integer[Any] | np.ndarray: ...
-
-
+) -> npt.NDArray[np.int_]: ...
 def time_to_samples(
     times: _ScalarOrSequence[_FloatLike_co], *, sr: float = 22050
-) -> np.integer[Any] | np.ndarray:
+) -> np.int_ | npt.NDArray[np.int_]:
     """Convert timestamps (in seconds) to sample indices.
 
     Parameters
@@ -415,24 +362,14 @@ def time_to_samples(
 
 
 @overload
-def samples_to_time(samples: _IntLike_co, *, sr: float = ...) -> np.floating[Any]: ...
-
-
+def samples_to_time(samples: _IntLike_co, *, sr: float = ...) -> np.float64: ...
 @overload
 def samples_to_time(
     samples: _SequenceLike[_IntLike_co], *, sr: float = ...
-) -> np.ndarray: ...
-
-
-@overload
-def samples_to_time(
-    samples: _ScalarOrSequence[_IntLike_co], *, sr: float = ...
-) -> np.floating[Any] | np.ndarray: ...
-
-
+) -> npt.NDArray[np.float64]: ...
 def samples_to_time(
     samples: _ScalarOrSequence[_IntLike_co], *, sr: float = 22050
-) -> np.floating[Any] | np.ndarray:
+) -> np.float64 | npt.NDArray[np.float64]:
     """Convert sample indices to time (in seconds).
 
     Parameters
@@ -469,24 +406,14 @@ def samples_to_time(
 
 
 @overload
-def blocks_to_frames(blocks: _IntLike_co, *, block_length: int) -> np.integer[Any]: ...
-
-
+def blocks_to_frames(blocks: _IntLike_co, *, block_length: int) -> np.integer: ...
 @overload
 def blocks_to_frames(
     blocks: _SequenceLike[_IntLike_co], *, block_length: int
-) -> np.ndarray: ...
-
-
-@overload
+) -> npt.NDArray[np.integer]: ...
 def blocks_to_frames(
     blocks: _ScalarOrSequence[_IntLike_co], *, block_length: int
-) -> np.integer[Any] | np.ndarray: ...
-
-
-def blocks_to_frames(
-    blocks: _ScalarOrSequence[_IntLike_co], *, block_length: int
-) -> np.integer[Any] | np.ndarray:
+) -> np.integer | npt.NDArray[np.integer]:
     """Convert block indices to frame indices
 
     Parameters
@@ -524,24 +451,14 @@ def blocks_to_frames(
 @overload
 def blocks_to_samples(
     blocks: _IntLike_co, *, block_length: int, hop_length: int
-) -> np.integer[Any]: ...
-
-
+) -> np.int_: ...
 @overload
 def blocks_to_samples(
     blocks: _SequenceLike[_IntLike_co], *, block_length: int, hop_length: int
-) -> np.ndarray: ...
-
-
-@overload
+) -> npt.NDArray[np.int_]: ...
 def blocks_to_samples(
     blocks: _ScalarOrSequence[_IntLike_co], *, block_length: int, hop_length: int
-) -> np.integer[Any] | np.ndarray: ...
-
-
-def blocks_to_samples(
-    blocks: _ScalarOrSequence[_IntLike_co], *, block_length: int, hop_length: int
-) -> np.integer[Any] | np.ndarray:
+) -> np.int_ | npt.NDArray[np.int_]:
     """Convert block indices to sample indices
 
     Parameters
@@ -586,32 +503,18 @@ def blocks_to_samples(
 @overload
 def blocks_to_time(
     blocks: _IntLike_co, *, block_length: int, hop_length: int, sr: float
-) -> np.floating[Any]: ...
-
-
+) -> np.float64: ...
 @overload
 def blocks_to_time(
     blocks: _SequenceLike[_IntLike_co], *, block_length: int, hop_length: int, sr: float
-) -> np.ndarray: ...
-
-
-@overload
+) -> npt.NDArray[np.float64]: ...
 def blocks_to_time(
     blocks: _ScalarOrSequence[_IntLike_co],
     *,
     block_length: int,
     hop_length: int,
     sr: float,
-) -> np.floating[Any] | np.ndarray: ...
-
-
-def blocks_to_time(
-    blocks: _ScalarOrSequence[_IntLike_co],
-    *,
-    block_length: int,
-    hop_length: int,
-    sr: float,
-) -> np.floating[Any] | np.ndarray:
+) -> np.float64 | npt.NDArray[np.float64]:
     """Convert block indices to time (in seconds)
 
     Parameters
@@ -658,22 +561,18 @@ def blocks_to_time(
 
 
 @overload
-def note_to_hz(note: str, *, round_midi: bool = ...) -> np.floating[Any]: ...
-
-
-@overload
-def note_to_hz(note: _IterableLike[str], *, round_midi: bool = ...) -> np.ndarray: ...
-
-
+def note_to_hz(note: str, *, round_midi: bool = ...) -> np.float64: ...
 @overload
 def note_to_hz(
-    note: str | _IterableLike[str] | Iterable[str], *, round_midi: bool = ...
-) -> np.floating[Any] | np.ndarray: ...
-
-
+    note: _IterableLike[str], *, round_midi: bool = ...
+) -> _Array1D[np.float64]: ...
+@overload
+def note_to_hz(
+    note: Iterable[str], *, round_midi: bool = ...
+) -> np.float64 | _Array1D[np.float64]: ...
 def note_to_hz(
     note: str | _IterableLike[str] | Iterable[str], *, round_midi: bool = False
-) -> np.floating[Any] | np.ndarray:
+) -> np.float64 | _Array1D[np.float64]:
     """Convert one or more note names to frequency (Hz)
 
     Examples
@@ -714,22 +613,18 @@ def note_to_hz(
 
 
 @overload
-def note_to_midi(note: str, *, round_midi: bool = ...) -> float | int: ...
-
-
-@overload
-def note_to_midi(note: _IterableLike[str], *, round_midi: bool = ...) -> np.ndarray: ...
-
-
+def note_to_midi(note: str, *, round_midi: bool = ...) -> float: ...
 @overload
 def note_to_midi(
-    note: str | _IterableLike[str] | Iterable[str], *, round_midi: bool = ...
-) -> float | int | np.ndarray: ...
-
-
+    note: _IterableLike[str], *, round_midi: bool = ...
+) -> _Array1D[np.float64]: ...
+@overload
 def note_to_midi(
-    note: str | _IterableLike[str] | Iterable[str], *, round_midi: bool = True
-) -> float | np.ndarray:
+    note: Iterable[str], *, round_midi: bool = ...
+) -> float | _Array1D[np.float64]: ...
+def note_to_midi(
+    note: str | Iterable[str], *, round_midi: bool = True
+) -> float | _Array1D[np.float64]:
     """Convert one or more spelled notes to MIDI number(s).
 
     Notes may be spelled out with optional accidentals or octave numbers.
@@ -969,22 +864,14 @@ def midi_to_note(
 
 
 @overload
-def midi_to_hz(notes: _FloatLike_co) -> np.floating[Any]: ...
-
-
+def midi_to_hz(notes: float) -> np.float64: ...
+@overload
+def midi_to_hz(notes: _FloatLike_co) -> np.floating: ...
+@overload
+def midi_to_hz(notes: Sequence[float]) -> _Array1D[np.float64]: ...
 @overload
 def midi_to_hz(notes: _SequenceLike[_FloatLike_co]) -> np.ndarray: ...
-
-
-@overload
-def midi_to_hz(
-    notes: _ScalarOrSequence[_FloatLike_co],
-) -> np.ndarray | np.floating[Any]: ...
-
-
-def midi_to_hz(
-    notes: _ScalarOrSequence[_FloatLike_co],
-) -> np.ndarray | np.floating[Any]:
+def midi_to_hz(notes: _ScalarOrSequence[_FloatLike_co]) -> np.floating | np.ndarray:
     """Get the frequency (Hz) of MIDI note(s)
 
     Examples
@@ -1016,22 +903,14 @@ def midi_to_hz(
 
 
 @overload
-def hz_to_midi(frequencies: _FloatLike_co) -> np.floating[Any]: ...
-
-
+def hz_to_midi(frequencies: float) -> np.float64: ...
+@overload
+def hz_to_midi(frequencies: _FloatLike_co) -> np.floating: ...
+@overload
+def hz_to_midi(frequencies: Sequence[float]) -> _Array1D[np.float64]: ...
 @overload
 def hz_to_midi(frequencies: _SequenceLike[_FloatLike_co]) -> np.ndarray: ...
-
-
-@overload
-def hz_to_midi(
-    frequencies: _ScalarOrSequence[_FloatLike_co],
-) -> np.ndarray | np.floating[Any]: ...
-
-
-def hz_to_midi(
-    frequencies: _ScalarOrSequence[_FloatLike_co],
-) -> np.ndarray | np.floating[Any]:
+def hz_to_midi(frequencies: _ScalarOrSequence[_FloatLike_co]) -> np.floating | np.ndarray:
     """Get MIDI note number(s) for given frequencies
 
     Examples
@@ -1113,24 +992,18 @@ def hz_to_note(
 
 
 @overload
-def hz_to_mel(frequencies: _FloatLike_co, *, htk: bool = ...) -> np.floating[Any]: ...
-
-
+def hz_to_mel(frequencies: float, *, htk: bool = ...) -> np.float64: ...
+@overload
+def hz_to_mel(frequencies: _FloatLike_co, *, htk: bool = ...) -> np.floating: ...
+@overload
+def hz_to_mel(frequencies: Sequence[float], *, htk: bool = ...) -> _Array1D[np.float64]: ...
 @overload
 def hz_to_mel(
     frequencies: _SequenceLike[_FloatLike_co], *, htk: bool = ...
 ) -> np.ndarray: ...
-
-
-@overload
-def hz_to_mel(
-    frequencies: _ScalarOrSequence[_FloatLike_co], *, htk: bool = ...
-) -> np.floating[Any] | np.ndarray: ...
-
-
 def hz_to_mel(
     frequencies: _ScalarOrSequence[_FloatLike_co], *, htk: bool = False
-) -> np.floating[Any] | np.ndarray:
+) -> np.floating | np.ndarray:
     """Convert Hz to Mels
 
     Examples
@@ -1186,22 +1059,16 @@ def hz_to_mel(
 
 
 @overload
-def mel_to_hz(mels: _FloatLike_co, *, htk: bool = ...) -> np.floating[Any]: ...
-
-
+def mel_to_hz(mels: float, *, htk: bool = ...) -> np.float64: ...
+@overload
+def mel_to_hz(mels: _FloatLike_co, *, htk: bool = ...) -> np.floating: ...
+@overload
+def mel_to_hz(mels: Sequence[float], *, htk: bool = ...) -> _Array1D[np.float64]: ...
 @overload
 def mel_to_hz(mels: _SequenceLike[_FloatLike_co], *, htk: bool = ...) -> np.ndarray: ...
-
-
-@overload
-def mel_to_hz(
-    mels: _ScalarOrSequence[_FloatLike_co], *, htk: bool = ...
-) -> np.floating[Any] | np.ndarray: ...
-
-
 def mel_to_hz(
     mels: _ScalarOrSequence[_FloatLike_co], *, htk: bool = False
-) -> np.floating[Any] | np.ndarray:
+) -> np.floating | np.ndarray:
     """Convert mel bin numbers to frequencies
 
     Examples
@@ -1256,10 +1123,19 @@ def mel_to_hz(
 
 @overload
 def hz_to_octs(
+    frequencies: float, *, tuning: float = ..., bins_per_octave: int = ...
+) -> np.float64: ...
+@overload
+def hz_to_octs(
     frequencies: _FloatLike_co, *, tuning: float = ..., bins_per_octave: int = ...
-) -> np.floating[Any]: ...
-
-
+) -> np.floating: ...
+@overload
+def hz_to_octs(
+    frequencies: Sequence[float],
+    *,
+    tuning: float = ...,
+    bins_per_octave: int = ...,
+) -> _Array1D[np.float64]: ...
 @overload
 def hz_to_octs(
     frequencies: _SequenceLike[_FloatLike_co],
@@ -1267,23 +1143,12 @@ def hz_to_octs(
     tuning: float = ...,
     bins_per_octave: int = ...,
 ) -> np.ndarray: ...
-
-
-@overload
-def hz_to_octs(
-    frequencies: _ScalarOrSequence[_FloatLike_co],
-    *,
-    tuning: float = ...,
-    bins_per_octave: int = ...,
-) -> np.floating[Any] | np.ndarray: ...
-
-
 def hz_to_octs(
     frequencies: _ScalarOrSequence[_FloatLike_co],
     *,
     tuning: float = 0.0,
     bins_per_octave: int = 12,
-) -> np.floating[Any] | np.ndarray:
+) -> np.floating | np.ndarray:
     """Convert frequencies (Hz) to (fractional) octave numbers.
 
     Examples
@@ -1319,10 +1184,16 @@ def hz_to_octs(
 
 @overload
 def octs_to_hz(
+    octs: float, *, tuning: float = ..., bins_per_octave: int = ...
+) -> np.float64: ...
+@overload
+def octs_to_hz(
     octs: _FloatLike_co, *, tuning: float = ..., bins_per_octave: int = ...
-) -> np.floating[Any]: ...
-
-
+) -> np.floating: ...
+@overload
+def octs_to_hz(
+    octs: Sequence[float], *, tuning: float = ..., bins_per_octave: int = ...
+) -> _Array1D[np.float64]: ...
 @overload
 def octs_to_hz(
     octs: _SequenceLike[_FloatLike_co],
@@ -1330,23 +1201,12 @@ def octs_to_hz(
     tuning: float = ...,
     bins_per_octave: int = ...,
 ) -> np.ndarray: ...
-
-
-@overload
-def octs_to_hz(
-    octs: _ScalarOrSequence[_FloatLike_co],
-    *,
-    tuning: float = ...,
-    bins_per_octave: int = ...,
-) -> np.floating[Any] | np.ndarray: ...
-
-
 def octs_to_hz(
     octs: _ScalarOrSequence[_FloatLike_co],
     *,
     tuning: float = 0.0,
     bins_per_octave: int = 12,
-) -> np.floating[Any] | np.ndarray:
+) -> np.floating | np.ndarray:
     """Convert octaves numbers to frequencies.
 
     Octaves are counted relative to A.
@@ -1382,26 +1242,20 @@ def octs_to_hz(
 
 
 @overload
+def A4_to_tuning(A4: float, *, bins_per_octave: int = ...) -> np.float64: ...
+@overload
+def A4_to_tuning(A4: _FloatLike_co, *, bins_per_octave: int = ...) -> np.floating: ...
+@overload
 def A4_to_tuning(
-    A4: _FloatLike_co, *, bins_per_octave: int = ...
-) -> np.floating[Any]: ...
-
-
+    A4: Sequence[float], *, bins_per_octave: int = ...
+) -> _Array1D[np.float64]: ...
 @overload
 def A4_to_tuning(
     A4: _SequenceLike[_FloatLike_co], *, bins_per_octave: int = ...
 ) -> np.ndarray: ...
-
-
-@overload
-def A4_to_tuning(
-    A4: _ScalarOrSequence[_FloatLike_co], *, bins_per_octave: int = ...
-) -> np.floating[Any] | np.ndarray: ...
-
-
 def A4_to_tuning(
     A4: _ScalarOrSequence[_FloatLike_co], *, bins_per_octave: int = 12
-) -> np.floating[Any] | np.ndarray:
+) -> np.floating | np.ndarray:
     """Convert a reference pitch frequency (e.g., ``A4=435``) to a tuning estimation, in fractions of a bin per octave.
 
     This is useful for determining the tuning deviation relative to
@@ -1451,26 +1305,20 @@ def A4_to_tuning(
 
 
 @overload
+def tuning_to_A4(tuning: float, *, bins_per_octave: int = ...) -> np.float64: ...
+@overload
+def tuning_to_A4(tuning: _FloatLike_co, *, bins_per_octave: int = ...) -> np.floating: ...
+@overload
 def tuning_to_A4(
-    tuning: _FloatLike_co, *, bins_per_octave: int = ...
-) -> np.floating[Any]: ...
-
-
+    tuning: Sequence[float], *, bins_per_octave: int = ...
+) -> _Array1D[np.float64]: ...
 @overload
 def tuning_to_A4(
     tuning: _SequenceLike[_FloatLike_co], *, bins_per_octave: int = ...
 ) -> np.ndarray: ...
-
-
-@overload
-def tuning_to_A4(
-    tuning: _ScalarOrSequence[_FloatLike_co], *, bins_per_octave: int = ...
-) -> np.floating[Any] | np.ndarray: ...
-
-
 def tuning_to_A4(
     tuning: _ScalarOrSequence[_FloatLike_co], *, bins_per_octave: int = 12
-) -> np.floating[Any] | np.ndarray:
+) -> np.floating | np.ndarray:
     """Convert a tuning deviation (from 0) to a reference pitch frequency relative to A440.
 
     This is useful if you are working in a non-A440 tuning system
@@ -1518,7 +1366,7 @@ def tuning_to_A4(
     return 440.0 * 2.0 ** (np.asanyarray(tuning)[()] / bins_per_octave)
 
 
-def fft_frequencies(*, sr: float = 22050, n_fft: int = 2048) -> np.ndarray:
+def fft_frequencies(*, sr: float = 22050, n_fft: int = 2048) -> _Array1D[np.float64]:
     """Alternative interface for `np.fft.rfftfreq`
 
     Parameters
@@ -1539,12 +1387,13 @@ def fft_frequencies(*, sr: float = 22050, n_fft: int = 2048) -> np.ndarray:
     array([     0.   ,   1378.125,   2756.25 ,   4134.375,
              5512.5  ,   6890.625,   8268.75 ,   9646.875,  11025.   ])
     """
-    return np.fft.rfftfreq(n=n_fft, d=1.0 / sr)
+    # the return dtype was unnecessarily broad in the numpy<2.5 dtype stubs
+    return np.fft.rfftfreq(n=n_fft, d=1.0 / sr)  # type:ignore[return-value]
 
 
 def cqt_frequencies(
     n_bins: int, *, fmin: float, bins_per_octave: int = 12, tuning: float = 0.0
-) -> np.ndarray:
+) -> _Array1D[np.float64]:
     """Compute the center frequencies of Constant-Q bins.
 
     Examples
@@ -1582,7 +1431,7 @@ def cqt_frequencies(
 
 def mel_frequencies(
     n_mels: int = 128, *, fmin: float = 0.0, fmax: float = 11025.0, htk: bool = False
-) -> np.ndarray:
+) -> _Array1D[np.float64]:
     """Compute an array of acoustic frequencies tuned to the mel scale.
 
     The mel scale is a quasi-logarithmic function of acoustic frequency
@@ -1659,13 +1508,12 @@ def mel_frequencies(
 
     mels = np.linspace(min_mel, max_mel, n_mels)
 
-    hz: np.ndarray = mel_to_hz(mels, htk=htk)
-    return hz
+    return mel_to_hz(mels, htk=htk)
 
 
 def tempo_frequencies(
     n_bins: int, *, hop_length: int = 512, sr: float = 22050
-) -> np.ndarray:
+) -> _Array1D[np.float64]:
     """Compute the frequencies (in beats per minute) corresponding to an onset auto-correlation or tempogram matrix.
 
     Parameters
@@ -1702,7 +1550,7 @@ def tempo_frequencies(
 
 def fourier_tempo_frequencies(
     *, sr: float = 22050, win_length: int = 384, hop_length: int = 512
-) -> np.ndarray:
+) -> _Array1D[np.float64]:
     """Compute the frequencies (in beats per minute) corresponding to a Fourier tempogram matrix.
 
     Parameters
@@ -1731,31 +1579,21 @@ def fourier_tempo_frequencies(
     return fft_frequencies(sr=sr * 60 / float(hop_length), n_fft=win_length)
 
 
-# A-weighting should be capitalized: suppress the naming warning
+@overload
+def A_weighting(frequencies: float, *, min_db: float | None = ...) -> np.float64: ...
+@overload
+def A_weighting(frequencies: _FloatLike_co, *, min_db: float | None = ...) -> np.floating: ...
 @overload
 def A_weighting(
-    frequencies: _FloatLike_co, *, min_db: float | None = ...
-) -> np.floating[Any]:  # pylint: disable=invalid-name
-    ...
-
-
+    frequencies: Sequence[float], *, min_db: float | None = ...
+) -> _Array1D[np.float64]: ...
 @overload
 def A_weighting(
     frequencies: _SequenceLike[_FloatLike_co], *, min_db: float | None = ...
-) -> np.ndarray:  # pylint: disable=invalid-name
-    ...
-
-
-@overload
-def A_weighting(
-    frequencies: _ScalarOrSequence[_FloatLike_co], *, min_db: float | None = ...
-) -> np.floating[Any] | np.ndarray:  # pylint: disable=invalid-name
-    ...
-
-
+) -> np.ndarray: ...
 def A_weighting(
     frequencies: _ScalarOrSequence[_FloatLike_co], *, min_db: float | None = -80.0
-) -> np.floating[Any] | np.ndarray:  # pylint: disable=invalid-name
+) -> np.floating | np.ndarray:
     """Compute the A-weighting of a set of frequencies.
 
     Parameters
@@ -1825,29 +1663,20 @@ def A_weighting(
 
 
 @overload
+def B_weighting(frequencies: float, *, min_db: float | None = ...) -> np.float64: ...
+@overload
+def B_weighting(frequencies: _FloatLike_co, *, min_db: float | None = ...) -> np.floating: ...
+@overload
 def B_weighting(
-    frequencies: _FloatLike_co, *, min_db: float | None = ...
-) -> np.floating[Any]:  # pylint: disable=invalid-name
-    ...
-
-
+    frequencies: Sequence[float], *, min_db: float | None = ...
+) -> _Array1D[np.float64]: ...
 @overload
 def B_weighting(
     frequencies: _SequenceLike[_FloatLike_co], *, min_db: float | None = ...
-) -> np.ndarray:  # pylint: disable=invalid-name
-    ...
-
-
-@overload
-def B_weighting(
-    frequencies: _ScalarOrSequence[_FloatLike_co], *, min_db: float | None = ...
-) -> np.floating[Any] | np.ndarray:  # pylint: disable=invalid-name
-    ...
-
-
+) -> np.ndarray: ...
 def B_weighting(
     frequencies: _ScalarOrSequence[_FloatLike_co], *, min_db: float | None = -80.0
-) -> np.floating[Any] | np.ndarray:  # pylint: disable=invalid-name
+) -> np.floating | np.ndarray:
     """Compute the B-weighting of a set of frequencies.
 
     Parameters
@@ -1916,29 +1745,20 @@ def B_weighting(
 
 
 @overload
+def C_weighting(frequencies: float, *, min_db: float | None = ...) -> np.float64: ...
+@overload
+def C_weighting(frequencies: _FloatLike_co, *, min_db: float | None = ...) -> np.floating: ...
+@overload
 def C_weighting(
-    frequencies: _FloatLike_co, *, min_db: float | None = ...
-) -> np.floating[Any]:  # pylint: disable=invalid-name
-    ...
-
-
+    frequencies: Sequence[float], *, min_db: float | None = ...
+) -> _Array1D[np.float64]: ...
 @overload
 def C_weighting(
     frequencies: _SequenceLike[_FloatLike_co], *, min_db: float | None = ...
-) -> np.ndarray:  # pylint: disable=invalid-name
-    ...
-
-
-@overload
-def C_weighting(
-    frequencies: _ScalarOrSequence[_FloatLike_co], *, min_db: float | None = ...
-) -> np.floating[Any] | np.ndarray:  # pylint: disable=invalid-name
-    ...
-
-
+) -> np.ndarray: ...
 def C_weighting(
     frequencies: _ScalarOrSequence[_FloatLike_co], *, min_db: float | None = -80.0
-) -> np.floating[Any] | np.ndarray:  # pylint: disable=invalid-name
+) -> np.floating | np.ndarray:
     """Compute the C-weighting of a set of frequencies.
 
     Parameters
@@ -2003,29 +1823,20 @@ def C_weighting(
 
 
 @overload
+def D_weighting(frequencies: float, *, min_db: float | None = ...) -> np.float64: ...
+@overload
+def D_weighting(frequencies: _FloatLike_co, *, min_db: float | None = ...) -> np.floating: ...
+@overload
 def D_weighting(
-    frequencies: _FloatLike_co, *, min_db: float | None = ...
-) -> np.floating[Any]:  # pylint: disable=invalid-name
-    ...
-
-
+    frequencies: Sequence[float], *, min_db: float | None = ...
+) -> _Array1D[np.float64]: ...
 @overload
 def D_weighting(
     frequencies: _SequenceLike[_FloatLike_co], *, min_db: float | None = ...
-) -> np.ndarray:  # pylint: disable=invalid-name
-    ...
-
-
-@overload
-def D_weighting(
-    frequencies: _ScalarOrSequence[_FloatLike_co], *, min_db: float | None = ...
-) -> np.floating[Any] | np.ndarray:  # pylint: disable=invalid-name
-    ...
-
-
+) -> np.ndarray: ...
 def D_weighting(
     frequencies: _ScalarOrSequence[_FloatLike_co], *, min_db: float | None = -80.0
-) -> np.floating[Any] | np.ndarray:  # pylint: disable=invalid-name
+) -> np.floating | np.ndarray:
     """Compute the D-weighting of a set of frequencies.
 
     Parameters
@@ -2096,7 +1907,7 @@ def D_weighting(
 
 def Z_weighting(
     frequencies: Sized, *, min_db: float | None = None
-) -> np.ndarray:  # pylint: disable=invalid-name
+) -> _Array1D[np.float64]:
     """Apply no weighting curve (aka Z-weighting).
 
     This function behaves similarly to `A_weighting`, `B_weighting`, etc.,
@@ -2135,7 +1946,7 @@ def Z_weighting(
 
 
 WEIGHTING_FUNCTIONS: dict[
-    str | None, Callable[..., np.floating[Any] | np.ndarray]
+    str | None, Callable[..., np.floating | np.ndarray]
 ] = {
     "A": A_weighting,
     "B": B_weighting,
@@ -2148,28 +1959,23 @@ WEIGHTING_FUNCTIONS: dict[
 
 @overload
 def frequency_weighting(
+    frequencies: float, *, kind: str = ..., **kwargs: Any
+) -> np.float64: ...
+@overload
+def frequency_weighting(
     frequencies: _FloatLike_co, *, kind: str = ..., **kwargs: Any
-) -> np.floating[Any]:  # pylint: disable=invalid-name
-    ...
-
-
+) -> np.floating: ...
+@overload
+def frequency_weighting(
+    frequencies: Sequence[float], *, kind: str = ..., **kwargs: Any
+) -> _Array1D[np.float64]: ...
 @overload
 def frequency_weighting(
     frequencies: _SequenceLike[_FloatLike_co], *, kind: str = ..., **kwargs: Any
-) -> np.ndarray:  # pylint: disable=invalid-name
-    ...
-
-
-@overload
-def frequency_weighting(
-    frequencies: _ScalarOrSequence[_FloatLike_co], *, kind: str = ..., **kwargs: Any
-) -> np.floating[Any] | np.ndarray:  # pylint: disable=invalid-name
-    ...
-
-
+) -> np.ndarray: ...
 def frequency_weighting(
     frequencies: _ScalarOrSequence[_FloatLike_co], *, kind: str = "A", **kwargs: Any
-) -> np.floating[Any] | np.ndarray:
+) -> np.floating | np.ndarray:
     """Compute the weighting of a set of frequencies.
 
     Parameters

--- a/librosa/core/intervals.py
+++ b/librosa/core/intervals.py
@@ -14,9 +14,9 @@ from ..util.files import _resource_file
 if TYPE_CHECKING:
     from typing import Collection, Iterable, Literal
 
-    from numpy.typing import ArrayLike
+    from numpy.typing import ArrayLike, NDArray
 
-    from .._typing import _FloatLike_co
+    from .._typing import _Array1D, _FloatLike_co
 
 
 with _resource_file("librosa.core", "intervals.msgpack") as _imsgpack, _imsgpack.open("rb") as _fdesc:
@@ -33,7 +33,7 @@ def interval_frequencies(
     bins_per_octave: int = 12,
     tuning: float = 0.0,
     sort: bool = True
-) -> np.ndarray:
+) -> _Array1D[np.float64]:
     """Construct a set of frequencies from an interval set
 
     Parameters
@@ -135,32 +135,16 @@ def interval_frequencies(
 
 @overload
 def pythagorean_intervals(
-    *,
-    bins_per_octave: int = ...,
-    sort: bool = ...,
-    return_factors: Literal[False] = ...
-) -> np.ndarray:
-    ...
-
-
+    *, bins_per_octave: int = ..., sort: bool = ..., return_factors: Literal[False] = ...
+) -> _Array1D[np.float64]: ...
 @overload
 def pythagorean_intervals(
     *, bins_per_octave: int = ..., sort: bool = ..., return_factors: Literal[True]
-) -> list[dict[int, int]]:
-    ...
-
-
-@overload
-def pythagorean_intervals(
-    *, bins_per_octave: int = ..., sort: bool = ..., return_factors: bool = ...
-) -> np.ndarray | list[dict[int, int]]:
-    ...
-
-
+) -> list[dict[int, int]]: ...
 @cache(level=10)
 def pythagorean_intervals(
     *, bins_per_octave: int = 12, sort: bool = True, return_factors: bool = False
-) -> np.ndarray | list[dict[int, int]]:
+) -> _Array1D[np.float64] | list[dict[int, int]]:
     """Pythagorean intervals
 
     Intervals are constructed by stacking ratios of 3/2 (i.e.,
@@ -303,41 +287,24 @@ def plimit_intervals(
     primes: ArrayLike,
     bins_per_octave: int = ...,
     sort: bool = ...,
-    return_factors: Literal[False] = ...
-) -> np.ndarray:
-    ...
-
-
+    return_factors: Literal[False] = ...,
+) -> NDArray[np.float64]: ...
 @overload
 def plimit_intervals(
     *,
     primes: ArrayLike,
     bins_per_octave: int = ...,
     sort: bool = ...,
-    return_factors: Literal[True]
-) -> list[dict[int, int]]:
-    ...
-
-
-@overload
-def plimit_intervals(
-    *,
-    primes: ArrayLike,
-    bins_per_octave: int = ...,
-    sort: bool = ...,
-    return_factors: bool = ...
-) -> np.ndarray | list[dict[int, int]]:
-    ...
-
-
+    return_factors: Literal[True],
+) -> list[dict[int, int]]: ...
 @cache(level=10)
 def plimit_intervals(
     *,
     primes: ArrayLike,
     bins_per_octave: int = 12,
     sort: bool = True,
-    return_factors: bool = False
-) -> np.ndarray | list[dict[int, int]]:
+    return_factors: bool = False,
+) -> NDArray[np.float64] | list[dict[int, int]]:
     """Construct p-limit intervals for a given set of prime factors.
 
     This function is based on the "harmonic crystal growth" algorithm

--- a/librosa/core/intervals.py
+++ b/librosa/core/intervals.py
@@ -130,7 +130,8 @@ def interval_frequencies(
     if sort:
         all_ratios = np.sort(all_ratios)
 
-    return all_ratios * fmin
+    frequencies: np.ndarray = all_ratios * fmin
+    return frequencies
 
 
 @overload

--- a/librosa/core/notation.py
+++ b/librosa/core/notation.py
@@ -20,7 +20,13 @@ if TYPE_CHECKING:
 
     import numpy.typing as npt
 
-    from .._typing import _FloatLike_co, _IterableLike, _ScalarOrSequence, _SequenceLike
+    from .._typing import (
+        _Array1D,
+        _FloatLike_co,
+        _IterableLike,
+        _ScalarOrSequence,
+        _SequenceLike,
+    )
 
 __all__ = [
     "key_to_degrees",
@@ -160,7 +166,7 @@ OFFSET_DICT = { "ion": 0, "dor": 1, "phr": 2, "lyd": 3, "mix": 4, "aeo": 5, "loc
 ACC_MAP = {"#": 1, "♮": 0, "": 0, "n": 0,  "b": -1, "!": -1, "♯": 1, "♭": -1, "𝄪": 2, "𝄫": -2}
 
 
-def thaat_to_degrees(thaat: str) -> np.ndarray:
+def thaat_to_degrees(thaat: str) -> _Array1D[np.int_]:
     """Construct the svara indices (degrees) for a given thaat
 
     Parameters
@@ -191,7 +197,7 @@ def thaat_to_degrees(thaat: str) -> np.ndarray:
     return np.asarray(THAAT_MAP[thaat.lower()])
 
 
-def mela_to_degrees(mela: str | int) -> np.ndarray:
+def mela_to_degrees(mela: str | int) -> _Array1D[np.int_]:
     """Construct the svara indices (degrees) for a given melakarta raga
 
     Parameters
@@ -498,15 +504,12 @@ def list_thaat() -> list[str]:
     return list(THAAT_MAP.keys())
 
 @overload
-def __note_to_degree(key: str) -> int:
-    ...
+def __note_to_degree(key: str) -> int: ...
 @overload
-def __note_to_degree(key: _IterableLike[str]) -> np.ndarray:
-    ...
+def __note_to_degree(key: _IterableLike[str]) -> _Array1D[np.int_]: ...
 @overload
-def __note_to_degree(key: str | _IterableLike[str] | Iterable[str]) -> int | np.ndarray:
-    ...
-def __note_to_degree(key: str | _IterableLike[str] | Iterable[str]) -> int | np.ndarray:
+def __note_to_degree(key: Iterable[str]) -> int | _Array1D[np.int_]: ...
+def __note_to_degree(key: str | _IterableLike[str] | Iterable[str]) -> int | _Array1D[np.int_]:
     """Take a note name and return the degree of that note (e.g. 'C#' -> 1). We allow possibilities like "C#b".
 
     >>> librosa.__note_to_degree('B#')

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -1720,9 +1720,7 @@ def power_to_db(
     amin: float = ...,
     top_db: float | None = ...,
     axes: None | Literal["auto"] | int | tuple[int, ...] = ...,
-) -> np.floating[Any]: ...
-
-
+) -> np.floating: ...
 @overload
 def power_to_db(
     S: _SequenceLike[_ComplexLike_co],
@@ -1732,19 +1730,6 @@ def power_to_db(
     top_db: float | None = ...,
     axes: None | Literal["auto"] | int | tuple[int, ...] = ...,
 ) -> np.ndarray: ...
-
-
-@overload
-def power_to_db(
-    S: _ScalarOrSequence[_ComplexLike_co],
-    *,
-    ref: float | Callable = ...,
-    amin: float = ...,
-    top_db: float | None = ...,
-    axes: None | Literal["auto"] | int | tuple[int, ...] = ...,
-) -> np.floating[Any] | np.ndarray: ...
-
-
 @cache(level=30)
 def power_to_db(
     S: _ScalarOrSequence[_ComplexLike_co],
@@ -1753,7 +1738,7 @@ def power_to_db(
     amin: float = 1e-10,
     top_db: float | None = 80.0,
     axes: None | Literal["auto"] | int | tuple[int, ...] = "auto",
-) -> np.floating[Any] | np.ndarray:
+) -> np.floating | np.ndarray:
     """Convert a power spectrogram (amplitude squared) to decibel (dB) units
 
     This computes the scaling ``10 * log10(S / ref)`` in a numerically
@@ -1902,29 +1887,17 @@ def db_to_power(
     S_db: _FloatLike_co,
     *,
     ref: float = ...,
-) -> np.floating[Any]: ...
-
-
+) -> np.floating: ...
 @overload
 def db_to_power(
     S_db: np.ndarray,
     *,
     ref: float = ...,
 ) -> np.ndarray: ...
-
-
-@overload
-def db_to_power(
-    S_db: _FloatLike_co | np.ndarray,
-    *,
-    ref: float = ...,
-) -> np.floating[Any] | np.ndarray: ...
-
-
 @cache(level=30)
 def db_to_power(
     S_db: _FloatLike_co | np.ndarray, *, ref: float = 1.0
-) -> np.floating[Any] | np.ndarray:
+) -> np.floating | np.ndarray:
     """Convert dB-scale values to a power values.
 
     This effectively inverts ``power_to_db``::
@@ -1958,9 +1931,7 @@ def amplitude_to_db(
     amin: float = ...,
     top_db: float | None = ...,
     axes: None | Literal["auto"] | int | tuple[int, ...] = ...,
-) -> np.floating[Any]: ...
-
-
+) -> np.floating: ...
 @overload
 def amplitude_to_db(
     S: _SequenceLike[_ComplexLike_co],
@@ -1970,19 +1941,6 @@ def amplitude_to_db(
     top_db: float | None = ...,
     axes: None | Literal["auto"] | int | tuple[int, ...] = ...,
 ) -> np.ndarray: ...
-
-
-@overload
-def amplitude_to_db(
-    S: _ScalarOrSequence[_ComplexLike_co],
-    *,
-    ref: float | Callable = ...,
-    amin: float = ...,
-    top_db: float | None = ...,
-    axes: None | Literal["auto"] | int | tuple[int, ...] = ...,
-) -> np.floating[Any] | np.ndarray: ...
-
-
 @cache(level=30)
 def amplitude_to_db(
     S: _ScalarOrSequence[_ComplexLike_co],
@@ -1991,7 +1949,7 @@ def amplitude_to_db(
     amin: float = 1e-5,
     top_db: float | None = 80.0,
     axes: None | Literal["auto"] | int | tuple[int, ...] = "auto",
-) -> np.floating[Any] | np.ndarray:
+) -> np.floating | np.ndarray:
     """Convert an amplitude spectrogram to dB-scaled spectrogram.
 
     This is equivalent to ``power_to_db(S**2, ref=ref**2, amin=amin**2, top_db=top_db)``,
@@ -2084,29 +2042,17 @@ def db_to_amplitude(
     S_db: _FloatLike_co,
     *,
     ref: float = ...,
-) -> np.floating[Any]: ...
-
-
+) -> np.floating: ...
 @overload
 def db_to_amplitude(
     S_db: np.ndarray,
     *,
     ref: float = ...,
 ) -> np.ndarray: ...
-
-
-@overload
-def db_to_amplitude(
-    S_db: _FloatLike_co | np.ndarray,
-    *,
-    ref: float = ...,
-) -> np.floating[Any] | np.ndarray: ...
-
-
 @cache(level=30)
 def db_to_amplitude(
     S_db: _FloatLike_co | np.ndarray, *, ref: float = 1.0
-) -> np.floating[Any] | np.ndarray:
+) -> np.floating | np.ndarray:
     """Convert a dB-scaled spectrogram to an amplitude spectrogram.
 
     This effectively inverts `amplitude_to_db`::
@@ -2426,8 +2372,6 @@ def pcen(
     zi: np.ndarray | None = ...,
     return_zf: Literal[False] = ...,
 ) -> np.ndarray: ...
-
-
 @overload
 def pcen(
     S: np.ndarray,
@@ -2447,29 +2391,6 @@ def pcen(
     zi: np.ndarray | None = ...,
     return_zf: Literal[True],
 ) -> tuple[np.ndarray, np.ndarray]: ...
-
-
-@overload
-def pcen(
-    S: np.ndarray,
-    *,
-    sr: float = ...,
-    hop_length: int = ...,
-    gain: float = ...,
-    bias: float = ...,
-    power: float = ...,
-    time_constant: float = ...,
-    eps: float = ...,
-    b: float | None = ...,
-    max_size: int = ...,
-    ref: np.ndarray | None = ...,
-    axis: int = ...,
-    max_axis: int | None = ...,
-    zi: np.ndarray | None = ...,
-    return_zf: bool = ...,
-) -> np.ndarray | tuple[np.ndarray, np.ndarray]: ...
-
-
 @cache(level=30)
 def pcen(
     S: np.ndarray,

--- a/librosa/display.py
+++ b/librosa/display.py
@@ -84,6 +84,7 @@ if TYPE_CHECKING:
     import matplotlib
     import matplotlib.axes
     import matplotlib.figure
+    import numpy.typing as npt
     import scipy.interpolate
     from matplotlib.artist import Artist
     from matplotlib.collections import PolyCollection, QuadMesh
@@ -93,7 +94,7 @@ if TYPE_CHECKING:
     from matplotlib.path import Path as MplPath
     from matplotlib.typing import ColorType
 
-    from ._typing import ArrayLike, _FloatLike_co
+    from ._typing import ArrayLike, _Array1D, _FloatLike_co
 
 
 __all__ = [
@@ -2369,7 +2370,7 @@ def __decorate_axis(
 
 def __coord_fft_hz(
     n: int, sr: float = 22050, n_fft: int | None = None, **_kwargs: Any
-) -> np.ndarray:
+) -> _Array1D[np.float64]:
     """Get the frequencies for FFT bins"""
     if n_fft is None:
         n_fft = 2 * (n - 1)
@@ -2386,7 +2387,7 @@ def __coord_mel_hz(
     sr: float = 22050,
     htk: bool = False,
     **_kwargs: Any,
-) -> np.ndarray:
+) -> _Array1D[np.float64]:
     """Get the frequencies for Mel bins"""
     if fmin is None:
         fmin = 0.0
@@ -2403,7 +2404,7 @@ def __coord_cqt_hz(
     bins_per_octave: int = 12,
     sr: float = 22050,
     **_kwargs: Any,
-) -> np.ndarray:
+) -> _Array1D[np.float64]:
     """Get CQT bin frequencies"""
     if fmin is None:
         fmin = core.note_to_hz("C1")
@@ -2436,7 +2437,7 @@ def __coord_vqt_hz(
     intervals: str | Collection[float] | None = None,
     unison: str | None = None,
     **_kwargs: Any,
-) -> np.ndarray:
+) -> _Array1D[np.float64]:
     if fmin is None:
         fmin = core.note_to_hz("C1")
 
@@ -3694,7 +3695,7 @@ def _mp_setup_axes(
     orient: Literal["h", "v"],
     sharex: bool,
     sharey: bool,
-) -> tuple[matplotlib.figure.FigureBase, np.ndarray, tuple[int, ...]]:
+) -> tuple[matplotlib.figure.FigureBase, npt.NDArray[np.object_], tuple[int, ...]]:
     """Set up the figure and axes for a multiplot grid.
 
     Parameters
@@ -3783,7 +3784,7 @@ def _mp_setup_axes(
 
 def _mp_setup_labels(
     labels: Sequence[str | None] | None, shape: tuple[int, ...]
-) -> np.ndarray:
+) -> npt.NDArray[np.object_]:
     """Set up the labels for a multiplot grid.
 
     Parameters
@@ -3861,7 +3862,7 @@ def _mp_setup_prop_group(
 
 def _mp_setup_properties(
     prop_group: np.ndarray, badprops: list[str], prop_cycle: cycler.Cycler | None
-) -> np.ndarray:
+) -> npt.NDArray[np.object_]:
     """Set up the properties for each subplot in a multiplot grid based on the property groups.
 
     Parameters
@@ -3918,7 +3919,7 @@ def multiplot(
     titles: Sequence[str | None] | None = None,
     prop_cycle: cycler.Cycler | None = None,
     **kwargs: Any,
-) -> np.ndarray:
+) -> npt.NDArray[np.object_]:
     """Visualize multiple related waveforms or spectrograms on an array of subplots.
 
     Example use cases include:

--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
     from numpy.typing import ArrayLike
 
     from ._typing import (
+        _Array1D,
         _FloatLike_co,
         _IntLike_co,
         _PadModeSTFT,
@@ -644,7 +645,7 @@ def _signal_to_frame_nonsilent(
     top_db: float = 60,
     ref: Callable | float = np.max,
     aggregate: Callable = np.max,
-) -> np.ndarray:
+) -> _Array1D[np.bool]:
     """Frame-wise non-silent indicator for audio input.
 
     This is a helper function for `trim` and `split`.
@@ -704,7 +705,7 @@ def trim(
     frame_length: int = 2048,
     hop_length: int = 512,
     aggregate: Callable = np.max,
-) -> tuple[np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, _Array1D[np.int_]]:
     """Trim leading and trailing silence from an audio signal.
 
     Silence is defined as segments of the audio signal that are `top_db`
@@ -860,8 +861,6 @@ def preemphasis(
     zi: ArrayLike | None = ...,
     return_zf: Literal[False] = ...,
 ) -> np.ndarray: ...
-
-
 @overload
 def preemphasis(
     y: np.ndarray,
@@ -870,18 +869,6 @@ def preemphasis(
     zi: ArrayLike | None = ...,
     return_zf: Literal[True],
 ) -> tuple[np.ndarray, np.ndarray]: ...
-
-
-@overload
-def preemphasis(
-    y: np.ndarray,
-    *,
-    coef: float = ...,
-    zi: ArrayLike | None = ...,
-    return_zf: bool,
-) -> np.ndarray | tuple[np.ndarray, np.ndarray]: ...
-
-
 def preemphasis(
     y: np.ndarray,
     *,
@@ -987,8 +974,6 @@ def deemphasis(
     zi: ArrayLike | None = ...,
     return_zf: Literal[False] = ...,
 ) -> np.ndarray: ...
-
-
 @overload
 def deemphasis(
     y: np.ndarray,
@@ -997,8 +982,6 @@ def deemphasis(
     zi: ArrayLike | None = ...,
     return_zf: Literal[True],
 ) -> tuple[np.ndarray, np.ndarray]: ...
-
-
 def deemphasis(
     y: np.ndarray,
     *,

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -49,7 +49,7 @@ from .util.exceptions import ParameterError
 if TYPE_CHECKING:
     from typing import Any, Literal
 
-    from numpy.typing import ArrayLike, DTypeLike
+    from numpy.typing import ArrayLike, DTypeLike, NDArray
 
     from ._typing import _FloatLike_co, _WindowSpec
 
@@ -429,7 +429,7 @@ def wavelet_lengths(
     filter_scale: float = 1,
     gamma: float | None = 0,
     alpha: float | np.ndarray | None = None,
-) -> tuple[np.ndarray, float]:
+) -> tuple[NDArray[np.float64], float]:
     """Return length of each filter in a wavelet basis.
 
     Parameters

--- a/librosa/segment.py
+++ b/librosa/segment.py
@@ -27,7 +27,7 @@ Temporal clustering
 from __future__ import annotations
 
 import itertools
-from typing import TYPE_CHECKING, overload
+from typing import TYPE_CHECKING, cast, overload
 
 import numpy as np
 import scipy
@@ -43,9 +43,7 @@ if TYPE_CHECKING:
 
     import sklearn.cluster
 
-    from ._typing import _FloatLike_co, _SparseArray, _WindowSpec
-
-    _F = TypeVar("_F", bound=Callable[..., Any])
+    from ._typing import _Array1D, _FloatLike_co, _SparseArray, _WindowSpec
 
     _ArrayOrSparseArray = TypeVar(
         "_ArrayOrSparseArray", bound=np.ndarray | _SparseArray
@@ -76,10 +74,7 @@ def cross_similarity(
     mode: str = ...,
     bandwidth: np.ndarray | _FloatLike_co | str | None = None,
     full: bool = False,
-) -> np.ndarray:
-    ...
-
-
+) -> np.ndarray: ...
 @overload
 def cross_similarity(
     data: np.ndarray,
@@ -91,10 +86,7 @@ def cross_similarity(
     mode: str = ...,
     bandwidth: np.ndarray | _FloatLike_co | str | None = None,
     full: bool = False,
-) -> scipy.sparse.csc_array:
-    ...
-
-
+) -> scipy.sparse.csc_array: ...
 @cache(level=30)
 def cross_similarity(
     data: np.ndarray,
@@ -900,7 +892,7 @@ def lag_to_recurrence(
 
 
 
-def timelag_filter(function: _F, pad: bool = True, index: int = 0) -> _F:
+def timelag_filter[F: Callable[..., Any]](function: F, pad: bool = True, index: int = 0) -> F:
     """Apply a filter in the time-lag domain.
 
     This is primarily useful for adapting image filters to operate on
@@ -983,7 +975,7 @@ def timelag_filter(function: _F, pad: bool = True, index: int = 0) -> _F:
 @cache(level=30)
 def subsegment(
     data: np.ndarray, frames: np.ndarray, *, n_segments: int = 4, axis: int = -1
-) -> np.ndarray:
+) -> _Array1D[np.int_]:
     """Sub-divide a segmentation by feature clustering.
 
     Given a set of frame boundaries (``frames``), and a data matrix (``data``),
@@ -1061,7 +1053,7 @@ def subsegment(
     if n_segments < 1:
         raise ParameterError("n_segments must be a positive integer")
 
-    boundaries = []
+    boundaries: list = []
     idx_slices = [slice(None)] * data.ndim
 
     for seg_start, seg_end in itertools.pairwise(frames):
@@ -1069,7 +1061,9 @@ def subsegment(
         boundaries.extend(
             seg_start
             + agglomerative(
-                data[tuple(idx_slices)], min(seg_end - seg_start, n_segments), axis=axis
+                data[tuple(idx_slices)],
+                cast("np.integer", min(seg_end - seg_start, n_segments)),
+                axis=axis,
             )
         )
 
@@ -1078,11 +1072,11 @@ def subsegment(
 
 def agglomerative(
     data: np.ndarray,
-    k: int,
+    k: int | np.integer,
     *,
     clusterer: sklearn.cluster.AgglomerativeClustering | None = None,
     axis: int = -1,
-) -> np.ndarray:
+) -> _Array1D[np.int_]:
     """Bottom-up temporal segmentation.
 
     Use a temporally-constrained agglomerative clustering routine to partition

--- a/librosa/sequence.py
+++ b/librosa/sequence.py
@@ -35,7 +35,7 @@ Transition matrices
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, overload
+from typing import TYPE_CHECKING, cast, overload
 
 import numpy as np
 from numba import jit
@@ -47,7 +47,9 @@ from .util.exceptions import ParameterError
 if TYPE_CHECKING:
     from typing import Any, Iterable, Literal
 
-    from ._typing import _WindowSpec
+    import numpy.typing as npt
+
+    from ._typing import _Array2D, _WindowSpec
 
 
 __all__ = [
@@ -78,9 +80,7 @@ def dtw(
     global_constraints: bool = ...,
     band_rad: float = ...,
     return_steps: Literal[False] = ...,
-) -> np.ndarray: ...
-
-
+) -> _Array2D[np.float64]: ...
 @overload
 def dtw(
     *,
@@ -94,9 +94,7 @@ def dtw(
     global_constraints: bool = ...,
     band_rad: float = ...,
     return_steps: Literal[False] = ...,
-) -> np.ndarray: ...
-
-
+) -> _Array2D[np.float64]: ...
 @overload
 def dtw(
     X: np.ndarray,
@@ -111,9 +109,7 @@ def dtw(
     global_constraints: bool = ...,
     band_rad: float = ...,
     return_steps: Literal[True],
-) -> tuple[np.ndarray, np.ndarray]: ...
-
-
+) -> tuple[_Array2D[np.float64], _Array2D[np.int32]]: ...
 @overload
 def dtw(
     *,
@@ -127,9 +123,7 @@ def dtw(
     global_constraints: bool = ...,
     band_rad: float = ...,
     return_steps: Literal[True],
-) -> tuple[np.ndarray, np.ndarray]: ...
-
-
+) -> tuple[_Array2D[np.float64], _Array2D[np.int32]]: ...
 @overload
 def dtw(
     X: np.ndarray,
@@ -144,9 +138,7 @@ def dtw(
     global_constraints: bool = ...,
     band_rad: float = ...,
     return_steps: Literal[False] = ...,
-) -> tuple[np.ndarray, np.ndarray]: ...
-
-
+) -> tuple[_Array2D[np.float64], _Array2D[np.int_]]: ...
 @overload
 def dtw(
     *,
@@ -160,9 +152,7 @@ def dtw(
     global_constraints: bool = ...,
     band_rad: float = ...,
     return_steps: Literal[False] = ...,
-) -> tuple[np.ndarray, np.ndarray]: ...
-
-
+) -> tuple[_Array2D[np.float64], _Array2D[np.int_]]: ...
 @overload
 def dtw(
     X: np.ndarray,
@@ -177,9 +167,7 @@ def dtw(
     global_constraints: bool = ...,
     band_rad: float = ...,
     return_steps: Literal[True],
-) -> tuple[np.ndarray, np.ndarray, np.ndarray]: ...
-
-
+) -> tuple[_Array2D[np.float64], _Array2D[np.int_], _Array2D[np.int32]]: ...
 @overload
 def dtw(
     *,
@@ -193,9 +181,7 @@ def dtw(
     global_constraints: bool = ...,
     band_rad: float = ...,
     return_steps: Literal[True],
-) -> tuple[np.ndarray, np.ndarray, np.ndarray]: ...
-
-
+) -> tuple[_Array2D[np.float64], _Array2D[np.int_], _Array2D[np.int32]]: ...
 def dtw(
     X: np.ndarray | None = None,
     Y: np.ndarray | None = None,
@@ -210,7 +196,11 @@ def dtw(
     global_constraints: bool = False,
     band_rad: float = 0.25,
     return_steps: bool = False,
-) -> np.ndarray | tuple[np.ndarray, np.ndarray] | tuple[np.ndarray, np.ndarray, np.ndarray]:
+) -> (
+    _Array2D[np.float64]
+    | tuple[_Array2D[np.float64], _Array2D[np.int_] | _Array2D[np.int32]]
+    | tuple[_Array2D[np.float64], _Array2D[np.int_], _Array2D[np.int32]]
+):
     """Dynamic time warping (DTW).
 
     This function performs a DTW and path backtracking on two sequences.
@@ -656,7 +646,7 @@ def dtw_backtracking(
     step_sizes_sigma: np.ndarray | None = None,
     subseq: bool = False,
     start: int | np.integer[Any] | None = None,
-) -> np.ndarray:
+) -> _Array2D[np.int_]:
     """Backtrack a warping path.
 
     Uses the saved step sizes from the cost accumulation
@@ -712,9 +702,7 @@ def rqa(
     gap_extend: float = ...,
     knight_moves: bool = ...,
     backtrack: Literal[False],
-) -> np.ndarray: ...
-
-
+) -> _Array2D[Any]: ...
 @overload
 def rqa(
     sim: np.ndarray,
@@ -723,20 +711,7 @@ def rqa(
     gap_extend: float = ...,
     knight_moves: bool = ...,
     backtrack: Literal[True] = ...,
-) -> tuple[np.ndarray, np.ndarray]: ...
-
-
-@overload
-def rqa(
-    sim: np.ndarray,
-    *,
-    gap_onset: float = ...,
-    gap_extend: float = ...,
-    knight_moves: bool = ...,
-    backtrack: bool = ...,
-) -> np.ndarray | tuple[np.ndarray, np.ndarray]: ...
-
-
+) -> tuple[_Array2D[Any], _Array2D[np.uint]]: ...
 def rqa(
     sim: np.ndarray,
     *,
@@ -744,7 +719,7 @@ def rqa(
     gap_extend: float = 1,
     knight_moves: bool = True,
     backtrack: bool = True,
-) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
+) -> _Array2D[Any] | tuple[_Array2D[Any], _Array2D[np.uint]]:
     """Recurrence quantification analysis (RQA)
 
     This function implements different forms of RQA as described by
@@ -894,7 +869,7 @@ def rqa(
 @jit(nopython=True, cache=True)  # type: ignore
 def __rqa_dp(
     sim: np.ndarray, gap_onset: float, gap_extend: float, knight: bool
-) -> tuple[np.ndarray, np.ndarray]:  # pragma: no cover
+) -> tuple[np.ndarray, npt.NDArray[np.int8]]:  # pragma: no cover
     """RQA dynamic programming implementation"""
     # The output array
     score = np.zeros(sim.shape, dtype=sim.dtype)
@@ -1045,7 +1020,7 @@ def __rqa_dp(
     return score, backtrack
 
 
-def __rqa_backtrack(score, pointers):
+def __rqa_backtrack(score, pointers) -> _Array2D[np.uint]:
     """RQA path backtracking
 
     Given the score matrix and backtracking index array,
@@ -1096,7 +1071,7 @@ def __rqa_backtrack(score, pointers):
     return np.asarray(path, dtype=np.uint)
 
 
-def path_to_steps(path: np.ndarray, *, inverse: bool = False) -> np.ndarray:
+def path_to_steps(path: np.ndarray, *, inverse: bool = False) -> npt.NDArray[np.float64]:
     """Convert a DTW warping path to an array of fractional steps.
 
     The step sequence is computed by linear interpolation of the warping
@@ -1190,7 +1165,7 @@ def path_to_steps(path: np.ndarray, *, inverse: bool = False) -> np.ndarray:
     frames_in = np.arange(path[:, idx_to].min(), path[:, idx_to].max() + 1)
     steps = step_interp(frames_in)
 
-    return steps
+    return cast("npt.NDArray[np.float64]", steps)
 
 
 @jit(nopython=True, cache=True)  # type: ignore
@@ -1199,7 +1174,7 @@ def _viterbi(
     log_trans: np.ndarray,
     log_p_init: np.ndarray,
     log_trans_threshold: float,
-) -> tuple[np.ndarray, np.ndarray]:  # pragma: no cover
+) -> tuple[npt.NDArray[np.uint16], npt.NDArray[np.float64]]:  # pragma: no cover
     """Core Viterbi algorithm.
 
     This is intended for internal use only.
@@ -1289,9 +1264,7 @@ def viterbi(
     p_init: np.ndarray | None = ...,
     return_logp: Literal[True],
     transition_min_prob: float | None = ...,
-) -> tuple[np.ndarray, np.ndarray]: ...
-
-
+) -> tuple[npt.NDArray[np.uint16], npt.NDArray[np.float64]]: ...
 @overload
 def viterbi(
     prob: np.ndarray,
@@ -1300,9 +1273,7 @@ def viterbi(
     p_init: np.ndarray | None = ...,
     return_logp: Literal[False] = ...,
     transition_min_prob: float | None = ...,
-) -> np.ndarray: ...
-
-
+) -> npt.NDArray[np.uint16]: ...
 def viterbi(
     prob: np.ndarray,
     transition: np.ndarray,
@@ -1310,7 +1281,7 @@ def viterbi(
     p_init: np.ndarray | None = None,
     return_logp: bool = False,
     transition_min_prob: float | None = None,
-) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
+) -> npt.NDArray[np.uint16] | tuple[npt.NDArray[np.uint16], npt.NDArray[np.float64]]:
     """Viterbi decoding from observation likelihoods.
 
     Given a sequence of observation likelihoods ``prob[s, t]``,
@@ -1430,7 +1401,7 @@ def viterbi(
             f"Invalid transition_min_prob={transition_min_prob}, must be None or non-negative."
         )
 
-    def _helper(lp):
+    def _helper(lp) -> tuple[npt.NDArray[np.uint16], npt.NDArray[np.float64]]:
         # Transpose input
         _state, logp = _viterbi(lp.T, log_trans, log_p_init, log_trans_threshold)
         # Transpose outputs for return
@@ -1467,9 +1438,7 @@ def viterbi_discriminative(
     p_init: np.ndarray | None = ...,
     return_logp: Literal[False] = ...,
     transition_min_prob: float | None = ...,
-) -> np.ndarray: ...
-
-
+) -> npt.NDArray[np.uint16]: ...
 @overload
 def viterbi_discriminative(
     prob: np.ndarray,
@@ -1479,21 +1448,7 @@ def viterbi_discriminative(
     p_init: np.ndarray | None = ...,
     return_logp: Literal[True],
     transition_min_prob: float | None = ...,
-) -> tuple[np.ndarray, np.ndarray]: ...
-
-
-@overload
-def viterbi_discriminative(
-    prob: np.ndarray,
-    transition: np.ndarray,
-    *,
-    p_state: np.ndarray | None = ...,
-    p_init: np.ndarray | None = ...,
-    return_logp: bool,
-    transition_min_prob: float | None = ...,
-) -> np.ndarray | tuple[np.ndarray, np.ndarray]: ...
-
-
+) -> tuple[npt.NDArray[np.uint16], npt.NDArray[np.float64]]: ...
 def viterbi_discriminative(
     prob: np.ndarray,
     transition: np.ndarray,
@@ -1502,7 +1457,7 @@ def viterbi_discriminative(
     p_init: np.ndarray | None = None,
     return_logp: bool = False,
     transition_min_prob: float | None = None,
-) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
+) -> npt.NDArray[np.uint16] | tuple[npt.NDArray[np.uint16], npt.NDArray[np.float64]]:
     """Viterbi decoding from discriminative state predictions.
 
     Given a sequence of conditional state predictions ``prob[s, t]``,
@@ -1730,9 +1685,7 @@ def viterbi_binary(
     p_init: np.ndarray | None = ...,
     return_logp: Literal[False] = ...,
     transition_min_prob: float | None = ...,
-) -> np.ndarray: ...
-
-
+) -> npt.NDArray[np.uint16]: ...
 @overload
 def viterbi_binary(
     prob: np.ndarray,
@@ -1742,21 +1695,7 @@ def viterbi_binary(
     p_init: np.ndarray | None = ...,
     return_logp: Literal[True],
     transition_min_prob: float | None = ...,
-) -> tuple[np.ndarray, np.ndarray]: ...
-
-
-@overload
-def viterbi_binary(
-    prob: np.ndarray,
-    transition: np.ndarray,
-    *,
-    p_state: np.ndarray | None = ...,
-    p_init: np.ndarray | None = ...,
-    return_logp: bool = ...,
-    transition_min_prob: float | None = ...,
-) -> np.ndarray | tuple[np.ndarray, np.ndarray]: ...
-
-
+) -> tuple[npt.NDArray[np.uint16], npt.NDArray[np.float64]]: ...
 def viterbi_binary(
     prob: np.ndarray,
     transition: np.ndarray,
@@ -1765,7 +1704,7 @@ def viterbi_binary(
     p_init: np.ndarray | None = None,
     return_logp: bool = False,
     transition_min_prob: float | None = None,
-) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
+) -> npt.NDArray[np.uint16] | tuple[npt.NDArray[np.uint16], npt.NDArray[np.float64]]:
     """Viterbi decoding from binary (multi-label), discriminative state predictions.
 
     Given a sequence of conditional state predictions ``prob[s, t]``,
@@ -1932,7 +1871,7 @@ def viterbi_binary(
     return states
 
 
-def transition_uniform(n_states: int) -> np.ndarray:
+def transition_uniform(n_states: int) -> _Array2D[np.float64]:
     """Construct a uniform transition matrix over ``n_states``.
 
     Parameters
@@ -1960,7 +1899,7 @@ def transition_uniform(n_states: int) -> np.ndarray:
     return transition
 
 
-def transition_loop(n_states: int, prob: float | Iterable[float]) -> np.ndarray:
+def transition_loop(n_states: int, prob: float | Iterable[float]) -> _Array2D[np.float64]:
     """Construct a self-loop transition matrix over ``n_states``.
 
     The transition matrix will have the following properties:
@@ -2025,7 +1964,7 @@ def transition_loop(n_states: int, prob: float | Iterable[float]) -> np.ndarray:
     return transition
 
 
-def transition_cycle(n_states: int, prob: float | Iterable[float]) -> np.ndarray:
+def transition_cycle(n_states: int, prob: float | Iterable[float]) -> _Array2D[np.float64]:
     """Construct a cyclic transition matrix over ``n_states``.
 
     The transition matrix will have the following properties:
@@ -2095,7 +2034,7 @@ def transition_local(
     *,
     window: _WindowSpec = "triangle",
     wrap: bool = False,
-) -> np.ndarray:
+) -> _Array2D[np.float64]:
     """Construct a localized transition matrix.
 
     The transition matrix will have the following properties:

--- a/librosa/util/matching.py
+++ b/librosa/util/matching.py
@@ -12,7 +12,7 @@ from .exceptions import ParameterError
 from .utils import valid_intervals
 
 if TYPE_CHECKING:
-    from .._typing import _SequenceLike
+    from .._typing import _Array1D, _SequenceLike
 
 __all__ = ["match_intervals", "match_events"]
 
@@ -65,7 +65,7 @@ def __match_interval_overlaps(query, intervals_to, candidates):  # pragma: no co
 @numba.jit(nopython=True, cache=True)  # type: ignore
 def __match_intervals(
     intervals_from: np.ndarray, intervals_to: np.ndarray, strict: bool = True
-) -> np.ndarray:  # pragma: no cover
+) -> _Array1D[np.uint32]:  # pragma: no cover
     """Numba-accelerated interval matching algorithm."""
     # sort index of the interval starts
     start_index = np.argsort(intervals_to[:, 0])
@@ -118,7 +118,7 @@ def __match_intervals(
 
 def match_intervals(
     intervals_from: np.ndarray, intervals_to: np.ndarray, strict: bool = True
-) -> np.ndarray:
+) -> _Array1D[np.uint32]:
     """Match one set of time intervals to another.
 
     This can be useful for tasks such as mapping beat timings

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -1309,6 +1309,20 @@ def peak_pick(
     method: _PeakPickMethod = "greedy",
     axis: int = -1,
 ) -> NDArray[np.int_]: ...
+@overload  # this overload should not be needed, but mypy becomes confused without it
+def peak_pick(
+    x: np.ndarray,
+    *,
+    pre_max: int,
+    post_max: int,
+    pre_avg: int,
+    post_avg: int,
+    delta: float,
+    wait: int,
+    sparse: bool = True,
+    method: _PeakPickMethod = "greedy",
+    axis: int = -1,
+) -> NDArray[np.bool | np.int_]: ...
 def peak_pick(
     x: np.ndarray,
     *,

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -34,6 +34,8 @@ if TYPE_CHECKING:
         _SparseMatrix,
     )
 
+    type _PeakPickMethod = Literal["greedy", "dp_count", "dp_value"]
+
 
 # Constrain STFT block sizes to 256 KB
 MAX_MEM_BLOCK = 2**8 * 2**10
@@ -1279,6 +1281,34 @@ def __peak_pick_dp(x, pre_max, post_max, pre_avg, post_avg, delta, wait, count, 
         n = pointers[n]
 
 
+@overload
+def peak_pick(
+    x: np.ndarray,
+    *,
+    pre_max: int,
+    post_max: int,
+    pre_avg: int,
+    post_avg: int,
+    delta: float,
+    wait: int,
+    sparse: Literal[False],
+    method: _PeakPickMethod = "greedy",
+    axis: int = -1,
+) -> NDArray[np.bool]: ...
+@overload
+def peak_pick(
+    x: np.ndarray,
+    *,
+    pre_max: int,
+    post_max: int,
+    pre_avg: int,
+    post_avg: int,
+    delta: float,
+    wait: int,
+    sparse: Literal[True] = True,
+    method: _PeakPickMethod = "greedy",
+    axis: int = -1,
+) -> NDArray[np.int_]: ...
 def peak_pick(
     x: np.ndarray,
     *,
@@ -1289,7 +1319,7 @@ def peak_pick(
     delta: float,
     wait: int,
     sparse: bool = True,
-    method: Literal["greedy", "dp_count", "dp_value"] = "greedy",
+    method: _PeakPickMethod = "greedy",
     axis: int = -1,
 ) -> NDArray[np.bool | np.int_]:
     """Use a flexible heuristic to pick peaks in a signal.
@@ -1772,7 +1802,7 @@ def sync(
 
 def softmask(
     X: np.ndarray, X_ref: np.ndarray, *, power: float = 1, split_zeros: bool = False
-) -> NDArray[np.bool]:
+) -> np.ndarray:
     """Robustly compute a soft-mask operation.
 
         ``M = X**power / (X**power + X_ref**power)``

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import itertools
-from typing import TYPE_CHECKING, overload
+from typing import TYPE_CHECKING, cast, overload
 
 import numba
 import numpy as np
@@ -18,9 +18,11 @@ from .exceptions import ParameterError
 if TYPE_CHECKING:
     from typing import Any, Callable, Literal, Sequence
 
-    from numpy.typing import DTypeLike
+    from numpy.typing import DTypeLike, NDArray
 
     from .._typing import (
+        _Array1D,
+        _Array2D,
         _Complex,
         _ComplexLike_co,
         _FloatLike_co,
@@ -590,7 +592,7 @@ def fix_frames(
     x_min: int | None = 0,
     x_max: int | None = None,
     pad: bool = True,
-) -> np.ndarray:
+) -> _Array1D[np.int_]:
     """Fix a list of frames to lie within [x_min, x_max]
 
     Examples
@@ -680,9 +682,7 @@ def axis_sort(
     axis: int = ...,
     index: Literal[False] = ...,
     value: Callable[..., Any] | None = ...,
-) -> np.ndarray: ...
-
-
+) -> _Array2D[Any]: ...
 @overload
 def axis_sort(
     S: np.ndarray,
@@ -690,16 +690,14 @@ def axis_sort(
     axis: int = ...,
     index: Literal[True],
     value: Callable[..., Any] | None = ...,
-) -> tuple[np.ndarray, np.ndarray]: ...
-
-
+) -> tuple[_Array2D[Any], _Array1D[np.int_]]: ...
 def axis_sort(
     S: np.ndarray,
     *,
     axis: int = -1,
     index: bool = False,
     value: Callable[..., Any] | None = None,
-) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
+) -> _Array2D[Any] | tuple[_Array2D[Any], _Array1D[np.int_]]:
     """Sort an array along its rows or columns.
 
     Examples
@@ -1057,7 +1055,7 @@ def _localmin(x, y):  # pragma: no cover
     y[:] = _localmin_sten(x)
 
 
-def localmax(x: np.ndarray, *, axis: int = 0) -> np.ndarray:
+def localmax(x: np.ndarray, *, axis: int = 0) -> NDArray[np.bool]:
     """Find local maxima in an array
 
     An element ``x[i]`` is considered a local maximum if the following
@@ -1118,7 +1116,7 @@ def localmax(x: np.ndarray, *, axis: int = 0) -> np.ndarray:
     return lmax
 
 
-def localmin(x: np.ndarray, *, axis: int = 0) -> np.ndarray:
+def localmin(x: np.ndarray, *, axis: int = 0) -> NDArray[np.bool]:
     """Find local minima in an array
 
     An element ``x[i]`` is considered a local minimum if the following
@@ -1293,7 +1291,7 @@ def peak_pick(
     sparse: bool = True,
     method: Literal["greedy", "dp_count", "dp_value"] = "greedy",
     axis: int = -1,
-) -> np.ndarray:
+) -> NDArray[np.bool | np.int_]:
     """Use a flexible heuristic to pick peaks in a signal.
 
     A sample n is selected as an peak if the corresponding ``x[n]``
@@ -1774,7 +1772,7 @@ def sync(
 
 def softmask(
     X: np.ndarray, X_ref: np.ndarray, *, power: float = 1, split_zeros: bool = False
-) -> np.ndarray:
+) -> NDArray[np.bool]:
     """Robustly compute a soft-mask operation.
 
         ``M = X**power / (X**power + X_ref**power)``
@@ -2445,7 +2443,7 @@ def __count_unique(x):
     return uniques.shape[0]
 
 
-def count_unique(data: np.ndarray, *, axis: int = -1) -> np.ndarray:
+def count_unique(data: np.ndarray, *, axis: int = -1) -> NDArray[np.int_]:
     """Count the number of unique values along a given axis.
 
     Parameters
@@ -2495,7 +2493,7 @@ def __is_unique(x):
     return uniques.shape[0] == x.size
 
 
-def is_unique(data: np.ndarray, *, axis: int = -1) -> np.ndarray:
+def is_unique(data: np.ndarray, *, axis: int = -1) -> NDArray[np.bool]:
     """Determine if the input consists of all unique values along a given axis.
 
     Parameters
@@ -2545,13 +2543,11 @@ def _cabs2(x: _ComplexLike_co) -> _FloatLike_co:  # pragma: no cover
 
 @overload
 def abs2(x: np.ndarray, dtype: DTypeLike | None = ...) -> np.ndarray: ...
-
 @overload
-def abs2(x: _Complex, dtype: DTypeLike | None = ...) -> np.floating[Any]: ...
-
-def abs2(x: np.ndarray | _Real | _Complex,
-         dtype: DTypeLike | None = None
-) -> np.ndarray | np.floating[Any]:
+def abs2(x: _Complex, dtype: DTypeLike | None = ...) -> np.floating: ...
+def abs2(
+    x: np.ndarray | _Real | _Complex, dtype: DTypeLike | None = None
+) -> np.ndarray | np.floating:
     """Compute the squared magnitude of a real or complex array.
 
     This function is equivalent to calling `np.abs(x)**2` but it
@@ -2594,26 +2590,20 @@ def abs2(x: np.ndarray | _Real | _Complex,
 @numba.vectorize(
     nopython=True, cache=True, identity=1
 )  # type: ignore
-def _phasor_angles(x) -> np.complexfloating[Any, Any]:
+def _phasor_angles(x) -> np.complexfloating:
     return np.cos(x) + 1j * np.sin(x)  # type: ignore
 
 
 
 @overload
 def phasor(angles: np.ndarray, *, mag: np.ndarray | None = ...) -> np.ndarray: ...
-
-
 @overload
-def phasor(
-    angles: _Real, *, mag: _Number | None = ...
-) -> np.complexfloating[Any, Any]: ...
-
-
+def phasor(angles: _Real, *, mag: _Number | None = ...) -> np.complexfloating: ...
 def phasor(
     angles: np.ndarray | _Real,
     *,
     mag: np.ndarray | _Number | None = None,
-) -> np.ndarray | np.complexfloating[Any, Any]:
+) -> np.ndarray | np.complexfloating:
     """Construct a complex phasor representation from angles.
 
     When `mag` is not provided, this is equivalent to:
@@ -2688,9 +2678,7 @@ def interp_broadcast(
     kind: _InterpKind = "linear",
     fill_value: float = 0,
     axis: int = -2,
-) -> tuple[np.ndarray, np.ndarray]: ...
-
-
+) -> tuple[NDArray[np.float64], NDArray[np.float64]]: ...
 @overload
 def interp_broadcast(
     *,
@@ -2703,9 +2691,7 @@ def interp_broadcast(
     kind: _InterpKind = "linear",
     fill_value: float = 0,
     axis: int = -2,
-) -> np.ndarray: ...
-
-
+) -> NDArray[np.float64]: ...
 def interp_broadcast(
     *,
     x1: np.ndarray,
@@ -2717,7 +2703,7 @@ def interp_broadcast(
     kind: _InterpKind = "linear",
     fill_value: float = 0,
     axis: int = -2,
-) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
+) -> NDArray[np.float64] | tuple[NDArray[np.float64], NDArray[np.float64]]:
     """Broadcast two arrays using interpolation
 
     Interpolates two arrays along a given axis to a common grid, and performs a broadcast operation
@@ -2826,8 +2812,8 @@ def interp_broadcast(
         fill_value=fill_value
     )
 
-    y1 = x1_interp(interp_pos)
-    y2 = x2_interp(interp_pos)
+    y1 = cast("NDArray[np.float64]", x1_interp(interp_pos))
+    y2 = cast("NDArray[np.float64]", x2_interp(interp_pos))
 
     if op is None:
         return y1, y2

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -2226,7 +2226,7 @@ def test_mp_setup_properties_badprops():
     properties = librosa.display._mp_setup_properties(prop_group, ["color"], None)
 
     for prop in properties.flat:
-        assert "color" not in prop
+        assert "color" not in prop  # type:ignore[operator]
 
 
 @pytest.mark.mpl_image_compare(


### PR DESCRIPTION
As promised in #2050, here are a bunch of other typing  improvements related to `ndarray` return types.

There are still (many) other `ndarray` return types that could still be improved, but those are all input-dependent in either their shape-type or dtype. So this PR only covers the "absolute" cases where the dtype and/or shape-type of the returned `ndarray` is always the same (with a couple of exceptions). I'll leave those input-dependent return types (not to be confused with the type-theoretical 
"dependent types", which are types that depend on values, and here we're talking about output types depending on input types), as they'll require a bit more effort (generic functions, a.k.a. parametric polymorphism) to tackle, and this PR is already larger than I'm usualy comfortable with haha.

Oh and in case you were wondering why I removed those `[Any]` type arguments for `np.floating` and other abstract generic numpy scalar types; those are no longer needed in recent numpy versions (deprecated, even). Without those `Any`s it's also a bit ~easier~ less difficult too read IMO. 