### PR TITLE
revising nnls initialization

### DIFF
--- a/.github/environment-ci.yml
+++ b/.github/environment-ci.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   # required
-  - defaults::pip<26.2
+  - pip
   - numpy>=2.1.0
   - scipy>=1.15.0
   - scikit-learn>=1.6.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
 
         - name: Update environment
           run:
-            mamba env update -n test -f ${{ matrix.envfile }} 
+            conda env update -n test -f ${{ matrix.envfile }} 
           if: steps.cache.outputs.cache-hit != 'true'
 
         - name: Conda info

--- a/librosa/util/_nnls.py
+++ b/librosa/util/_nnls.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 
 __all__ = ["nnls"]
 
+COND = 1e-15  # Condition number cutoff for least squares solver initialization
 
 def _nnls_obj(
     x: np.ndarray, shape: Sequence[int], A: np.ndarray, B: np.ndarray
@@ -66,9 +67,11 @@ def _nnls_lbfgs_block(
     """
     # If we don't have an initial point, start at the projected
     # least squares solution
+    import scipy.linalg
+    import scipy.optimize
     if x_init is None:
         # Suppress type checks because mypy can't find pinv
-        x_init = np.einsum("fm,...mt->...ft", np.linalg.pinv(A), B, optimize=True)
+        x_init = scipy.linalg.lstsq(A, B, cond=COND)[0]
         np.clip(x_init, 0, None, out=x_init)
 
     # Adapt the hessian approximation to the dimension of the problem
@@ -79,8 +82,6 @@ def _nnls_lbfgs_block(
     shape = x_init.shape
 
     # optimize
-    import scipy.optimize
-
     x, _obj_value, _diagnostics = scipy.optimize.fmin_l_bfgs_b(
         _nnls_obj, x_init, args=(shape, A, B), bounds=bounds, **kwargs
     )
@@ -158,7 +159,7 @@ def nnls(A: np.ndarray, B: np.ndarray, **kwargs: Any) -> np.ndarray:
         return _nnls_lbfgs_block(A, B, **kwargs).astype(A.dtype)
 
     x: np.ndarray
-    x = np.einsum("fm,...mt->...ft", np.linalg.pinv(A), B, optimize=True)
+    x = scipy.linalg.lstsq(A, B, cond=COND)[0]
     np.clip(x, 0, None, out=x)
     x_init = x
 

--- a/librosa/util/_nnls.py
+++ b/librosa/util/_nnls.py
@@ -71,7 +71,7 @@ def _nnls_lbfgs_block(
     import scipy.optimize
     if x_init is None:
         # Suppress type checks because mypy can't find pinv
-        x_init = np.einsum("fm,...mt->...ft", np.linalg.pinv(A, rtol=COND), B, optimize=True)
+        x_init = np.einsum("fm,...mt->...ft", scipy.linalg.pinv(A, rtol=COND), B, optimize=True)
         np.clip(x_init, 0, None, out=x_init)
 
     # Adapt the hessian approximation to the dimension of the problem
@@ -159,7 +159,7 @@ def nnls(A: np.ndarray, B: np.ndarray, **kwargs: Any) -> np.ndarray:
         return _nnls_lbfgs_block(A, B, **kwargs).astype(A.dtype)
 
     x: np.ndarray
-    x = np.einsum("fm,...mt->...ft", np.linalg.pinv(A, rtol=COND), B, optimize=True)
+    x = np.einsum("fm,...mt->...ft", scipy.linalg.pinv(A, rtol=COND), B, optimize=True)
     np.clip(x, 0, None, out=x)
     x_init = x
 

--- a/librosa/util/_nnls.py
+++ b/librosa/util/_nnls.py
@@ -71,7 +71,7 @@ def _nnls_lbfgs_block(
     import scipy.optimize
     if x_init is None:
         # Suppress type checks because mypy can't find pinv
-        x_init = scipy.linalg.lstsq(A, B, cond=COND)[0]
+        x_init = np.einsum("fm,...mt->...ft", np.linalg.pinv(A, rtol=COND), B, optimize=True)
         np.clip(x_init, 0, None, out=x_init)
 
     # Adapt the hessian approximation to the dimension of the problem
@@ -159,7 +159,7 @@ def nnls(A: np.ndarray, B: np.ndarray, **kwargs: Any) -> np.ndarray:
         return _nnls_lbfgs_block(A, B, **kwargs).astype(A.dtype)
 
     x: np.ndarray
-    x = scipy.linalg.lstsq(A, B, cond=COND)[0]
+    x = np.einsum("fm,...mt->...ft", np.linalg.pinv(A, rtol=COND), B, optimize=True)
     np.clip(x, 0, None, out=x)
     x_init = x
 


### PR DESCRIPTION
#### Reference Issue
NNLS regression surfaced in CI for #2083 


#### What does this implement/fix? Explain your changes.

This PR replaces the `numpy.linalg.pinv` + clipping initialization to `nnls` with the scipy equivalent, allowing us to control the condition number threshold.

#### Any other comments?

If CI is green, this should be fine to merge as it only amounts to a change in the initialization for solving a convex problem.