### PR TITLE
Stream resampling

### DIFF
--- a/docs/examples/plot_pcen_stream.py
+++ b/docs/examples/plot_pcen_stream.py
@@ -51,6 +51,7 @@ stream = librosa.stream(filename, block_length=16,
                         frame_length=n_fft,
                         hop_length=hop_length,
                         mono=True,
+                        sr=sr,
                         fill_value=0)
 #######################################################################
 # For this example, we'll compute PCEN on each block, find the maximum

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -219,7 +219,7 @@ def _align_step_size(target_step, target_sr, orig_sr):
     return int(aligned_native_step)
 
 
-@future_default(param_name="sr", old_default=None, new_default=22050, version="1.2.0")
+@future_default(param_name="sr", old_default=None, new_default=22050, version="1.1.0")
 def stream(
     path: str | int | sf.SoundFile | BinaryIO,
     *,

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -215,7 +215,7 @@ def _align_step_size(target_step, target_sr, orig_sr):
             f"fractional sample advance at original sampling rate {orig_sr}."
         )
 
-    return int((target_step * orig_sr) / target_sr)
+    return int(aligned_native_step)
 
 def stream(
     path: str | int | sf.SoundFile | BinaryIO,
@@ -250,10 +250,11 @@ def stream(
            refers to a buffer of audio which spans a given number of
            (potentially overlapping) frames.
         2. Automatic sample-rate conversion is supported,
-           but the hop length parameter, while interpreted
-           relative to the target (resampled) sampling rate,
-           must also be chosen to be an integer number of
-           samples in the native sampling rate of the file.
+           but not all combinations of ``block_length``, ``frame_length``, and
+           ``hop_length`` will be compatible with all sampling rates.
+           Specifically, ``(block_length * hop_length * native_sr) / sr``
+           must evaluate to an exact integer, where ``native_sr`` is the original
+           sampling rate of the stream prior to resampling.
         3. Many analyses require access to the entire signal
            to behave correctly, such as `resample`, `cqt`, or
            `beat_track`, so these methods will not be appropriate
@@ -406,7 +407,7 @@ def stream(
     try:
         orig_read_size = _align_step_size(target_advance, sr, orig_sr)
 
-        read_frames = int(np.round(duration * orig_sr)) if duration is not None else -1
+        read_frames = int(duration * orig_sr) if duration is not None else -1
 
         if needs_resampling:
             resampler = soxr.ResampleStream(
@@ -451,7 +452,9 @@ def stream(
                 read_idx = 0
                 write_idx = available
 
-                if write_idx + n_incoming > capacity:
+                # The following branch should never happen, but it's here
+                # just in case something goes wrong with the input stream
+                if write_idx + n_incoming > capacity:  # pragma: no cover
                     capacity = write_idx + n_incoming + target_yield_size
                     new_shape = (capacity,) if process_channels == 1 else (capacity, process_channels)
                     new_buffer = np.zeros(new_shape, dtype=dtype)

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -277,6 +277,10 @@ def stream(
 
         An existing `soundfile.SoundFile` object may also be provided.
 
+    sr : number > 0 [scalar]
+        target sampling rate.  If not provided, the original sampling rate of the file will be
+        used.
+
     block_length : int > 0
         The number of frames to include in each block.
 

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -14,6 +14,7 @@ from numba import guvectorize, jit, stencil
 
 from .. import util
 from .._cache import cache
+from ..util.decorators import future_default
 from ..util.exceptions import ParameterError
 from ..util.files import example
 from .convert import frames_to_samples, time_to_samples
@@ -217,6 +218,8 @@ def _align_step_size(target_step, target_sr, orig_sr):
 
     return int(aligned_native_step)
 
+
+@future_default("sr", old_default=None, new_default=22050, version="1.2.0")
 def stream(
     path: str | int | sf.SoundFile | BinaryIO,
     *,

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -389,6 +389,12 @@ def stream(
     if not util.is_positive_int(hop_length):
         raise ParameterError(f"hop_length={hop_length} must be a positive integer")
 
+    if sr is not None and not (np.isfinite(sr) and sr > 0):
+        raise ParameterError(f"sr={sr} must be a positive number")
+
+    if res_type not in {"soxr_vhq", "soxr_hq", "soxr_mq", "soxr_lq", "soxr_qq"}:
+        raise ParameterError(f"res_type={res_type} is not a valid soxr resampling mode for streaming")
+
     if isinstance(path, sf.SoundFile):
         sfo = path
     else:
@@ -485,7 +491,6 @@ def stream(
         else:
             tail_chunk = None
 
-        available = write_idx - read_idx
         final_data_list = [buffer[read_idx : write_idx]]
         if tail_chunk is not None and tail_chunk.shape[0] > 0:
             final_data_list.append(tail_chunk)

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -205,7 +205,11 @@ def _align_step_size(target_step, target_sr, orig_sr):
     if target_sr is None or target_sr == orig_sr:
         return target_step
 
-    if (target_step * orig_sr) % target_sr != 0:
+    exact_native_step = (target_step * orig_sr) / target_sr
+    aligned_native_step = np.round(exact_native_step)
+
+    # Tolerances (rtol=1e-7, atol=1e-5) safely absorb precision errors from float arithmetic
+    if not np.isclose(exact_native_step, aligned_native_step, rtol=1e-7, atol=1e-5):
         raise ParameterError(
             f"Target block step of {target_step} samples at {target_sr} results in a "
             f"fractional sample advance at original sampling rate {orig_sr}."
@@ -216,10 +220,10 @@ def _align_step_size(target_step, target_sr, orig_sr):
 def stream(
     path: str | int | sf.SoundFile | BinaryIO,
     *,
-    sr: float | None = None,
     block_length: int,
     frame_length: int,
     hop_length: int,
+    sr: float | None = None,
     mono: bool = True,
     offset: float = 0.0,
     duration: float | None = None,
@@ -246,7 +250,7 @@ def stream(
            refers to a buffer of audio which spans a given number of
            (potentially overlapping) frames.
         2. Automatic sample-rate conversion is supported,
-           but the frame length parameter, while interpreted
+           but the hop length parameter, while interpreted
            relative to the target (resampled) sampling rate,
            must also be chosen to be an integer number of
            samples in the native sampling rate of the file.
@@ -277,10 +281,6 @@ def stream(
 
         An existing `soundfile.SoundFile` object may also be provided.
 
-    sr : number > 0 [scalar]
-        target sampling rate.  If not provided, the original sampling rate of the file will be
-        used.
-
     block_length : int > 0
         The number of frames to include in each block.
 
@@ -298,6 +298,10 @@ def stream(
         Note that by when ``hop_length < frame_length``, neighboring frames
         will overlap.  Similarly, the last frame of one *block* will overlap
         with the first frame of the next *block*.
+
+    sr : number > 0 [scalar]
+        target sampling rate.  If not provided, the original sampling rate of the file will be
+        used.
 
     mono : bool
         Convert the signal to mono during streaming
@@ -396,7 +400,8 @@ def stream(
     process_channels = 1 if mono else sfo.channels
 
     needs_resampling = (sr is not None) and (orig_sr != sr)
-    sr = sr or orig_sr
+    if sr is None:
+        sr = orig_sr
 
     orig_read_size = _align_step_size(target_advance, sr, orig_sr)
 

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -70,7 +70,7 @@ def load(
     Audio will be automatically resampled to the given rate
     (default ``sr=22050``).
 
-    To preserve the orig sampling rate of the file, use ``sr=None``.
+    To preserve the native sampling rate of the file, use ``sr=None``.
 
     Parameters
     ----------
@@ -88,7 +88,7 @@ def load(
     sr : number > 0 [scalar]
         target sampling rate
 
-        'None' uses the orig sampling rate
+        'None' uses the native sampling rate
 
     mono : bool
         convert signal to mono
@@ -110,7 +110,7 @@ def load(
         .. note::
             By default, this uses `soxr`'s high-quality mode ('HQ').
 
-            For alterorig resampling modes, see `resample`
+            For alternative resampling modes, see `resample`
 
     Returns
     -------
@@ -152,17 +152,17 @@ def load(
     >>> sfo = soundfile.SoundFile(librosa.ex('brahms'))
     >>> y, sr = librosa.load(sfo)
     """
-    y, sr_orig = __soundfile_load(path, offset, duration, dtype)
+    y, sr_native = __soundfile_load(path, offset, duration, dtype)
 
     # Final cleanup for dtype and contiguity
     if mono:
         y = to_mono(y)
 
     if sr is not None:
-        y = resample(y, orig_sr=sr_orig, target_sr=sr, res_type=res_type)
+        y = resample(y, orig_sr=sr_native, target_sr=sr, res_type=res_type)
 
     else:
-        sr = sr_orig
+        sr = sr_native
 
     return y, sr
 
@@ -178,23 +178,23 @@ def __soundfile_load(path, offset, duration, dtype):
         context = sf.SoundFile(path)
 
     with context as sf_desc:
-        sr_orig = sf_desc.samplerate
+        sr_native = sf_desc.samplerate
         if offset != 0:
             if offset > 0:
                 # Seek to the start of the target read
-                sf_desc.seek(int(offset * sr_orig))
+                sf_desc.seek(int(offset * sr_native))
             else:
-                sf_desc.seek(-int(abs(offset) * sr_orig), whence=sf.SEEK_END)
+                sf_desc.seek(-int(abs(offset) * sr_native), whence=sf.SEEK_END)
 
         if duration is not None:
-            frame_duration = int(duration * sr_orig)
+            frame_duration = int(duration * sr_native)
         else:
             frame_duration = -1
 
         # Load the target number of frames, and transpose to match librosa form
         y = sf_desc.read(frames=frame_duration, dtype=dtype, always_2d=False).T
 
-    return y, sr_orig
+    return y, sr_native
 
 
 def _align_step_size(target_step, target_sr, orig_sr):
@@ -244,12 +244,11 @@ def stream(
            to produce blocks of audio.  A *block*, in this context,
            refers to a buffer of audio which spans a given number of
            (potentially overlapping) frames.
-        2. Automatic sample-rate conversion is not supported.
-           Audio will be streamed in its orig sample rate,
-           so no default values are provided for ``frame_length``
-           and ``hop_length``.  It is recommended that you first
-           get the sampling rate for the file in question, using
-           `get_samplerate`, and set these parameters accordingly.
+        2. Automatic sample-rate conversion is supported,
+           but the frame length parameter, while interpreted
+           relative to the target (resampled) sampling rate,
+           must also be chosen to be an integer number of
+           samples in the native sampling rate of the file.
         3. Many analyses require access to the entire signal
            to behave correctly, such as `resample`, `cqt`, or
            `beat_track`, so these methods will not be appropriate

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -224,6 +224,7 @@ def stream(
     offset: float = 0.0,
     duration: float | None = None,
     fill_value: float | None = None,
+    res_type: str = "soxr_hq",
     dtype: DTypeLike = np.float32,
 ) -> Generator[np.ndarray, None, None]:
     """Stream audio in fixed-length buffers.
@@ -316,6 +317,14 @@ def stream(
         In most cases, ``fill_value=0`` (silence) is expected, but
         you may specify any value here.
 
+    res_type : str
+        Resample type, must be one of the following:
+
+        'soxr_vhq', 'soxr_hq', 'soxr_mq' or 'soxr_lq'
+            `soxr` Very high-, High-, Medium-, Low-quality FFT-based bandlimited interpolation.
+            ``'soxr_hq'`` is the default setting of `soxr`.
+        'soxr_qq'
+            `soxr` Quick cubic interpolation (very fast, but not bandlimited)
     dtype : numeric type
         data type of audio buffers to be produced
 
@@ -399,7 +408,7 @@ def stream(
             out_rate=sr,
             num_channels=process_channels,
             dtype=dtype,
-            quality="HQ"
+            quality=res_type,
         )
 
     capacity = max(target_yield_size * 4, target_advance * 4)
@@ -439,7 +448,7 @@ def stream(
             if write_idx + n_incoming > capacity:
                 capacity = write_idx + n_incoming + target_yield_size
                 new_shape = (capacity,) if process_channels == 1 else (capacity, process_channels)
-                new_buffer = np.zeros(new_shape, dtype=np.float32)
+                new_buffer = np.zeros(new_shape, dtype=dtype)
                 new_buffer[:write_idx] = buffer[:write_idx]
                 buffer = new_buffer
 

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -219,7 +219,7 @@ def _align_step_size(target_step, target_sr, orig_sr):
     return int(aligned_native_step)
 
 
-@future_default("sr", old_default=None, new_default=22050, version="1.2.0")
+@future_default(param_name="sr", old_default=None, new_default=22050, version="1.2.0")
 def stream(
     path: str | int | sf.SoundFile | BinaryIO,
     *,

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -270,6 +270,10 @@ def stream(
            when the signal is carved into blocks, because it would introduce
            padding in the middle of the signal.  To disable this feature,
            use ``center=False`` in all frame-based analyses.
+        6. If you break out of the generator loop early, the underlying audio
+           file handle and resampling buffers will remain open until the
+           generator object is garbage-collected. To explicitly release resources,
+           call the generator's ``.close()`` method.
 
     See the examples below for proper usage of this function.
 
@@ -418,10 +422,9 @@ def stream(
                 quality=res_type,
             )
 
-        capacity = max(target_yield_size * 4, target_advance * 4)
+        capacity = target_yield_size + (target_advance * 2)
         buffer_shape = (capacity,) if process_channels == 1 else (capacity, process_channels)
         buffer = np.zeros(buffer_shape, dtype=dtype)
-
         write_idx = 0
         read_idx = 0
 
@@ -466,7 +469,7 @@ def stream(
 
             while write_idx - read_idx >= target_yield_size:
                 block = buffer[read_idx : read_idx + target_yield_size]
-                yield block.T
+                yield block.T.copy()
                 read_idx += target_advance
 
         if process_channels == 1:
@@ -483,8 +486,9 @@ def stream(
         final_data_list = [buffer[read_idx : write_idx]]
         if tail_chunk is not None and tail_chunk.shape[0] > 0:
             final_data_list.append(tail_chunk)
-
-        remainder = np.concatenate(final_data_list, axis=0) if final_data_list else np.array([])
+            remainder = np.concatenate(final_data_list, axis=0) if final_data_list else np.array([])
+        else:
+            remainder = buffer[read_idx : write_idx]
 
         rem_idx = 0
         while rem_idx < remainder.shape[0]:
@@ -499,7 +503,7 @@ def stream(
                                            mode="constant",
                                            constant_values=fill_value)
 
-            yield current_slice.T
+            yield current_slice.T.copy()
             rem_idx += target_advance
     finally:
         # If we instantiated a new SoundFile object, we should close it.  If the

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -403,100 +403,106 @@ def stream(
     if sr is None:
         sr = orig_sr
 
-    orig_read_size = _align_step_size(target_advance, sr, orig_sr)
+    try:
+        orig_read_size = _align_step_size(target_advance, sr, orig_sr)
 
-    read_frames = int(np.round(duration * orig_sr)) if duration is not None else -1
-
-    if needs_resampling:
-        resampler = soxr.ResampleStream(
-            in_rate=orig_sr,
-            out_rate=sr,
-            num_channels=process_channels,
-            dtype=dtype,
-            quality=res_type,
-        )
-
-    capacity = max(target_yield_size * 4, target_advance * 4)
-    buffer_shape = (capacity,) if process_channels == 1 else (capacity, process_channels)
-    buffer = np.zeros(buffer_shape, dtype=dtype)
-
-    write_idx = 0
-    read_idx = 0
-
-    if offset >= 0:
-        sfo.seek(int(offset * orig_sr))
-    else:
-        sfo.seek(-int(abs(offset) * orig_sr), whence=sf.SEEK_END)
-
-    for orig_chunk in sfo.blocks(blocksize=orig_read_size,
-                                 overlap=0,
-                                 dtype=dtype,
-                                 always_2d=False,
-                                 frames=read_frames):
-
-        if mono and is_multichannel:
-            # soundfile returns (samples, channels), to_mono expects (channels, samples)
-            orig_chunk = to_mono(orig_chunk.T)
+        read_frames = int(np.round(duration * orig_sr)) if duration is not None else -1
 
         if needs_resampling:
-            target_chunk = resampler.resample_chunk(orig_chunk)
-        else:
-            target_chunk = orig_chunk
-        n_incoming = target_chunk.shape[0]
+            resampler = soxr.ResampleStream(
+                in_rate=orig_sr,
+                out_rate=sr,
+                num_channels=process_channels,
+                dtype=dtype,
+                quality=res_type,
+            )
 
-        if write_idx + n_incoming > capacity:
-            available = write_idx - read_idx
-            buffer[:available] = buffer[read_idx : write_idx]
-            read_idx = 0
-            write_idx = available
+        capacity = max(target_yield_size * 4, target_advance * 4)
+        buffer_shape = (capacity,) if process_channels == 1 else (capacity, process_channels)
+        buffer = np.zeros(buffer_shape, dtype=dtype)
+
+        write_idx = 0
+        read_idx = 0
+
+        if offset >= 0:
+            sfo.seek(int(offset * orig_sr))
+        else:
+            sfo.seek(-int(abs(offset) * orig_sr), whence=sf.SEEK_END)
+
+        for orig_chunk in sfo.blocks(blocksize=orig_read_size,
+                                     overlap=0,
+                                     dtype=dtype,
+                                     always_2d=False,
+                                     frames=read_frames):
+
+            if mono and is_multichannel:
+                # soundfile returns (samples, channels), to_mono expects (channels, samples)
+                orig_chunk = to_mono(orig_chunk.T)
+
+            if needs_resampling:
+                target_chunk = resampler.resample_chunk(orig_chunk)
+            else:
+                target_chunk = orig_chunk
+            n_incoming = target_chunk.shape[0]
 
             if write_idx + n_incoming > capacity:
-                capacity = write_idx + n_incoming + target_yield_size
-                new_shape = (capacity,) if process_channels == 1 else (capacity, process_channels)
-                new_buffer = np.zeros(new_shape, dtype=dtype)
-                new_buffer[:write_idx] = buffer[:write_idx]
-                buffer = new_buffer
+                available = write_idx - read_idx
+                buffer[:available] = buffer[read_idx : write_idx]
+                read_idx = 0
+                write_idx = available
 
-        buffer[write_idx : write_idx + n_incoming] = target_chunk
-        write_idx += n_incoming
+                if write_idx + n_incoming > capacity:
+                    capacity = write_idx + n_incoming + target_yield_size
+                    new_shape = (capacity,) if process_channels == 1 else (capacity, process_channels)
+                    new_buffer = np.zeros(new_shape, dtype=dtype)
+                    new_buffer[:write_idx] = buffer[:write_idx]
+                    buffer = new_buffer
 
-        while write_idx - read_idx >= target_yield_size:
-            block = buffer[read_idx : read_idx + target_yield_size]
-            yield block.T
-            read_idx += target_advance
+            buffer[write_idx : write_idx + n_incoming] = target_chunk
+            write_idx += n_incoming
 
-    if process_channels == 1:
-        empty = np.empty((0,), dtype=buffer.dtype)
-    else:
-        empty = np.empty((0, process_channels), dtype=buffer.dtype)
+            while write_idx - read_idx >= target_yield_size:
+                block = buffer[read_idx : read_idx + target_yield_size]
+                yield block.T
+                read_idx += target_advance
 
-    if needs_resampling:
-        tail_chunk = resampler.resample_chunk(empty, last=True)
-    else:
-        tail_chunk = None
+        if process_channels == 1:
+            empty = np.empty((0,), dtype=buffer.dtype)
+        else:
+            empty = np.empty((0, process_channels), dtype=buffer.dtype)
 
-    available = write_idx - read_idx
-    final_data_list = [buffer[read_idx : write_idx]]
-    if tail_chunk is not None and tail_chunk.shape[0] > 0:
-        final_data_list.append(tail_chunk)
+        if needs_resampling:
+            tail_chunk = resampler.resample_chunk(empty, last=True)
+        else:
+            tail_chunk = None
 
-    remainder = np.concatenate(final_data_list, axis=0) if final_data_list else np.array([])
+        available = write_idx - read_idx
+        final_data_list = [buffer[read_idx : write_idx]]
+        if tail_chunk is not None and tail_chunk.shape[0] > 0:
+            final_data_list.append(tail_chunk)
 
-    rem_idx = 0
-    while rem_idx < remainder.shape[0]:
-        current_slice = remainder[rem_idx : rem_idx + target_yield_size]
+        remainder = np.concatenate(final_data_list, axis=0) if final_data_list else np.array([])
 
-        if current_slice.shape[0] < target_yield_size:
-            pad_length = target_yield_size - current_slice.shape[0]
-            pad_width = (0, pad_length) if process_channels == 1 else ((0, pad_length), (0, 0))
-            if fill_value is not None:
-                current_slice = np.pad(current_slice,
-                                       pad_width,
-                                       mode="constant",
-                                       constant_values=fill_value)
+        rem_idx = 0
+        while rem_idx < remainder.shape[0]:
+            current_slice = remainder[rem_idx : rem_idx + target_yield_size]
 
-        yield current_slice.T
-        rem_idx += target_advance
+            if current_slice.shape[0] < target_yield_size:
+                pad_length = target_yield_size - current_slice.shape[0]
+                pad_width = (0, pad_length) if process_channels == 1 else ((0, pad_length), (0, 0))
+                if fill_value is not None:
+                    current_slice = np.pad(current_slice,
+                                           pad_width,
+                                           mode="constant",
+                                           constant_values=fill_value)
+
+            yield current_slice.T
+            rem_idx += target_advance
+    finally:
+        # If we instantiated a new SoundFile object, we should close it.  If the
+        # user passed in an existing SoundFile object, we should leave it alone.
+        if not isinstance(path, sf.SoundFile):
+            sfo.close()
 
 
 def loadx(key: str, *, hq: bool | None = None, **kwargs: Any) -> tuple[np.ndarray, int | float]:

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -70,7 +70,7 @@ def load(
     Audio will be automatically resampled to the given rate
     (default ``sr=22050``).
 
-    To preserve the native sampling rate of the file, use ``sr=None``.
+    To preserve the orig sampling rate of the file, use ``sr=None``.
 
     Parameters
     ----------
@@ -88,7 +88,7 @@ def load(
     sr : number > 0 [scalar]
         target sampling rate
 
-        'None' uses the native sampling rate
+        'None' uses the orig sampling rate
 
     mono : bool
         convert signal to mono
@@ -110,7 +110,7 @@ def load(
         .. note::
             By default, this uses `soxr`'s high-quality mode ('HQ').
 
-            For alternative resampling modes, see `resample`
+            For alterorig resampling modes, see `resample`
 
     Returns
     -------
@@ -152,17 +152,17 @@ def load(
     >>> sfo = soundfile.SoundFile(librosa.ex('brahms'))
     >>> y, sr = librosa.load(sfo)
     """
-    y, sr_native = __soundfile_load(path, offset, duration, dtype)
+    y, sr_orig = __soundfile_load(path, offset, duration, dtype)
 
     # Final cleanup for dtype and contiguity
     if mono:
         y = to_mono(y)
 
     if sr is not None:
-        y = resample(y, orig_sr=sr_native, target_sr=sr, res_type=res_type)
+        y = resample(y, orig_sr=sr_orig, target_sr=sr, res_type=res_type)
 
     else:
-        sr = sr_native
+        sr = sr_orig
 
     return y, sr
 
@@ -178,28 +178,45 @@ def __soundfile_load(path, offset, duration, dtype):
         context = sf.SoundFile(path)
 
     with context as sf_desc:
-        sr_native = sf_desc.samplerate
+        sr_orig = sf_desc.samplerate
         if offset != 0:
             if offset > 0:
                 # Seek to the start of the target read
-                sf_desc.seek(int(offset * sr_native))
+                sf_desc.seek(int(offset * sr_orig))
             else:
-                sf_desc.seek(-int(abs(offset) * sr_native), whence=sf.SEEK_END)
+                sf_desc.seek(-int(abs(offset) * sr_orig), whence=sf.SEEK_END)
 
         if duration is not None:
-            frame_duration = int(duration * sr_native)
+            frame_duration = int(duration * sr_orig)
         else:
             frame_duration = -1
 
         # Load the target number of frames, and transpose to match librosa form
         y = sf_desc.read(frames=frame_duration, dtype=dtype, always_2d=False).T
 
-    return y, sr_native
+    return y, sr_orig
 
+
+def _align_step_size(target_step, target_sr, orig_sr):
+    """
+    When resampling a stream, we need to ensure that the target step size
+    remains integer-valued in the original sampling rate
+    """
+    if target_sr is None or target_sr == orig_sr:
+        return target_step
+
+    if (target_step * orig_sr) % target_sr != 0:
+        raise ParameterError(
+            f"Target block step of {target_step} samples at {target_sr} results in a "
+            f"fractional sample advance at original sampling rate {orig_sr}."
+        )
+
+    return int((target_step * orig_sr) / target_sr)
 
 def stream(
     path: str | int | sf.SoundFile | BinaryIO,
     *,
+    sr: float | None = None,
     block_length: int,
     frame_length: int,
     hop_length: int,
@@ -228,7 +245,7 @@ def stream(
            refers to a buffer of audio which spans a given number of
            (potentially overlapping) frames.
         2. Automatic sample-rate conversion is not supported.
-           Audio will be streamed in its native sample rate,
+           Audio will be streamed in its orig sample rate,
            so no default values are provided for ``frame_length``
            and ``hop_length``.  It is recommended that you first
            get the sampling rate for the file in question, using
@@ -354,34 +371,115 @@ def stream(
         sfo = sf.SoundFile(path)
 
     # Get the sample rate from the file info
-    sr = sfo.samplerate
+    orig_sr = sfo.samplerate
 
     # Construct the stream
     # Seek the soundfile object to the starting frame
+
+    target_yield_size = (block_length - 1) * hop_length + frame_length
+    target_advance = block_length * hop_length
+
+    # Determine internal channel state for buffer initialization
+    is_multichannel = sfo.channels > 1
+    process_channels = 1 if mono else sfo.channels
+
+    needs_resampling = (sr is not None) and (orig_sr != sr)
+    sr = sr or orig_sr
+
+    orig_read_size = _align_step_size(target_advance, sr, orig_sr)
+
+    read_frames = int(np.round(duration * orig_sr)) if duration is not None else -1
+
+    if needs_resampling:
+        resampler = soxr.ResampleStream(
+            in_rate=orig_sr,
+            out_rate=sr,
+            num_channels=process_channels,
+            dtype=dtype,
+            quality="HQ"
+        )
+
+    capacity = max(target_yield_size * 4, target_advance * 4)
+    buffer_shape = (capacity,) if process_channels == 1 else (capacity, process_channels)
+    buffer = np.zeros(buffer_shape, dtype=dtype)
+
+    write_idx = 0
+    read_idx = 0
+
     if offset >= 0:
-        sfo.seek(int(offset * sr))
+        sfo.seek(int(offset * orig_sr))
     else:
-        sfo.seek(-int(abs(offset) * sr), whence=sf.SEEK_END)
+        sfo.seek(-int(abs(offset) * orig_sr), whence=sf.SEEK_END)
 
-    if duration:
-        frames = int(duration * sr)
-    else:
-        frames = -1
+    for orig_chunk in sfo.blocks(blocksize=orig_read_size,
+                                 overlap=0,
+                                 dtype=dtype,
+                                 always_2d=False,
+                                 frames=read_frames):
 
-    blocks = sfo.blocks(
-        blocksize=frame_length + (block_length - 1) * hop_length,
-        overlap=frame_length - hop_length,
-        frames=frames,
-        dtype=dtype,
-        always_2d=False,
-        fill_value=fill_value,
-    )
+        if mono and is_multichannel:
+            # soundfile returns (samples, channels), to_mono expects (channels, samples)
+            orig_chunk = to_mono(orig_chunk.T)
 
-    for block in blocks:
-        if mono:
-            yield to_mono(block.T)
+        if needs_resampling:
+            target_chunk = resampler.resample_chunk(orig_chunk)
         else:
+            target_chunk = orig_chunk
+        n_incoming = target_chunk.shape[0]
+
+        if write_idx + n_incoming > capacity:
+            available = write_idx - read_idx
+            buffer[:available] = buffer[read_idx : write_idx]
+            read_idx = 0
+            write_idx = available
+
+            if write_idx + n_incoming > capacity:
+                capacity = write_idx + n_incoming + target_yield_size
+                new_shape = (capacity,) if process_channels == 1 else (capacity, process_channels)
+                new_buffer = np.zeros(new_shape, dtype=np.float32)
+                new_buffer[:write_idx] = buffer[:write_idx]
+                buffer = new_buffer
+
+        buffer[write_idx : write_idx + n_incoming] = target_chunk
+        write_idx += n_incoming
+
+        while write_idx - read_idx >= target_yield_size:
+            block = buffer[read_idx : read_idx + target_yield_size]
             yield block.T
+            read_idx += target_advance
+
+    if process_channels == 1:
+        empty = np.empty((0,), dtype=buffer.dtype)
+    else:
+        empty = np.empty((0, process_channels), dtype=buffer.dtype)
+
+    if needs_resampling:
+        tail_chunk = resampler.resample_chunk(empty, last=True)
+    else:
+        tail_chunk = None
+
+    available = write_idx - read_idx
+    final_data_list = [buffer[read_idx : write_idx]]
+    if tail_chunk is not None and tail_chunk.shape[0] > 0:
+        final_data_list.append(tail_chunk)
+
+    remainder = np.concatenate(final_data_list, axis=0) if final_data_list else np.array([])
+
+    rem_idx = 0
+    while rem_idx < remainder.shape[0]:
+        current_slice = remainder[rem_idx : rem_idx + target_yield_size]
+
+        if current_slice.shape[0] < target_yield_size:
+            pad_length = target_yield_size - current_slice.shape[0]
+            pad_width = (0, pad_length) if process_channels == 1 else ((0, pad_length), (0, 0))
+            if fill_value is not None:
+                current_slice = np.pad(current_slice,
+                                       pad_width,
+                                       mode="constant",
+                                       constant_values=fill_value)
+
+        yield current_slice.T
+        rem_idx += target_advance
 
 
 def loadx(key: str, *, hq: bool | None = None, **kwargs: Any) -> tuple[np.ndarray, int | float]:

--- a/librosa/util/decorators.py
+++ b/librosa/util/decorators.py
@@ -187,8 +187,8 @@ def future_default(*, param_name: str, old_default: Any, new_default: Any, versi
             if param_name not in bound.arguments:
                 warnings.warn(
                     f"The default value of '{param_name}' will change from "
-                    f"{old_default} to {new_default} in librosa version {version}. "
-                    f"To suppress this warning, explicitly pass '{param_name}={old_default}'.",
+                    f"{old_default!r} to {new_default!r} in librosa version {version}. "
+                    f"To suppress this warning, explicitly pass '{param_name}={old_default!r}'.",
                     FutureWarning,
                     stacklevel=2
                 )

--- a/librosa/util/decorators.py
+++ b/librosa/util/decorators.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import functools
+import inspect
 import warnings
 from typing import TYPE_CHECKING
 
@@ -13,7 +14,7 @@ from decorator import decorator
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
-    from typing import Protocol, type_check_only
+    from typing import Any, Protocol, type_check_only
 
     from numpy.typing import DTypeLike
 
@@ -94,7 +95,6 @@ def deprecated(*, version: str, version_removed: str) -> _Decorator:
     return decorator(__wrapper)
 
 
-
 def vectorize(
     *,
     otypes: str | Iterable[DTypeLike] | None = None,
@@ -155,3 +155,44 @@ def vectorize(
         return _vec
 
     return __wrapper
+
+
+def future_default(*, param_name: str, old_default: Any, new_default: Any, version: str) -> _Decorator:
+    """Mark a function parameter as having a future change to a default parameter value.
+
+    Parameters
+    ----------
+    param_name : str
+        The name of the parameter whose default value is changing.
+    old_default : Any
+        The current default value of the parameter.
+    new_default : Any
+        The future default value of the parameter.
+    version : str
+        The version in which the default value will change.
+
+    Returns
+    -------
+    decorator : Callable
+        A decorator that can be applied to the function to warn about the future change in default value
+    """
+    def decorator[**P, R](func: Callable[P, R]) -> Callable[P, R]:
+        sig = inspect.signature(func)
+
+        @functools.wraps(func)
+        def __wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            # functools.wraps does not inject defaults into args/kwargs
+            bound = sig.bind(*args, **kwargs)
+
+            if param_name not in bound.arguments:
+                warnings.warn(
+                    f"The default value of '{param_name}' will change from "
+                    f"{old_default} to {new_default} in librosa version {version}. "
+                    f"To suppress this warning, explicitly pass '{param_name}={old_default}'.",
+                    FutureWarning,
+                    stacklevel=2
+                )
+
+            return func(*args, **kwargs)
+        return __wrapper
+    return decorator

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2647,8 +2647,23 @@ def test_stream_badparam(path, block_length, frame_length, hop_length):
                 block_length=block_length,
                 frame_length=frame_length,
                 hop_length=hop_length,
+                sr=None,
             )
         )
+
+
+def test_stream_bad_sr(path):
+    with pytest.raises(librosa.ParameterError):
+        next(librosa.stream(path, block_length=10,
+                            frame_length=2048, hop_length=512,
+                            sr=-1))
+
+
+def test_stream_bad_res_type(path):
+    with pytest.raises(librosa.ParameterError):
+        next(librosa.stream(path, block_length=10,
+                            frame_length=2048, hop_length=512,
+                            sr=16000, res_type="foo"))
 
 
 def test_stream_bad_hop(path):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2659,6 +2659,7 @@ def test_stream_badparam(path, block_length, frame_length, hop_length):
 @pytest.mark.parametrize("duration", [None, 1.0])
 @pytest.mark.parametrize("fill_value", [None, 999.0])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
+@pytest.mark.parametrize("sr", [None, 22050, 11025])
 def test_stream(
     path,
     block_length,
@@ -2669,10 +2670,12 @@ def test_stream(
     duration,
     fill_value,
     dtype,
+    sr,
 ):
 
     stream = librosa.stream(
         path,
+        sr=sr,
         block_length=block_length,
         frame_length=frame_length,
         hop_length=hop_length,
@@ -2722,7 +2725,7 @@ def test_stream(
         path.seek(0)
 
     y_full, sr = librosa.load(
-        path, sr=None, dtype=dtype, mono=True, offset=offset, duration=duration
+        path, sr=sr, dtype=dtype, mono=True, offset=offset, duration=duration
     )
     # First, check the rate
     y_frame = librosa.util.frame(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2692,9 +2692,6 @@ def _verify_stream_parity(
             y_b_frame = librosa.util.frame(y_b_mono, frame_length=frame_length, hop_length=hop_length)
             y_frame_stream.append(y_b_frame)
 
-    if not y_frame_stream:
-        return
-
     y_frame_stream = np.concatenate(y_frame_stream, axis=1)
 
     if hasattr(path, "seek"):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2651,7 +2651,9 @@ def test_stream_badparam(path, block_length, frame_length, hop_length):
         )
 
 
-def test_stream_bad_frame(path):
+def test_stream_bad_hop(path):
+    # Fail if our hop length would not be integer-valued at the native
+    # sampling rate
     with pytest.raises(librosa.ParameterError):
         next(librosa.stream(path, block_length=3,
                             frame_length=2048, hop_length=513,
@@ -2721,7 +2723,7 @@ def test_stream_geometry_and_types(path, block_length, frame_length, hop_length,
     )
 
 
-@pytest.mark.parametrize("sr", [None, 11025])
+@pytest.mark.parametrize("sr", [None, 11025, 11025.0])
 @pytest.mark.parametrize("res_type", ["soxr_qq", "soxr_hq"])
 def test_stream_resampling(path, sr, res_type):
     _verify_stream_parity(path, sr=sr, res_type=res_type)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2659,7 +2659,8 @@ def test_stream_badparam(path, block_length, frame_length, hop_length):
 @pytest.mark.parametrize("duration", [None, 1.0])
 @pytest.mark.parametrize("fill_value", [None, 999.0])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
-@pytest.mark.parametrize("sr", [None, 22050, 11025])
+@pytest.mark.parametrize("sr", [None, 11025])
+@pytest.mark.parametrize("res_type", ["soxr_qq", "soxr_hq"])
 def test_stream(
     path,
     block_length,
@@ -2671,6 +2672,7 @@ def test_stream(
     fill_value,
     dtype,
     sr,
+    res_type,
 ):
 
     stream = librosa.stream(
@@ -2684,6 +2686,7 @@ def test_stream(
         offset=offset,
         duration=duration,
         fill_value=fill_value,
+        res_type=res_type,
     )
 
     y_frame_stream = []
@@ -2725,7 +2728,7 @@ def test_stream(
         path.seek(0)
 
     y_full, sr = librosa.load(
-        path, sr=sr, dtype=dtype, mono=True, offset=offset, duration=duration
+        path, sr=sr, dtype=dtype, mono=True, offset=offset, duration=duration, res_type=res_type
     )
     # First, check the rate
     y_frame = librosa.util.frame(
@@ -2734,7 +2737,10 @@ def test_stream(
 
     # Raw audio will not be padded
     n = y_frame.shape[1]
-    assert np.allclose(y_frame[:, :n], y_frame_stream[:, :n])
+    # Mostly we're going to be within tolerance, but non-associativity of floating point
+    # can drift values a little bit.  Tolerance of 1e-6 is well above errors detected in
+    # initial testing, but still negligible in practice.
+    assert np.allclose(y_frame[:, :n], y_frame_stream[:, :n], atol=1e-6), np.mean(np.abs(y_frame[:, :n] - y_frame_stream[:, :n]))
 
 
 @pytest.mark.parametrize("mu", [15, 31, 255])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2651,96 +2651,84 @@ def test_stream_badparam(path, block_length, frame_length, hop_length):
     )
 
 
-@pytest.mark.parametrize("block_length", [10, np.int64(30)])
-@pytest.mark.parametrize("frame_length", [1024, np.int64(2048)])
-@pytest.mark.parametrize("hop_length", [512, np.int64(1024)])
-@pytest.mark.parametrize("mono", [False, True])
-@pytest.mark.parametrize("offset", [0.0, 2.0, -2.0])
-@pytest.mark.parametrize("duration", [None, 1.0])
-@pytest.mark.parametrize("fill_value", [None, 999.0])
-@pytest.mark.parametrize("dtype", [np.float32, np.float64])
-@pytest.mark.parametrize("sr", [None, 11025])
-@pytest.mark.parametrize("res_type", ["soxr_qq", "soxr_hq"])
-def test_stream(
-    path,
-    block_length,
-    frame_length,
-    hop_length,
-    mono,
-    offset,
-    duration,
-    fill_value,
-    dtype,
-    sr,
-    res_type,
+def _verify_stream_parity(
+    path, block_length=10, frame_length=1024, hop_length=512,
+    mono=True, offset=0.0, duration=None, fill_value=None,
+    dtype=np.float32, sr=None, res_type="soxr_hq"
 ):
-
     stream = librosa.stream(
-        path,
-        sr=sr,
-        block_length=block_length,
-        frame_length=frame_length,
-        hop_length=hop_length,
-        dtype=dtype,
-        mono=mono,
-        offset=offset,
-        duration=duration,
-        fill_value=fill_value,
-        res_type=res_type,
+        path, sr=sr, block_length=block_length, frame_length=frame_length,
+        hop_length=hop_length, dtype=dtype, mono=mono, offset=offset,
+        duration=duration, fill_value=fill_value, res_type=res_type
     )
 
     y_frame_stream = []
     target_length = frame_length + (block_length - 1) * hop_length
 
     for y_block in stream:
-        # Check the dtype
         assert y_block.dtype == dtype
-
-        # Check for mono
         if mono:
             assert y_block.ndim == 1
         else:
             assert y_block.ndim == 2
             assert y_block.shape[0] == 2
 
-        # Check the length
         if fill_value is None:
             assert y_block.shape[-1] <= target_length
         else:
             assert y_block.shape[-1] == target_length
 
-        # frame this for easy checking
         y_b_mono = librosa.to_mono(y_block)
         if len(y_b_mono) >= frame_length:
-            y_b_frame = librosa.util.frame(
-                y_b_mono, frame_length=frame_length, hop_length=hop_length
-            )
+            y_b_frame = librosa.util.frame(y_b_mono, frame_length=frame_length, hop_length=hop_length)
             y_frame_stream.append(y_b_frame)
 
-    # Concatenate the framed blocks together
+    if not y_frame_stream:
+        return
+
     y_frame_stream = np.concatenate(y_frame_stream, axis=1)
 
-    # Load the reference data.
-    # We'll cast to mono here to simplify checking
-
-    # File objects have to be reset before loading
     if hasattr(path, "seek"):
         path.seek(0)
 
-    y_full, sr = librosa.load(
-        path, sr=sr, dtype=dtype, mono=True, offset=offset, duration=duration, res_type=res_type
-    )
-    # First, check the rate
-    y_frame = librosa.util.frame(
-        y_full, frame_length=frame_length, hop_length=hop_length
+    y_full, _ = librosa.load(
+        path, sr=sr, dtype=dtype, mono=True, offset=offset,
+        duration=duration, res_type=res_type
     )
 
-    # Raw audio will not be padded
+    y_frame = librosa.util.frame(y_full, frame_length=frame_length, hop_length=hop_length)
     n = y_frame.shape[1]
-    # Mostly we're going to be within tolerance, but non-associativity of floating point
-    # can drift values a little bit.  Tolerance of 1e-6 is well above errors detected in
-    # initial testing, but still negligible in practice.
-    assert np.allclose(y_frame[:, :n], y_frame_stream[:, :n], atol=1e-6), np.mean(np.abs(y_frame[:, :n] - y_frame_stream[:, :n]))
+
+    assert np.allclose(y_frame[:, :n], y_frame_stream[:, :n])
+
+
+@pytest.mark.parametrize("block_length", [10, np.int64(30)])
+@pytest.mark.parametrize("frame_length", [1024, np.int64(2048)])
+@pytest.mark.parametrize("hop_length", [512, np.int64(1024)])
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+@pytest.mark.parametrize("mono", [False, True])
+def test_stream_geometry_and_types(path, block_length, frame_length, hop_length, dtype, mono):
+    _verify_stream_parity(
+        path, block_length=block_length, frame_length=frame_length,
+        hop_length=hop_length, dtype=dtype, mono=mono
+    )
+
+
+@pytest.mark.parametrize("sr", [None, 11025])
+@pytest.mark.parametrize("res_type", ["soxr_qq", "soxr_hq"])
+def test_stream_resampling(path, sr, res_type):
+    _verify_stream_parity(path, sr=sr, res_type=res_type)
+
+
+@pytest.mark.parametrize("offset", [0.0, 2.0, -2.0])
+@pytest.mark.parametrize("duration", [None, 1.0])
+def test_stream_time_bounds(path, offset, duration):
+    _verify_stream_parity(path, offset=offset, duration=duration)
+
+
+@pytest.mark.parametrize("fill_value", [0.0, 999.0])
+def test_stream_padding(path, fill_value):
+    _verify_stream_parity(path, fill_value=fill_value)
 
 
 @pytest.mark.parametrize("mu", [15, 31, 255])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2639,16 +2639,23 @@ def path(request):
     "block_length,frame_length,hop_length",
     [(0, 1024, 512), (10, 0, 512), (10, 1024, 0)],
 )
-@pytest.mark.xfail(raises=librosa.ParameterError)
 def test_stream_badparam(path, block_length, frame_length, hop_length):
-    next(
-        librosa.stream(
-            path,
-            block_length=block_length,
-            frame_length=frame_length,
-            hop_length=hop_length,
+    with pytest.raises(librosa.ParameterError):
+        next(
+            librosa.stream(
+                path,
+                block_length=block_length,
+                frame_length=frame_length,
+                hop_length=hop_length,
+            )
         )
-    )
+
+
+def test_stream_bad_frame(path):
+    with pytest.raises(librosa.ParameterError):
+        next(librosa.stream(path, block_length=3,
+                            frame_length=2048, hop_length=513,
+                            sr=16000))
 
 
 def _verify_stream_parity(

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -821,6 +821,30 @@ def test_warning_moved():
         assert "moved" in str(out[0].message).lower()
 
 
+def test_warning_future_default():
+    @librosa.util.decorators.future_default(param_name="foo", old_default=1, new_default=2, version="1.0")
+    def __placeholder(foo=1):
+        return foo**2
+
+    with warnings.catch_warnings(record=True) as out:
+        v1 = __placeholder()
+        v2 = __placeholder(foo=1)
+        v3 = __placeholder(foo=2)
+
+        assert v1 == 1
+        assert v2 == 1
+        assert v3 == 4
+
+        # And that the warning triggered for the default case
+        assert len(out) > 0
+
+        # And that the category is correct
+        assert out[0].category is FutureWarning
+
+        # And that it says the right thing (roughly)
+        assert "default" in str(out[0].message).lower()
+
+
 def test_warning_rename_kw_pass():
 
     ov = librosa.util.Deprecated()


### PR DESCRIPTION
#### Reference Issue
Fixes #1518 


#### What does this implement/fix? Explain your changes.
This PR rewrites the simple block generator to support in-place sample rate conversion using soxr.

#### Any other comments?
There is a bit of an API consistency mismatch here, as the default for `sr=` is `None` here to preserve backward compatibility, while the default for `load` is 22K.  We should resolve this at some point, perhaps in 1.1 or 1.2.

The code is feature complete, but I haven't written new tests yet.  Right now I just want to start CI to ensure that the previous test suite passes.

Code co-authored by gemini pro 3.1.