### PR TITLE
Infer n_bins automatically in cqt/vqt

### DIFF
--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -948,8 +948,7 @@ def vqt(
     fmin = fmin * 2.0 ** (tuning / bins_per_octave)
 
     if fmin >= sr / 2:
-        raise ParameterError(f"fmin={fmin} is too high for sr={sr}")
-
+        raise ParameterError(f"fmin={fmin} must be less than sr/2={sr/2}")
     if n_bins is None:
         # If n_bins is None, we need to compute the number of bins to reach sr/2
         # Over-allocating by one octave buys us enough buffer to be safe.

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -244,7 +244,7 @@ def hybrid_cqt(
     fmin : float > 0 [scalar]
         Minimum frequency. Defaults to `C1 ~= 32.70 Hz`
 
-    n_bins : int > 0 [scalar]
+    n_bins : int > 0 or None [scalar]
         Number of frequency bins, starting at ``fmin``
         If `None` the number of bins will be inferred as the maximum that will
         fit below `sr/2`.
@@ -451,7 +451,7 @@ def pseudo_cqt(
     fmin : float > 0 [scalar]
         Minimum frequency. Defaults to `C1 ~= 32.70 Hz`
 
-    n_bins : int > 0 [scalar]
+    n_bins : int > 0 or None [scalar]
         Number of frequency bins, starting at ``fmin``
         If `None` the number of bins will be inferred as the maximum that will
         fit below `sr/2`.
@@ -1597,11 +1597,11 @@ def __et_relative_bw(bins_per_octave: int) -> np.ndarray:
 
 
 def __clip_freqs(
-        freqs: NDArray,
-        window: _WindowSpec,
-        filter_scale: float,
-        gamma: float | None,
-        sr: float
+    freqs: NDArray,
+    window: _WindowSpec,
+    filter_scale: float,
+    gamma: float | None,
+    sr: float
 ) -> NDArray[np.float64]:
     """Clip a frequency set to avoid exceeding the Nyquist frequency.
 
@@ -1618,7 +1618,7 @@ def __clip_freqs(
         Filter scale factor. Small values (<1) use shorter windows
         for improved time resolution.
 
-    gamma : float > 0 or None
+    gamma : float >= 0 or None
         Bandwidth offset for determining filter lengths.
         If `None`, use the default ERB-based calculation.
 

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -1084,7 +1084,13 @@ def vqt(
             __cqt_response(my_y, n_fft, my_hop, fft_basis, pad_mode, dtype=dtype)
         )
 
-        if my_hop % 2 == 0:
+        # We can downsample here if the hop length is even, and the highest frequency
+        # in the next octave down is comfortably below the target Nyquist frequency.
+        # Instead of the next octave's max, we'll use the current octave's min as a proxy.
+        # There should be at least half an octave between the min and the target Nyquist,
+        # which we approximate by my_sr / 3 = my_sr / 2 * 2/3 (P4 below proposed Nyquist)
+        # We additionally don't want to downsample if we're at the last octave anyway.
+        if my_hop % 2 == 0 and i < n_octaves - 1 and np.min(freqs_oct) * 2 <= my_sr / 3:
             my_hop //= 2
             my_sr /= 2.0
             my_y = audio.resample(
@@ -1221,7 +1227,6 @@ def __early_downsample_count(nyquist, filter_cutoff, hop_length, n_octaves):
 
     num_twos = __num_two_factors(hop_length)
     downsample_count2 = max(0, num_twos - n_octaves + 1)
-
     return min(downsample_count1, downsample_count2)
 
 

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -1086,16 +1086,18 @@ def vqt(
 
         # We can downsample here if the hop length is even, and the highest frequency
         # in the next octave down is comfortably below the target Nyquist frequency.
-        # Instead of the next octave's max, we'll use the current octave's min as a proxy.
-        # There should be at least half an octave between the min and the target Nyquist,
-        # which we approximate by my_sr / 3 = my_sr / 2 * 2/3 (P4 below proposed Nyquist)
-        # We additionally don't want to downsample if we're at the last octave anyway.
-        if my_hop % 2 == 0 and i < n_octaves - 1 and np.min(freqs_oct) * 2 <= my_sr / 3:
-            my_hop //= 2
-            my_sr /= 2.0
-            my_y = audio.resample(
-                my_y, orig_sr=2, target_sr=1, res_type=res_type, scale=True
-            )
+        # We'll assume that rolloff from downsampling starts at ~80% Nyquist.
+        # This is equivalent to 40% of the target sampling rate, or 20% of the current sampling
+        # rate.
+        # Only downsample if we're not in the last octave.
+        if i < n_octaves - 1:
+            f_max_next = freqs[sl.start - 1]
+            if my_hop % 2 == 0 and f_max_next <= my_sr / 5:
+                my_hop //= 2
+                my_sr /= 2.0
+                my_y = audio.resample(
+                    my_y, orig_sr=2, target_sr=1, res_type=res_type, scale=True
+                )
 
     V = __trim_stack(vqt_resp, n_bins, dtype)
 

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -351,7 +351,8 @@ def hybrid_cqt(
 
     if filter_cutoff > sr / 2:
         raise ParameterError(
-            f"Filter cutoff frequency {filter_cutoff} exceeds Nyquist frequency {sr/2}. Try reducing the number of frequency bins."
+            f"Filter cutoff frequency {filter_cutoff} exceeds Nyquist frequency {sr/2}. "
+            "Try reducing the number of frequency bins."
         )
 
     # Determine which filters to use with Pseudo CQT
@@ -548,7 +549,8 @@ def pseudo_cqt(
 
     if filter_cutoff > sr / 2:
         raise ParameterError(
-            f"Filter cutoff frequency {filter_cutoff} exceeds Nyquist frequency {sr/2}. Try reducing the number of frequency bins."
+            f"Filter cutoff frequency {filter_cutoff} exceeds Nyquist frequency {sr/2}. "
+            "Try reducing the number of frequency bins."
         )
 
     fft_basis, n_fft, _ = __vqt_filter_fft(

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -82,7 +82,8 @@ def cqt(
 
     n_bins : int > 0 or None [scalar]
         Number of frequency bins, starting at ``fmin``.
-        If `None`, the number of bins will be inferred to reach up to `sr/2`.
+        If `None`, the number of bins will be inferred as the maximum that will
+        fit below `sr/2`.
 
     bins_per_octave : int > 0 [scalar]
         Number of bins per octave
@@ -819,7 +820,8 @@ def vqt(
 
     n_bins : int > 0 or None [scalar]
         Number of frequency bins, starting at ``fmin``
-        If `None`, the number of bins will be inferred to reach up to `sr/2`.
+        If `None`, the number of bins will be inferred as the maximum that will
+        fit below `sr/2`.
 
     intervals : str or array of floats in [1, 2)
         Either a string specification for an interval set, e.g.,
@@ -944,6 +946,9 @@ def vqt(
 
     # Apply tuning correction
     fmin = fmin * 2.0 ** (tuning / bins_per_octave)
+
+    if fmin >= sr / 2:
+        raise ParameterError(f"fmin={fmin} is too high for sr={sr}")
 
     if n_bins is None:
         # If n_bins is None, we need to compute the number of bins to reach sr/2
@@ -1541,17 +1546,20 @@ def __et_relative_bw(bins_per_octave: int) -> np.ndarray:
     return np.atleast_1d((r**2 - 1) / (r**2 + 1))
 
 
-def __clip_freqs(freqs: NDArray,
-                 window: _WindowSpec,
-                 filter_scale: float,
-                 gamma: float | None,
-                 sr: float) -> NDArray[np.float64]:
+def __clip_freqs(
+        freqs: NDArray,
+        window: _WindowSpec,
+        filter_scale: float,
+        gamma: float | None,
+        sr: float
+) -> NDArray[np.float64]:
     """Clip a frequency set to avoid exceeding the Nyquist frequency.
 
     Parameters
     ----------
     freqs : np.ndarray [shape=(n_bins,)]
-        Frequency set to clip
+        Frequency set to clip.  At least two frequencies are
+        needed.
 
     window : str, tuple, or function
         Window specification for the basis filters.
@@ -1594,5 +1602,8 @@ def __clip_freqs(freqs: NDArray,
     f_cutoff = np.maximum.accumulate(freqs * (1 + 0.5 * window_bw / Q) + 0.5 * gamma_)
 
     idx = np.searchsorted(f_cutoff, sr / 2.0, side="left")
+
+    if idx < 1:
+        raise ParameterError(f"Unable to construct wavelet basis for fmin={freqs[0]:.2f} Hz and sr={sr:.2f} Hz.")
 
     return freqs[:idx]

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -212,7 +212,7 @@ def hybrid_cqt(
     sr: float = 22050,
     hop_length: int = 512,
     fmin: _FloatLike_co | None = None,
-    n_bins: int = 84,
+    n_bins: int | None = 84,
     bins_per_octave: int = 12,
     tuning: float | None = 0.0,
     filter_scale: float = 1,
@@ -246,6 +246,8 @@ def hybrid_cqt(
 
     n_bins : int > 0 [scalar]
         Number of frequency bins, starting at ``fmin``
+        If `None` the number of bins will be inferred as the maximum that will
+        fit below `sr/2`.
 
     bins_per_octave : int > 0 [scalar]
         Number of bins per octave
@@ -319,8 +321,22 @@ def hybrid_cqt(
     # Apply tuning correction
     fmin = fmin * 2.0 ** (tuning / bins_per_octave)
 
+    if fmin >= sr / 2:
+        raise ParameterError(f"fmin={fmin} must be less than sr/2={sr/2}")
+
+    if n_bins is None:
+        n_bins = int(np.ceil(bins_per_octave * (np.log2(sr) - np.log2(fmin))))
+        auto_n_bins = True
+    else:
+        auto_n_bins = False
+
     # Get all CQT frequencies
     freqs = cqt_frequencies(n_bins, fmin=fmin, bins_per_octave=bins_per_octave)
+
+    if auto_n_bins:
+        # Calling with gamma=0 here since this is CQT
+        freqs = __clip_freqs(freqs, window, filter_scale, 0, sr)
+        n_bins = len(freqs)
 
     # Pre-compute alpha
     if n_bins == 1:
@@ -329,9 +345,14 @@ def hybrid_cqt(
         alpha = filters._relative_bandwidth(freqs=freqs)
 
     # Compute the length of each constant-Q basis function
-    lengths, _ = filters.wavelet_lengths(
+    lengths, filter_cutoff = filters.wavelet_lengths(
         freqs=freqs, sr=sr, filter_scale=filter_scale, window=window, alpha=alpha
     )
+
+    if filter_cutoff > sr / 2:
+        raise ParameterError(
+            f"Filter cutoff frequency {filter_cutoff} exceeds Nyquist frequency {sr/2}. Try reducing the number of frequency bins."
+        )
 
     # Determine which filters to use with Pseudo CQT
     # These are the ones that fit within 2 hop lengths after padding
@@ -396,7 +417,7 @@ def pseudo_cqt(
     sr: float = 22050,
     hop_length: int = 512,
     fmin: _FloatLike_co | None = None,
-    n_bins: int = 84,
+    n_bins: int | None = 84,
     bins_per_octave: int = 12,
     tuning: float | None = 0.0,
     filter_scale: float = 1,
@@ -431,6 +452,8 @@ def pseudo_cqt(
 
     n_bins : int > 0 [scalar]
         Number of frequency bins, starting at ``fmin``
+        If `None` the number of bins will be inferred as the maximum that will
+        fit below `sr/2`.
 
     bins_per_octave : int > 0 [scalar]
         Number of bins per octave
@@ -498,16 +521,35 @@ def pseudo_cqt(
     # Apply tuning correction
     fmin = fmin * 2.0 ** (tuning / bins_per_octave)
 
+    if fmin >= sr / 2:
+        raise ParameterError(f"fmin={fmin} must be less than sr/2={sr/2}")
+
+    if n_bins is None:
+        n_bins = int(np.ceil(bins_per_octave * (np.log2(sr) - np.log2(fmin))))
+        auto_n_bins = True
+    else:
+        auto_n_bins = False
+
     freqs = cqt_frequencies(fmin=fmin, n_bins=n_bins, bins_per_octave=bins_per_octave)
+
+    if auto_n_bins:
+        # Calling with gamma=0 here since this is CQT
+        freqs = __clip_freqs(freqs, window, filter_scale, 0, sr)
+        n_bins = len(freqs)
 
     if n_bins == 1:
         alpha = __et_relative_bw(bins_per_octave)
     else:
         alpha = filters._relative_bandwidth(freqs=freqs)
 
-    lengths, _ = filters.wavelet_lengths(
+    lengths, filter_cutoff = filters.wavelet_lengths(
         freqs=freqs, sr=sr, window=window, filter_scale=filter_scale, alpha=alpha
     )
+
+    if filter_cutoff > sr / 2:
+        raise ParameterError(
+            f"Filter cutoff frequency {filter_cutoff} exceeds Nyquist frequency {sr/2}. Try reducing the number of frequency bins."
+        )
 
     fft_basis, n_fft, _ = __vqt_filter_fft(
         sr,

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -45,7 +45,7 @@ def cqt(
     sr: float = 22050,
     hop_length: int = 512,
     fmin: _FloatLike_co | None = None,
-    n_bins: int = 84,
+    n_bins: int | None = 84,
     bins_per_octave: int = 12,
     tuning: float | None = 0.0,
     filter_scale: float = 1,
@@ -81,7 +81,8 @@ def cqt(
         Minimum frequency. Defaults to `C1 ~= 32.70 Hz`
 
     n_bins : int > 0 [scalar]
-        Number of frequency bins, starting at ``fmin``
+        Number of frequency bins, starting at ``fmin``.
+        If `None`, the number of bins will be inferred to reach up to `sr/2`.
 
     bins_per_octave : int > 0 [scalar]
         Number of bins per octave
@@ -587,7 +588,7 @@ def icqt(
     tuning : float [scalar]
         Tuning offset in fractions of a bin.
 
-        The minimum frequency of the CQT will be modified to
+The minimum frequency of the CQT will be modified to
         ``fmin * 2**(tuning / bins_per_octave)``.
 
     filter_scale : float > 0 [scalar]
@@ -777,7 +778,7 @@ def vqt(
     sr: float = 22050,
     hop_length: int = 512,
     fmin: _FloatLike_co | None = None,
-    n_bins: int = 84,
+    n_bins: int | None = 84,
     intervals: str | Collection[float] = "equal",
     gamma: float | None = None,
     bins_per_octave: int = 12,
@@ -818,6 +819,7 @@ def vqt(
 
     n_bins : int > 0 [scalar]
         Number of frequency bins, starting at ``fmin``
+        If `None`, the number of bins will be inferred to reach up to `sr/2`.
 
     intervals : str or array of floats in [1, 2)
         Either a string specification for an interval set, e.g.,
@@ -930,10 +932,6 @@ def vqt(
     if not isinstance(intervals, str):
         bins_per_octave = len(intervals)
 
-    # How many octaves are we dealing with?
-    n_octaves = int(np.ceil(float(n_bins) / bins_per_octave))
-    n_filters = min(bins_per_octave, n_bins)
-
     if fmin is None:
         # C1 by default
         fmin = note_to_hz("C1")
@@ -947,7 +945,16 @@ def vqt(
     # Apply tuning correction
     fmin = fmin * 2.0 ** (tuning / bins_per_octave)
 
-    # First thing, get the freqs of the top octave
+    if n_bins is None:
+        # If n_bins is None, we need to compute the number of bins to reach sr/2
+        # Over-allocating by one octave buys us enough buffer to be safe.
+        # We'll clip back down later as needed.
+        n_bins = int(np.ceil(bins_per_octave * (np.log2(sr) - np.log2(fmin))))
+        # Equivalently: bins_per_octave * (1 + log2(sr/2 / fmin))
+        auto_n_bins = True
+    else:
+        auto_n_bins = False
+
     freqs = interval_frequencies(
         n_bins=n_bins,
         fmin=fmin,
@@ -956,9 +963,10 @@ def vqt(
         sort=True,
     )
 
-    freqs_top = freqs[-bins_per_octave:]
+    if auto_n_bins:
+        freqs = __clip_freqs(freqs, window, filter_scale, gamma, sr)
+        n_bins = len(freqs)
 
-    fmax_t: float = np.max(freqs_top)
     if n_bins == 1:
         alpha = __et_relative_bw(bins_per_octave)
     else:
@@ -977,10 +985,16 @@ def vqt(
     nyquist = sr / 2.0
 
     if filter_cutoff > nyquist:
+        freqs_top = freqs[-bins_per_octave:]
+        fmax_t: float = np.max(freqs_top)
         raise ParameterError(
             f"Wavelet basis with max frequency={fmax_t} would exceed the Nyquist frequency={nyquist}. "
             "Try reducing the number of frequency bins."
         )
+
+    # How many octaves are we dealing with?
+    n_octaves = int(np.ceil(float(n_bins) / bins_per_octave))
+    n_filters = min(bins_per_octave, n_bins)
 
     y, sr, hop_length = __early_downsample(
         y, sr, hop_length, res_type, n_octaves, nyquist, filter_cutoff, scale
@@ -1525,3 +1539,54 @@ def __et_relative_bw(bins_per_octave: int) -> np.ndarray:
     """
     r = 2 ** (1 / bins_per_octave)
     return np.atleast_1d((r**2 - 1) / (r**2 + 1))
+
+
+def __clip_freqs(freqs, window, filter_scale, gamma, sr):
+    """Clip a frequency set to avoid exceeding the Nyquist frequency.
+
+    Parameters
+    ----------
+    freqs : np.ndarray [shape=(n_bins,)]
+        Frequency set to clip
+
+    window : str, tuple, or function
+        Window specification for the basis filters.
+
+    filter_scale : float > 0
+        Filter scale factor. Small values (<1) use shorter windows
+        for improved time resolution.
+
+    gamma : float > 0
+        Bandwidth offset for determining filter lengths.
+
+    sr : number > 0
+        Audio sampling rate
+
+    Returns
+    -------
+    freqs : np.ndarray [shape=(n_bins,)]
+        Frequency set clipped to avoid exceeding the Nyquist frequency.
+    """
+    logf = np.log2(freqs)
+    window_bw = filters.window_bandwidth(window)
+
+    # Slide down the frequency set until we cross nyquist
+    # We need to calculate what truncated reflection alpha computation would do
+    i = len(freqs) - 1
+    for i in range(len(freqs) - 1, 0, -1):
+        # Effective bins-per-octave at this truncation point
+        bpo = 1 /(logf[i] - logf[i-1])
+        # Alpha at this point
+        alpha = (2.0**(2/bpo) - 1) / (2.0 ** (2/bpo) + 1)
+
+        if gamma is None:
+            gamma_ = alpha * 24.7 / 0.108
+        else:
+            gamma_ = gamma
+        Q = float(filter_scale) / alpha
+
+        f_cutoff = freqs[i] * (1 + 0.5 * window_bw / Q) + 0.5 * gamma_
+        if f_cutoff <= sr * 0.5:
+            break
+
+    return freqs[:i+1]

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -588,7 +588,7 @@ def icqt(
     tuning : float [scalar]
         Tuning offset in fractions of a bin.
 
-The minimum frequency of the CQT will be modified to
+        The minimum frequency of the CQT will be modified to
         ``fmin * 2**(tuning / bins_per_octave)``.
 
     filter_scale : float > 0 [scalar]

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -23,7 +23,7 @@ from .spectrum import istft, stft
 if TYPE_CHECKING:
     from typing import Collection
 
-    from numpy.typing import DTypeLike
+    from numpy.typing import DTypeLike, NDArray
 
     from .._typing import (
         RNGLike,
@@ -80,7 +80,7 @@ def cqt(
     fmin : float > 0 [scalar]
         Minimum frequency. Defaults to `C1 ~= 32.70 Hz`
 
-    n_bins : int > 0 [scalar]
+    n_bins : int > 0 or None [scalar]
         Number of frequency bins, starting at ``fmin``.
         If `None`, the number of bins will be inferred to reach up to `sr/2`.
 
@@ -817,7 +817,7 @@ def vqt(
     fmin : float > 0 [scalar]
         Minimum frequency. Defaults to `C1 ~= 32.70 Hz`
 
-    n_bins : int > 0 [scalar]
+    n_bins : int > 0 or None [scalar]
         Number of frequency bins, starting at ``fmin``
         If `None`, the number of bins will be inferred to reach up to `sr/2`.
 
@@ -1541,7 +1541,11 @@ def __et_relative_bw(bins_per_octave: int) -> np.ndarray:
     return np.atleast_1d((r**2 - 1) / (r**2 + 1))
 
 
-def __clip_freqs(freqs, window, filter_scale, gamma, sr):
+def __clip_freqs(freqs: NDArray,
+                 window: _WindowSpec,
+                 filter_scale: float,
+                 gamma: float | None,
+                 sr: float) -> NDArray[np.float64]:
     """Clip a frequency set to avoid exceeding the Nyquist frequency.
 
     Parameters
@@ -1556,8 +1560,9 @@ def __clip_freqs(freqs, window, filter_scale, gamma, sr):
         Filter scale factor. Small values (<1) use shorter windows
         for improved time resolution.
 
-    gamma : float > 0
+    gamma : float > 0 or None
         Bandwidth offset for determining filter lengths.
+        If `None`, use the default ERB-based calculation.
 
     sr : number > 0
         Audio sampling rate
@@ -1570,23 +1575,24 @@ def __clip_freqs(freqs, window, filter_scale, gamma, sr):
     logf = np.log2(freqs)
     window_bw = filters.window_bandwidth(window)
 
-    # Slide down the frequency set until we cross nyquist
-    # We need to calculate what truncated reflection alpha computation would do
-    i = len(freqs) - 1
-    for i in range(len(freqs) - 1, 0, -1):
-        # Effective bins-per-octave at this truncation point
-        bpo = 1 /(logf[i] - logf[i-1])
-        # Alpha at this point
-        alpha = (2.0**(2/bpo) - 1) / (2.0 ** (2/bpo) + 1)
+    # Use the reflection calculation for alpha, under the
+    # assumption that each frequency could be acting as the
+    # fmax.
+    bpo = 1 / np.diff(logf, prepend=0)
+    bpo[0] = 1 / (logf[1] - logf[0])
+    alpha = (2.0**(2/bpo) - 1) / (2.0 ** (2/bpo) + 1)
 
-        if gamma is None:
-            gamma_ = alpha * 24.7 / 0.108
-        else:
-            gamma_ = gamma
-        Q = float(filter_scale) / alpha
+    if gamma is None:
+        gamma_ = alpha * 24.7 / 0.108
+    else:
+        gamma_ = gamma
+    Q = float(filter_scale) / alpha
 
-        f_cutoff = freqs[i] * (1 + 0.5 * window_bw / Q) + 0.5 * gamma_
-        if f_cutoff <= sr * 0.5:
-            break
+    # Assuming non-monotonicity here: find the
+    # maximum cutoff frequency such that all frequencies
+    # below it land below the Nyquist frequency.
+    f_cutoff = np.maximum.accumulate(freqs * (1 + 0.5 * window_bw / Q) + 0.5 * gamma_)
 
-    return freqs[:i+1]
+    idx = np.searchsorted(f_cutoff, sr / 2.0, side="left")
+
+    return freqs[:idx]

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -972,8 +972,6 @@ def test_pseudo_cqt_nbins_none_small(y_cqt):
         librosa.pseudo_cqt(y=y_cqt, sr=2000, fmin=999,
                     n_bins=None, bins_per_octave=1)
 
-def test_hybrid_cqt_fmin_over(y_cqt):
+def test_pseudo_cqt_fmin_over(y_cqt):
     with pytest.raises(librosa.ParameterError):
-        librosa.hybrid_cqt(y=y_cqt, sr=2000, fmin=1500, n_bins=12)
-
-
+        librosa.pseudo_cqt(y=y_cqt, sr=2000, fmin=1500, n_bins=12)

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -831,11 +831,13 @@ def test_cqt_nbins_none(y_cqt, sr_cqt, bins_per_octave):
 @pytest.mark.parametrize("bins_per_octave", [12, 24, 60])
 @pytest.mark.parametrize("intervals", ["equal", "ji5", "ji7"])
 @pytest.mark.parametrize("gamma", [None, 0])
-def test_vqt_nbins_none(y_cqt, sr_cqt, bins_per_octave, intervals, gamma):
+@pytest.mark.parametrize("fmin", [32, 64, 128])
+def test_vqt_nbins_none(y_cqt, sr_cqt, bins_per_octave, intervals, gamma, fmin):
     # Test that n_bins=None works for VQT
     V = librosa.vqt(
         y=y_cqt,
         sr=sr_cqt,
+        fmin=fmin,
         n_bins=None,
         bins_per_octave=bins_per_octave,
         intervals=intervals,
@@ -845,6 +847,7 @@ def test_vqt_nbins_none(y_cqt, sr_cqt, bins_per_octave, intervals, gamma):
     V2 = librosa.vqt(
         y=y_cqt,
         sr=sr_cqt,
+        fmin=fmin,
         n_bins=V.shape[-2],
         bins_per_octave=bins_per_octave,
         intervals=intervals,
@@ -858,6 +861,7 @@ def test_vqt_nbins_none(y_cqt, sr_cqt, bins_per_octave, intervals, gamma):
         librosa.vqt(
             y=y_cqt,
             sr=sr_cqt,
+            fmin=fmin,
             n_bins=V.shape[-2] + 1,
             bins_per_octave=bins_per_octave,
             intervals=intervals,
@@ -877,3 +881,99 @@ def test_vqt_nbins_none_small(y_cqt):
 def test_vqt_fmin_over(y_cqt):
     with pytest.raises(librosa.ParameterError):
         librosa.vqt(y=y_cqt, sr=2000, fmin=1500, n_bins=12)
+
+
+@pytest.mark.parametrize("bins_per_octave", [12, 24, 60])
+@pytest.mark.parametrize("fmin", [32, 64, 128])
+def test_hybrid_cqt_nbins_none(y_cqt, sr_cqt, bins_per_octave, fmin):
+    # Test that n_bins=None works for VQT
+    V = librosa.hybrid_cqt(
+        y=y_cqt,
+        sr=sr_cqt,
+        fmin=fmin,
+        n_bins=None,
+        bins_per_octave=bins_per_octave,
+    )
+    # We'll compare to explicitly setting n_bins to match
+    V2 = librosa.hybrid_cqt(
+        y=y_cqt,
+        sr=sr_cqt,
+        fmin=fmin,
+        n_bins=V.shape[-2],
+        bins_per_octave=bins_per_octave,
+    )
+
+    assert np.allclose(V, V2)
+
+    # Now verify that going one step further would raise an error
+    with pytest.raises(librosa.ParameterError):
+        librosa.hybrid_cqt(
+            y=y_cqt,
+            sr=sr_cqt,
+            fmin=fmin,
+            n_bins=V.shape[-2] + 1,
+            bins_per_octave=bins_per_octave,
+        )
+
+def test_hybrid_cqt_fmin_high(y_cqt):
+    with pytest.raises(librosa.ParameterError):
+        librosa.hybrid_cqt(y=y_cqt, sr=2000, fmin=999,
+                    n_bins=2, bins_per_octave=1)
+
+def test_hybrid_cqt_nbins_none_small(y_cqt):
+    with pytest.raises(librosa.ParameterError):
+        librosa.hybrid_cqt(y=y_cqt, sr=2000, fmin=999,
+                    n_bins=None, bins_per_octave=1)
+
+def test_hybrid_cqt_fmin_over(y_cqt):
+    with pytest.raises(librosa.ParameterError):
+        librosa.hybrid_cqt(y=y_cqt, sr=2000, fmin=1500, n_bins=12)
+
+
+@pytest.mark.parametrize("bins_per_octave", [12, 24, 60])
+@pytest.mark.parametrize("fmin", [32, 64, 128])
+def test_pseudo_cqt_nbins_none(y_cqt, sr_cqt, bins_per_octave, fmin):
+    # Test that n_bins=None works for VQT
+    V = librosa.pseudo_cqt(
+        y=y_cqt,
+        sr=sr_cqt,
+        fmin=fmin,
+        n_bins=None,
+        bins_per_octave=bins_per_octave,
+    )
+    # We'll compare to explicitly setting n_bins to match
+    V2 = librosa.pseudo_cqt(
+        y=y_cqt,
+        sr=sr_cqt,
+        fmin=fmin,
+        n_bins=V.shape[-2],
+        bins_per_octave=bins_per_octave,
+    )
+
+    assert np.allclose(V, V2)
+
+    # Now verify that going one step further would raise an error
+    with pytest.raises(librosa.ParameterError):
+        librosa.pseudo_cqt(
+            y=y_cqt,
+            sr=sr_cqt,
+            fmin=fmin,
+            n_bins=V.shape[-2] + 1,
+            bins_per_octave=bins_per_octave,
+        )
+
+def test_pseudo_cqt_fmin_high(y_cqt):
+    with pytest.raises(librosa.ParameterError):
+        librosa.pseudo_cqt(y=y_cqt, sr=2000, fmin=999,
+                    n_bins=2, bins_per_octave=1)
+
+def test_pseudo_cqt_nbins_none_small(y_cqt):
+    with pytest.raises(librosa.ParameterError):
+        librosa.pseudo_cqt(y=y_cqt, sr=2000, fmin=999,
+                    n_bins=None, bins_per_octave=1)
+
+def test_hybrid_cqt_fmin_over(y_cqt):
+    with pytest.raises(librosa.ParameterError):
+        librosa.hybrid_cqt(y=y_cqt, sr=2000, fmin=1500, n_bins=12)
+
+

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -886,7 +886,7 @@ def test_vqt_fmin_over(y_cqt):
 @pytest.mark.parametrize("bins_per_octave", [12, 24, 60])
 @pytest.mark.parametrize("fmin", [32, 64, 128])
 def test_hybrid_cqt_nbins_none(y_cqt, sr_cqt, bins_per_octave, fmin):
-    # Test that n_bins=None works for VQT
+    # Test that n_bins=None works for hybrid CQT
     V = librosa.hybrid_cqt(
         y=y_cqt,
         sr=sr_cqt,
@@ -933,7 +933,7 @@ def test_hybrid_cqt_fmin_over(y_cqt):
 @pytest.mark.parametrize("bins_per_octave", [12, 24, 60])
 @pytest.mark.parametrize("fmin", [32, 64, 128])
 def test_pseudo_cqt_nbins_none(y_cqt, sr_cqt, bins_per_octave, fmin):
-    # Test that n_bins=None works for VQT
+    # Test that n_bins=None works for pseudo CQT
     V = librosa.pseudo_cqt(
         y=y_cqt,
         sr=sr_cqt,

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -819,13 +819,13 @@ def test_cqt_nbins_none(y_cqt, sr_cqt, bins_per_octave):
     # Test that n_bins=None works
     C = librosa.cqt(y=y_cqt, sr=sr_cqt, n_bins=None, bins_per_octave=bins_per_octave)
     # We'll compare to explicitly setting n_bins to match
-    C2 = librosa.cqt(y=y_cqt, sr=sr_cqt, n_bins=C.shape[0], bins_per_octave=bins_per_octave)
+    C2 = librosa.cqt(y=y_cqt, sr=sr_cqt, n_bins=C.shape[-2], bins_per_octave=bins_per_octave)
 
     assert np.allclose(C, C2)
 
     # Now verify that going one step further would raise an error
     with pytest.raises(librosa.ParameterError):
-        librosa.cqt(y=y_cqt, sr=sr_cqt, n_bins=C.shape[0] + 1, bins_per_octave=bins_per_octave)
+        librosa.cqt(y=y_cqt, sr=sr_cqt, n_bins=C.shape[-2] + 1, bins_per_octave=bins_per_octave)
 
 
 @pytest.mark.parametrize("bins_per_octave", [12, 24, 60])
@@ -845,7 +845,7 @@ def test_vqt_nbins_none(y_cqt, sr_cqt, bins_per_octave, intervals, gamma):
     V2 = librosa.vqt(
         y=y_cqt,
         sr=sr_cqt,
-        n_bins=V.shape[0],
+        n_bins=V.shape[-2],
         bins_per_octave=bins_per_octave,
         intervals=intervals,
         gamma=gamma,
@@ -858,8 +858,18 @@ def test_vqt_nbins_none(y_cqt, sr_cqt, bins_per_octave, intervals, gamma):
         librosa.vqt(
             y=y_cqt,
             sr=sr_cqt,
-            n_bins=V.shape[0] + 1,
+            n_bins=V.shape[-2] + 1,
             bins_per_octave=bins_per_octave,
             intervals=intervals,
             gamma=gamma,
         )
+
+def test_vqt_fmin_high(y_cqt):
+    with pytest.raises(librosa.ParameterError):
+        librosa.vqt(y=y_cqt, sr=2000, fmin=999,
+                    n_bins=2, bins_per_octave=1)
+
+def test_vqt_nbins_none_small(y_cqt):
+    with pytest.raises(librosa.ParameterError):
+        librosa.vqt(y=y_cqt, sr=2000, fmin=999,
+                    n_bins=None, bins_per_octave=1)

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -812,3 +812,54 @@ def test_vqt_provided_intervals(y_cqt, sr_cqt):
     V2 = librosa.vqt(y=y_cqt, sr=sr_cqt, n_bins=60, intervals=intervals)
 
     assert np.allclose(V1, V2)
+
+
+@pytest.mark.parametrize("bins_per_octave", [12, 24, 60])
+def test_cqt_nbins_none(y_cqt, sr_cqt, bins_per_octave):
+    # Test that n_bins=None works
+    C = librosa.cqt(y=y_cqt, sr=sr_cqt, n_bins=None, bins_per_octave=bins_per_octave)
+    # We'll compare to explicitly setting n_bins to match
+    C2 = librosa.cqt(y=y_cqt, sr=sr_cqt, n_bins=C.shape[0], bins_per_octave=bins_per_octave)
+
+    assert np.allclose(C, C2)
+
+    # Now verify that going one step further would raise an error
+    with pytest.raises(librosa.ParameterError):
+        librosa.cqt(y=y_cqt, sr=sr_cqt, n_bins=C.shape[0] + 1, bins_per_octave=bins_per_octave)
+
+
+@pytest.mark.parametrize("bins_per_octave", [12, 24, 60])
+@pytest.mark.parametrize("intervals", ["equal", "ji5", "ji7"])
+@pytest.mark.parametrize("gamma", [None, 0])
+def test_vqt_nbins_none(y_cqt, sr_cqt, bins_per_octave, intervals, gamma):
+    # Test that n_bins=None works for VQT
+    V = librosa.vqt(
+        y=y_cqt,
+        sr=sr_cqt,
+        n_bins=None,
+        bins_per_octave=bins_per_octave,
+        intervals=intervals,
+        gamma=gamma,
+    )
+    # We'll compare to explicitly setting n_bins to match
+    V2 = librosa.vqt(
+        y=y_cqt,
+        sr=sr_cqt,
+        n_bins=V.shape[0],
+        bins_per_octave=bins_per_octave,
+        intervals=intervals,
+        gamma=gamma,
+    )
+
+    assert np.allclose(V, V2)
+
+    # Now verify that going one step further would raise an error
+    with pytest.raises(librosa.ParameterError):
+        librosa.vqt(
+            y=y_cqt,
+            sr=sr_cqt,
+            n_bins=V.shape[0] + 1,
+            bins_per_octave=bins_per_octave,
+            intervals=intervals,
+            gamma=gamma,
+        )

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -537,11 +537,11 @@ def test_icqt(y_icqt, sr_icqt, scale, hop_length, over_sample, res_type):
     yinv = yinv[sr_icqt // 2 : -sr_icqt // 2]
 
     residual = np.abs(y_icqt - yinv)
-    # We'll tolerate 10% RMSE
+    # We'll tolerate 6% RMSE
     # error is lower on more recent numpy/scipy builds
 
     resnorm = np.sqrt(np.mean(residual**2))
-    assert resnorm <= 0.1, resnorm
+    assert resnorm <= 0.06, resnorm
 
 
 @pytest.mark.parametrize("hop_length", [384, 512])
@@ -574,7 +574,7 @@ def test_icqt_nolength(y_icqt, sr_icqt, hop_length):
 
     residual = np.abs(y_icqt - yinv)
     resnorm = np.sqrt(np.mean(residual**2))
-    assert resnorm <= 0.1, resnorm
+    assert resnorm <= 0.06, resnorm
 
 
 def test_icqt_dtype(y_icqt, sr_icqt):

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -873,3 +873,7 @@ def test_vqt_nbins_none_small(y_cqt):
     with pytest.raises(librosa.ParameterError):
         librosa.vqt(y=y_cqt, sr=2000, fmin=999,
                     n_bins=None, bins_per_octave=1)
+
+def test_vqt_fmin_over(y_cqt):
+    with pytest.raises(librosa.ParameterError):
+        librosa.vqt(y=y_cqt, sr=2000, fmin=1500, n_bins=12)


### PR DESCRIPTION
#### Reference Issue
Fixes #1966 
Fixes #2071 

#### What does this implement/fix? Explain your changes.
This PR implements automatic n_bins detection for vqt (and cqt).  This automatically picks the largest `n_bins` such that filters will remain within the pass-band.

#### Any other comments?

I think this is functionally fine.  The code is a bit messy, in that there's a fair amount of redundant logic here for calculating filter cutoffs.  OTOH it's simple enough that the redundancy doesn't bother me too much.

Some thoughts:

- I don't think this should ever become the default parametrization because it will lead to unpredictable (or, more correctly, surprising) output sizes for users.
- There's a question as to whether this should become the default for *internal* uses of cqt/vqt, such as when computing chroma features.  I'm ambivalent on this one.