### PR TITLE
Skip redundant np.abs copy in piptrack for non-negative real input

### DIFF
--- a/librosa/core/pitch.py
+++ b/librosa/core/pitch.py
@@ -314,8 +314,13 @@ def piptrack(
         pad_mode=pad_mode,
     )
 
-    # Make sure we're dealing with magnitudes
-    S = np.abs(S)
+    # Make sure we're dealing with magnitudes.
+    # ``np.abs(S)`` forces a full-size copy of ``S`` on every call.  For a
+    # real, non-negative spectrogram (the common case, e.g. a magnitude or
+    # power spectrogram) that copy is redundant, so only rectify when the
+    # input is complex or actually contains negative values.
+    if np.iscomplexobj(S) or S.min() < 0:
+        S = np.abs(S)
 
     # Truncate to feasible region
     fmin = np.maximum(fmin, 0)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1655,6 +1655,29 @@ def test_piptrack(freq, n_fft):
     assert np.all(np.abs(np.log2(recovered_pitches) - np.log2(freq)) <= 1e-2)
 
 
+@pytest.mark.parametrize("n_fft", [1024, 2048])
+def test_piptrack_magnitude_equivalence(n_fft):
+    # piptrack rectifies its input to magnitudes internally. That rectification
+    # is skipped for a real, non-negative spectrogram (to avoid a redundant
+    # full-size copy), so a non-negative magnitude spectrogram, its complex
+    # counterpart, and its sign-flipped version must all yield identical output.
+    y = librosa.tone(440, sr=22050, duration=0.2)
+    D = librosa.stft(y, n_fft=n_fft, center=False)
+    S = np.abs(D)
+
+    # Non-negative real input: the copy-skipping fast path.
+    pitches_mag, mags_mag = librosa.piptrack(S=S, fmin=100)
+    # Complex input: must be converted to magnitude.
+    pitches_cplx, mags_cplx = librosa.piptrack(S=D, fmin=100)
+    # Negative real input: must be rectified.
+    pitches_neg, mags_neg = librosa.piptrack(S=-S, fmin=100)
+
+    assert np.allclose(pitches_mag, pitches_cplx)
+    assert np.allclose(mags_mag, mags_cplx)
+    assert np.allclose(pitches_mag, pitches_neg)
+    assert np.allclose(mags_mag, mags_neg)
+
+
 @pytest.mark.parametrize("center_note", [69, 84, 108])
 @pytest.mark.parametrize("tuning", np.linspace(-0.5, 0.5, 5, endpoint=False))
 @pytest.mark.parametrize("bins_per_octave", [12])


### PR DESCRIPTION
Refs #2076

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/librosa/librosa/blob/main/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
Follow-up to #2076 (partial — addresses one of the allocations, not the full piptrack rework).


#### What does this implement/fix? Explain your changes.
piptrack unconditionally ran `S = np.abs(S)`, which allocates a full-size copy of the spectrogram on every call — even when `S` is already a real, non-negative magnitude/power spectrogram (the common case). This is one of the intermediate allocations behind the RSS growth in #2076 (glibc arena fragmentation, confirmed with malloc_trim, not a reference leak). I guarded the rectification so it only runs when it's actually needed:
      
    if np.iscomplexobj(S) or S.min() < 0:
        S = np.abs(S)

Complex input is still converted to magnitude and signed real input is still rectified, so output is unchanged for every input; the copy is only skipped when `S` is already non-negative.

#### Any other comments?

  - On the condition: the issue suggested `S.min() <= 0`, but I used `< 0`. Real spectrograms often contain exact zeros, so `<= 0` would trigger the copy on almost every real input and defeat the optimization (`abs(0) == 0`, so zeros don't need rectifying). Happy to change it if you prefer `<=`.
  - Scope: this removes only one of piptrack's several intermediate allocations. The larger streamlining you mentioned (numba stencil reusing  `_parabolic_interpolation`) is left for a possible follow-up.
  - Tests: added `test_piptrack_magnitude_equivalence` (non-negative real vs complex vs sign-flipped → identical output). piptrack / estimate_tuning / chroma suites pass; ruff, numpydoc lint, mypy, and codespell clean locally.