### PR TITLE
Validate audio input in feature.rms (closes #2086)

### DIFF
--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -884,6 +884,8 @@ def rms(
     >>> plt.show()
     """
     if y is not None:
+        util.valid_audio(y)
+
         if center:
             padding = [(0, 0) for _ in range(y.ndim)]
             padding[-1] = (int(frame_length // 2), int(frame_length // 2))

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -412,6 +412,26 @@ def test_rms_badshape():
     librosa.feature.rms(S=S, frame_length=100)
 
 
+@pytest.mark.parametrize("bad", [np.nan, np.inf, -np.inf])
+@pytest.mark.xfail(raises=librosa.ParameterError)
+def test_rms_nonfinite(bad):
+    # A single non-finite sample used to propagate silently: NaN compares
+    # False against every threshold, so effects.trim and effects.split
+    # concluded the whole signal was silence and returned nothing.
+    y = np.zeros(4096, dtype=np.float32)
+    y[2048] = bad
+    librosa.feature.rms(y=y)
+
+
+@pytest.mark.parametrize("effect", [librosa.effects.trim, librosa.effects.split])
+@pytest.mark.xfail(raises=librosa.ParameterError)
+def test_effects_nonfinite(effect):
+    # These route through rms, so they inherited the missing check.
+    y = np.zeros(4096, dtype=np.float32)
+    y[2048] = np.nan
+    effect(y)
+
+
 @pytest.fixture(params=[32, 16, 8, 4, 2], scope="module")
 def y_zcr(request):
     sr = 16384


### PR DESCRIPTION
Closes #2086.

`rms` is the only feature function that reaches `util.frame` without going through
`valid_audio`, so it never rejected non-finite input. `effects.trim` and
`effects.split` both route through it, and since NaN compares False against any
threshold, no frame was ever marked non-silent and they returned an empty result
for the whole signal.

```python
y = np.zeros(4096, dtype=np.float32); y[2048] = np.nan
librosa.effects.trim(y)[0].shape    # before: (0,)   after: ParameterError
```

## One behaviour change worth flagging before you merge

`valid_audio` also enforces the dtype, so this makes `rms` reject integer and
complex input that it previously accepted. That is a real change and I would
rather surface it than have it turn up later.

I checked whether it breaks a supported input or closes a hole, on `1.0.0rc0`
before this patch:

```
stft                rejects int16   ParameterError: Audio data must be floating-point
melspectrogram      rejects int16
mfcc                rejects int16
zero_crossing_rate  rejects int16
spectral_centroid   rejects int16
resample            rejects int16

feature.rms         ACCEPTS int16
effects.trim        ACCEPTS int16   (via rms)
effects.split       ACCEPTS int16   (via rms)
```

So integer support in `rms` came from the same missing check rather than from
intent, and the three functions that accept it are exactly the three affected
here. This aligns them with the rest of the library.

The caller most likely to notice is `scipy.io.wavfile.read`, which returns int16
for a 16-bit WAV. If you would rather not change dtype behaviour in a 1.0
release, the narrower version is a finiteness check alone:

```python
if not np.isfinite(y).all():
    raise ParameterError("Audio buffer is not finite everywhere")
```

That fixes the reported bug and keeps integer input working. Happy to switch to
it, I just think consistency with `valid_audio` is the better default and did not
want to make that call silently.

## Tests

Added to `tests/test_features.py`: `test_rms_nonfinite` parametrised over
nan/inf/-inf, and `test_effects_nonfinite` over `trim` and `split`.

```
tests/test_features.py   437 passed, 72 xfailed
tests/test_effects.py    264 passed
```

The wider suite shows 104 failures both with and without this patch, all
`ModuleNotFoundError: No module named 'resampy'` from my environment, so nothing
new.

The `S=` path is untouched.
