### PR TITLE
Standardize n_fft parameter docstrings

### DIFF
--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -1163,7 +1163,7 @@ def get_duration(
         it is better to use the audio time series directly.
 
     n_fft : int > 0 [scalar]
-        FFT window size for ``S``
+        length of the FFT frame used when computing ``S``
 
     hop_length : int > 0 [ scalar]
         number of audio samples between columns of ``S``

--- a/librosa/core/convert.py
+++ b/librosa/core/convert.py
@@ -100,7 +100,7 @@ def frames_to_samples(
     hop_length : int > 0 [scalar]
         number of samples between successive frames
     n_fft : None or int > 0 [scalar]
-        Optional: length of the FFT window.
+        Optional: length of the FFT frame.
         If given, time conversion will include an offset of ``n_fft // 2``
         to counteract windowing effects when using a non-centered STFT.
 
@@ -169,7 +169,7 @@ def samples_to_frames(
         number of samples between successive frames
 
     n_fft : None or int > 0 [scalar]
-        Optional: length of the FFT window.
+        Optional: length of the FFT frame.
         If given, time conversion will include an offset of ``- n_fft // 2``
         to counteract windowing effects in STFT.
 
@@ -229,7 +229,7 @@ def frames_to_time(
     hop_length : int > 0 [scalar]
         number of samples between successive frames
     n_fft : None or int > 0 [scalar]
-        Optional: length of the FFT window.
+        Optional: length of the FFT frame.
         If given, time conversion will include an offset of ``n_fft // 2``
         to counteract windowing effects when using a non-centered STFT.
 
@@ -293,7 +293,7 @@ def time_to_frames(
         number of samples between successive frames
 
     n_fft : None or int > 0 [scalar]
-        Optional: length of the FFT window.
+        Optional: length of the FFT frame.
         If given, time conversion will include an offset of ``- n_fft // 2``
         to counteract windowing effects in STFT.
 
@@ -1374,7 +1374,7 @@ def fft_frequencies(*, sr: float = 22050, n_fft: int = 2048) -> _Array1D[np.floa
     sr : number > 0 [scalar]
         Audio sampling rate
     n_fft : int > 0 [scalar]
-        length of the FFT window
+        length of the FFT frame
 
     Returns
     -------
@@ -2090,7 +2090,7 @@ def times_like(
     hop_length : int > 0 [scalar]
         number of samples between successive frames
     n_fft : None or int > 0 [scalar]
-        Optional: length of the FFT window.
+        Optional: length of the FFT frame.
         If given, time conversion will include an offset of ``n_fft // 2``
         to counteract windowing effects when using a non-centered STFT.
     axis : int [scalar]
@@ -2147,7 +2147,7 @@ def samples_like(
     hop_length : int > 0 [scalar]
         number of samples between successive frames
     n_fft : None or int > 0 [scalar]
-        Optional: length of the FFT window.
+        Optional: length of the FFT frame.
         If given, time conversion will include an offset of ``n_fft // 2``
         to counteract windowing effects when using a non-centered STFT.
     axis : int [scalar]

--- a/librosa/core/convert.py
+++ b/librosa/core/convert.py
@@ -1374,7 +1374,7 @@ def fft_frequencies(*, sr: float = 22050, n_fft: int = 2048) -> _Array1D[np.floa
     sr : number > 0 [scalar]
         Audio sampling rate
     n_fft : int > 0 [scalar]
-        FFT window size
+        length of the FFT window
 
     Returns
     -------

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -46,7 +46,7 @@ def estimate_tuning(
     S : np.ndarray [shape=(..., d, t)] or None
         magnitude or power spectrogram
     n_fft : int > 0 [scalar] or None
-        length of the FFT window to use, if ``y`` is provided.
+        length of the FFT frame to use, if ``y`` is provided.
     resolution : float in `(0, 1)`
         Resolution of the tuning as a fraction of a bin.
         0.01 corresponds to measurements in cents.
@@ -213,7 +213,7 @@ def piptrack(
         magnitude or power spectrogram
 
     n_fft : int > 0 [scalar] or None
-        length of the FFT window to use, if ``y`` is provided.
+        length of the FFT frame to use, if ``y`` is provided.
 
     hop_length : int > 0 [scalar] or None
         number of samples to hop

--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -46,7 +46,7 @@ def estimate_tuning(
     S : np.ndarray [shape=(..., d, t)] or None
         magnitude or power spectrogram
     n_fft : int > 0 [scalar] or None
-        number of FFT bins to use, if ``y`` is provided.
+        length of the FFT window to use, if ``y`` is provided.
     resolution : float in `(0, 1)`
         Resolution of the tuning as a fraction of a bin.
         0.01 corresponds to measurements in cents.
@@ -213,7 +213,7 @@ def piptrack(
         magnitude or power spectrogram
 
     n_fft : int > 0 [scalar] or None
-        number of FFT bins to use, if ``y`` is provided.
+        length of the FFT window to use, if ``y`` is provided.
 
     hop_length : int > 0 [scalar] or None
         number of samples to hop

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -428,7 +428,7 @@ def istft(
         Number of frames between STFT columns.
         If unspecified, defaults to ``win_length // 4``.
 
-    win_length : int <= n_fft = 2 * (stft_matrix.shape[0] - 1)
+    win_length : int <= n_fft = 2 * (stft_matrix.shape[-2] - 1)
         When reconstructing the time series, each frame is windowed
         and each sample is normalized by the sum of squared window
         according to the ``window`` function (see below).
@@ -437,9 +437,10 @@ def istft(
 
     n_fft : int > 0 or None
         The number of samples per frame in the input spectrogram.
-        By default, this will be inferred from the shape of ``stft_matrix``.
-        However, if an odd frame length was used, you can specify the correct
-        length by setting ``n_fft``.
+        By default, this is inferred as ``2 * (stft_matrix.shape[-2] - 1)``,
+        which assumes an even-length ``n_fft``. If the STFT was computed with
+        an odd ``n_fft``, that inference is off by one; pass the original
+        ``n_fft`` to recover the correct frame length.
 
     window : str, tuple, number, function, np.ndarray [shape=(n_fft,)]
         - a window specification (str, tuple, or number);
@@ -686,7 +687,7 @@ def __reassign_frequencies(
         to `__reassign_frequencies`
 
     n_fft : int > 0 [scalar]
-        FFT window size. Defaults to 2048.
+        length of the FFT window. Defaults to 2048.
 
     hop_length : int > 0 [scalar]
         hop length, number samples between subsequent frames.
@@ -849,7 +850,7 @@ def __reassign_times(
         to `__reassign_times`
 
     n_fft : int > 0 [scalar]
-        FFT window size. Defaults to 2048.
+        length of the FFT window. Defaults to 2048.
 
     hop_length : int > 0 [scalar]
         hop length, number samples between subsequent frames.
@@ -1051,7 +1052,7 @@ def reassigned_spectrogram(
         to ``reassigned_spectrogram``
 
     n_fft : int > 0 [scalar]
-        FFT window size. Defaults to 2048.
+        length of the FFT window. Defaults to 2048.
 
     hop_length : int > 0 [scalar]
         hop length, number samples between subsequent frames.
@@ -1421,7 +1422,7 @@ def phase_vocoder(
     hop_length : int > 0 [scalar] or None
         The number of samples between successive columns of ``D``.
 
-        If None, defaults to ``n_fft//4 = (D.shape[0]-1)//2``
+        If None, defaults to ``n_fft//4 = (D.shape[-2]-1)//2``
 
         .. warning:: This parameter is deprecated as of 1.0 and will
             be removed in 1.1.  It is unused in the current implementation.
@@ -2942,7 +2943,7 @@ def _spectrogram(
         Spectrogram input, optional
 
     n_fft : int > 0
-        STFT window size
+        length of the FFT window
 
     hop_length : int > 0
         STFT hop length

--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -687,7 +687,7 @@ def __reassign_frequencies(
         to `__reassign_frequencies`
 
     n_fft : int > 0 [scalar]
-        length of the FFT window. Defaults to 2048.
+        length of the FFT frame. Defaults to 2048.
 
     hop_length : int > 0 [scalar]
         hop length, number samples between subsequent frames.
@@ -850,7 +850,7 @@ def __reassign_times(
         to `__reassign_times`
 
     n_fft : int > 0 [scalar]
-        length of the FFT window. Defaults to 2048.
+        length of the FFT frame. Defaults to 2048.
 
     hop_length : int > 0 [scalar]
         hop length, number samples between subsequent frames.
@@ -1052,7 +1052,7 @@ def reassigned_spectrogram(
         to ``reassigned_spectrogram``
 
     n_fft : int > 0 [scalar]
-        length of the FFT window. Defaults to 2048.
+        length of the FFT frame. Defaults to 2048.
 
     hop_length : int > 0 [scalar]
         hop length, number samples between subsequent frames.
@@ -2943,7 +2943,7 @@ def _spectrogram(
         Spectrogram input, optional
 
     n_fft : int > 0
-        length of the FFT window
+        length of the FFT frame
 
     hop_length : int > 0
         STFT hop length

--- a/librosa/feature/inverse.py
+++ b/librosa/feature/inverse.py
@@ -42,7 +42,7 @@ def mel_to_stft(
     sr : number > 0 [scalar]
         sampling rate of the underlying signal
     n_fft : int > 0 [scalar]
-        number of FFT components in the resulting STFT
+        length of the FFT window of the resulting STFT; the output has ``1 + n_fft // 2`` frequency bins
     power : float > 0 [scalar]
         Exponent for the magnitude melspectrogram
     **kwargs :
@@ -67,7 +67,7 @@ def mel_to_stft(
 
     Returns
     -------
-    S : np.ndarray [shape=(..., n_fft, t), non-negative]
+    S : np.ndarray [shape=(..., 1 + n_fft // 2, t), non-negative]
         An approximate linear magnitude spectrogram
 
     See Also
@@ -144,7 +144,7 @@ def mel_to_audio(
     sr : number > 0 [scalar]
         sampling rate of the underlying signal
     n_fft : int > 0 [scalar]
-        number of FFT components in the resulting STFT
+        length of the FFT window for the intermediate STFT
     hop_length : None or int > 0
         The hop length of the STFT.  If not provided, it will default to ``n_fft // 4``
     win_length : None or int > 0
@@ -329,7 +329,7 @@ def mfcc_to_audio(
     sr : number > 0 [scalar]
         sampling rate of the underlying signal
     n_fft : int > 0 [scalar]
-        number of FFT components in the resulting STFT
+        length of the FFT window for the intermediate STFT
     hop_length : None or int > 0
         The hop length of the STFT.  If not provided, it will default to ``n_fft // 4``
     win_length : None or int > 0

--- a/librosa/feature/inverse.py
+++ b/librosa/feature/inverse.py
@@ -42,7 +42,7 @@ def mel_to_stft(
     sr : number > 0 [scalar]
         sampling rate of the underlying signal
     n_fft : int > 0 [scalar]
-        length of the FFT window of the resulting STFT; the output has ``1 + n_fft // 2`` frequency bins
+        length of the FFT frame of the resulting STFT; the output has ``1 + n_fft // 2`` frequency bins
     power : float > 0 [scalar]
         Exponent for the magnitude melspectrogram
     **kwargs :
@@ -144,7 +144,7 @@ def mel_to_audio(
     sr : number > 0 [scalar]
         sampling rate of the underlying signal
     n_fft : int > 0 [scalar]
-        length of the FFT window for the intermediate STFT
+        length of the FFT frame for the intermediate STFT
     hop_length : None or int > 0
         The hop length of the STFT.  If not provided, it will default to ``n_fft // 4``
     win_length : None or int > 0
@@ -329,7 +329,7 @@ def mfcc_to_audio(
     sr : number > 0 [scalar]
         sampling rate of the underlying signal
     n_fft : int > 0 [scalar]
-        length of the FFT window for the intermediate STFT
+        length of the FFT frame for the intermediate STFT
     hop_length : None or int > 0
         The hop length of the STFT.  If not provided, it will default to ``n_fft // 4``
     win_length : None or int > 0

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -82,7 +82,7 @@ def spectral_centroid(
     S : np.ndarray [shape=(..., d, t)] or None
         (optional) spectrogram magnitude
     n_fft : int > 0 [scalar]
-        length of the FFT window
+        length of the FFT frame
     hop_length : int > 0 [scalar]
         hop length for STFT. See `librosa.stft` for details.
     freq : None or np.ndarray [shape=(d,) or shape=(d, t)]
@@ -226,7 +226,7 @@ def spectral_bandwidth(
     S : np.ndarray [shape=(..., d, t)] or None
         (optional) spectrogram magnitude
     n_fft : int > 0 [scalar]
-        length of the FFT window
+        length of the FFT frame
     hop_length : int > 0 [scalar]
         hop length for STFT. See `librosa.stft` for details.
     win_length : int <= n_fft [scalar]
@@ -394,7 +394,7 @@ def spectral_contrast(
     S : np.ndarray [shape=(..., d, t)] or None
         (optional) spectrogram magnitude
     n_fft : int > 0 [scalar]
-        length of the FFT window
+        length of the FFT frame
     hop_length : int > 0 [scalar]
         hop length for STFT. See `librosa.stft` for details.
     win_length : int <= n_fft [scalar]
@@ -563,7 +563,7 @@ def spectral_rolloff(
     S : np.ndarray [shape=(d, t)] or None
         (optional) spectrogram magnitude
     n_fft : int > 0 [scalar]
-        length of the FFT window
+        length of the FFT frame
     hop_length : int > 0 [scalar]
         hop length for STFT. See `librosa.stft` for details.
     win_length : int <= n_fft [scalar]
@@ -716,7 +716,7 @@ def spectral_flatness(
     S : np.ndarray [shape=(..., d, t)] or None
         (optional) pre-computed spectrogram magnitude
     n_fft : int > 0 [scalar]
-        length of the FFT window
+        length of the FFT frame
     hop_length : int > 0 [scalar]
         hop length for STFT. See `librosa.stft` for details.
     win_length : int <= n_fft [scalar]
@@ -941,7 +941,7 @@ def poly_features(
     S : np.ndarray [shape=(..., d, t)] or None
         (optional) spectrogram magnitude
     n_fft : int > 0 [scalar]
-        length of the FFT window
+        length of the FFT frame
     hop_length : int > 0 [scalar]
         hop length for STFT. See `librosa.stft` for details.
     win_length : int <= n_fft [scalar]
@@ -1171,7 +1171,7 @@ def chroma_stft(
         See `librosa.util.normalize` for details.
         If `None`, no normalization is performed.
     n_fft : int  > 0 [scalar]
-        length of the FFT window, if ``y, sr`` are provided instead of ``S``
+        length of the FFT frame, if ``y, sr`` are provided instead of ``S``
     hop_length : int > 0 [scalar]
         hop length if provided ``y, sr`` instead of ``S``
     win_length : int <= n_fft [scalar]
@@ -1881,7 +1881,7 @@ def mfcc(
     **kwargs
         additional keyword arguments to `melspectrogram` if operating on time series input
     n_fft : int > 0 [scalar]
-        length of the FFT window
+        length of the FFT frame
     hop_length : int > 0 [scalar]
         number of samples between successive frames.
         See `librosa.stft`
@@ -2053,7 +2053,7 @@ def melspectrogram(
     S : np.ndarray [shape=(..., d, t)]
         spectrogram
     n_fft : int > 0 [scalar]
-        length of the FFT window
+        length of the FFT frame
     hop_length : int > 0 [scalar]
         number of samples between successive frames.
         See `librosa.stft`

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -82,7 +82,7 @@ def spectral_centroid(
     S : np.ndarray [shape=(..., d, t)] or None
         (optional) spectrogram magnitude
     n_fft : int > 0 [scalar]
-        FFT window size
+        length of the FFT window
     hop_length : int > 0 [scalar]
         hop length for STFT. See `librosa.stft` for details.
     freq : None or np.ndarray [shape=(d,) or shape=(d, t)]
@@ -226,7 +226,7 @@ def spectral_bandwidth(
     S : np.ndarray [shape=(..., d, t)] or None
         (optional) spectrogram magnitude
     n_fft : int > 0 [scalar]
-        FFT window size
+        length of the FFT window
     hop_length : int > 0 [scalar]
         hop length for STFT. See `librosa.stft` for details.
     win_length : int <= n_fft [scalar]
@@ -394,7 +394,7 @@ def spectral_contrast(
     S : np.ndarray [shape=(..., d, t)] or None
         (optional) spectrogram magnitude
     n_fft : int > 0 [scalar]
-        FFT window size
+        length of the FFT window
     hop_length : int > 0 [scalar]
         hop length for STFT. See `librosa.stft` for details.
     win_length : int <= n_fft [scalar]
@@ -563,7 +563,7 @@ def spectral_rolloff(
     S : np.ndarray [shape=(d, t)] or None
         (optional) spectrogram magnitude
     n_fft : int > 0 [scalar]
-        FFT window size
+        length of the FFT window
     hop_length : int > 0 [scalar]
         hop length for STFT. See `librosa.stft` for details.
     win_length : int <= n_fft [scalar]
@@ -716,7 +716,7 @@ def spectral_flatness(
     S : np.ndarray [shape=(..., d, t)] or None
         (optional) pre-computed spectrogram magnitude
     n_fft : int > 0 [scalar]
-        FFT window size
+        length of the FFT window
     hop_length : int > 0 [scalar]
         hop length for STFT. See `librosa.stft` for details.
     win_length : int <= n_fft [scalar]
@@ -941,7 +941,7 @@ def poly_features(
     S : np.ndarray [shape=(..., d, t)] or None
         (optional) spectrogram magnitude
     n_fft : int > 0 [scalar]
-        FFT window size
+        length of the FFT window
     hop_length : int > 0 [scalar]
         hop length for STFT. See `librosa.stft` for details.
     win_length : int <= n_fft [scalar]
@@ -1171,7 +1171,7 @@ def chroma_stft(
         See `librosa.util.normalize` for details.
         If `None`, no normalization is performed.
     n_fft : int  > 0 [scalar]
-        FFT window size if provided ``y, sr`` instead of ``S``
+        length of the FFT window, if ``y, sr`` are provided instead of ``S``
     hop_length : int > 0 [scalar]
         hop length if provided ``y, sr`` instead of ``S``
     win_length : int <= n_fft [scalar]

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -136,7 +136,7 @@ def mel(
         sampling rate of the incoming signal
 
     n_fft : int > 0 [scalar]
-        number of FFT components
+        length of the FFT window; the filter bank has ``1 + n_fft // 2`` frequency bins
 
     n_mels : int > 0 [scalar]
         number of Mel bands to generate
@@ -275,7 +275,7 @@ def chroma(
         audio sampling rate
 
     n_fft : int > 0 [scalar]
-        number of FFT bins
+        length of the FFT window; the filter bank has ``1 + n_fft // 2`` frequency bins
 
     n_chroma : int > 0 [scalar]
         number of chroma bins

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -136,7 +136,7 @@ def mel(
         sampling rate of the incoming signal
 
     n_fft : int > 0 [scalar]
-        length of the FFT window; the filter bank has ``1 + n_fft // 2`` frequency bins
+        length of the FFT frame; the filter bank has ``1 + n_fft // 2`` frequency bins
 
     n_mels : int > 0 [scalar]
         number of Mel bands to generate
@@ -275,7 +275,7 @@ def chroma(
         audio sampling rate
 
     n_fft : int > 0 [scalar]
-        length of the FFT window; the filter bank has ``1 + n_fft // 2`` frequency bins
+        length of the FFT frame; the filter bank has ``1 + n_fft // 2`` frequency bins
 
     n_chroma : int > 0 [scalar]
         number of chroma bins

--- a/librosa/onset.py
+++ b/librosa/onset.py
@@ -477,7 +477,7 @@ def onset_strength_multi(
         pre-computed (log-power) spectrogram
 
     n_fft : int > 0 [scalar]
-        length of the FFT window for use in ``feature()`` if ``S`` is not provided.
+        length of the FFT frame for use in ``feature()`` if ``S`` is not provided.
 
     hop_length : int > 0 [scalar]
         hop length for use in ``feature()`` if ``S`` is not provided.

--- a/librosa/onset.py
+++ b/librosa/onset.py
@@ -477,7 +477,7 @@ def onset_strength_multi(
         pre-computed (log-power) spectrogram
 
     n_fft : int > 0 [scalar]
-        FFT window size for use in ``feature()`` if ``S`` is not provided.
+        length of the FFT window for use in ``feature()`` if ``S`` is not provided.
 
     hop_length : int > 0 [scalar]
         hop length for use in ``feature()`` if ``S`` is not provided.


### PR DESCRIPTION
#### Reference Issue
Fixes #1522

#### What does this implement/fix? Explain your changes.
An audit of every `n_fft` parameter docstring found the definitions reduce to three semantic groups; full breakdown in [this comment on #1522](https://github.com/librosa/librosa/issues/1522#issuecomment-4907859317). This PR:

- Standardizes the analysis-frame group on **"length of the FFT frame"**. (Earlier revisions used "window"; per review, `n_fft` is the frame length, and a window can be shorter than the frame, so the whole set including the `frames_to_time` family and `fft_frequencies` now uses "frame".)
- Fixes the bins/components wordings that conflated the frame length with the `1 + n_fft // 2` bin count (`filters.mel`, `filters.chroma`, `piptrack`, `estimate_tuning`, `feature.inverse.*`). Shape claims are stated only where the output or filter bank is actually shaped by them: `filters.mel`, `filters.chroma`, and `mel_to_stft`; the audio-output functions (`mel_to_audio`, `mfcc_to_audio`) reference the intermediate STFT with no shape claim.
- Rewrites `istft`'s frame-length inference note with the explicit formula (`2 * (stft_matrix.shape[-2] - 1)`) and why odd frame lengths need `n_fft` passed.
- Corrects `mel_to_stft`'s documented return shape from `(..., n_fft, t)` to `(..., 1 + n_fft // 2, t)`, matching what `nnls(mel_basis, M)` produces.
- Fixes two frequency-axis references that assumed 2D input (`istft`'s `win_length` line, `phase_vocoder`'s `hop_length` line): axis is `-2` for multichannel.

Docstrings only; no behavior changes. Rebuilt against `1.0.0dev` after retargeting, including the definitions that only exist on that branch.

#### Any other comments?
If you would rather keep #1522 open for the glossary discussion, I am happy to change "Fixes" to "References".