### PR TITLE
Trying to fix doc deploy action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
     branches:
     - main
-    - 1.0.0dev
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
     branches:
     - main
-    - 1.0.0dev
 
   
 concurrency:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -73,7 +73,7 @@ jobs:
             ln -srf build/html/$(./scripts/get_latest_release.sh) build/html/latest  # auto-link the latest tag
 
         - name: Push to web
-          uses: tagus/git-deploy@v0.4.1
+          uses: tagus/git-deploy@v0.5.0
           with:
             changes: build/html
             branch: main


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Doc build is currently failing to deploy to our target repository.

First step in fixing this is bumping the version of git-deploy.

#### Any other comments?

Probably this won't fix it and we'll need to redo the whole doc deploy secrets.  But this is a first step.

I'm also removing the no longer needed branch targets from ci workflows.