### PR TITLE
Keep doctrees and reST sources out of the published docs

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -77,7 +77,7 @@ jobs:
         - name: Build documentation site
           shell: bash -l {0}
           run: |
-            sphinx-build -b html docs build/html
+            sphinx-build -b html -d build/doctrees docs build/html
             touch build/html/.nojekyll
 
         - name: Upload compiled documentation site

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Build documentations
         shell: bash -el {0}
         run: |
-          sphinx-build -b html docs build/html/dev
+          sphinx-build -b html -d build/doctrees docs build/html/dev
           cp docs/docsite-index-redirect.html build/html/index.html
 
 

--- a/.github/workflows/publish-doc-asset.yml
+++ b/.github/workflows/publish-doc-asset.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Build documentations
         shell: bash -el {0}
-        run: sphinx-build -b html docs build/html
+        run: sphinx-build -b html -d build/doctrees docs build/html
 
       - name: Zip and Upload Release Asset
         shell: bash -el {0}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -357,6 +357,10 @@ html_css_files = [
 ]
 html_show_sourcelink = False
 
+# Sourcelinks are disabled above, so nothing references the reST sources and
+# there is no reason to ship them.
+html_copy_source = False
+
 html_context = {
     "default_mode": "light"
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -118,7 +118,7 @@ import librosa
 )
 plot_include_source = True
 plot_html_show_source_link = False
-plot_formats = [("png", 150), ("pdf", 150)]
+plot_formats = [("png", 150)]
 plot_html_show_formats = False
 
 from cycler import cycler


### PR DESCRIPTION
#### Reference Issue

Fixes #2088

#### What does this implement/fix? Explain your changes.

Two separate reasons the built docs are larger than they need to be.

1. `sphinx-build` writes `.doctrees` into the output directory unless `-d` points somewhere else. `docs/Makefile` already passes `-d $(BUILDDIR)/doctrees`, but the three workflows that build the site and the release asset do not, so the doctrees end up inside the directory that gets zipped and published.

2. `html_copy_source` defaults to `True` even when `html_show_sourcelink` is `False`. `conf.py` already sets the sourcelink to False, so `_sources` is being shipped with nothing linking to it.

Measured from the git tree of `librosa/doc`, so these are the deployed sizes rather than estimates:

| version | total | `.doctrees` | `_sources` | prunable |
|---|---|---|---|---|
| dev | 468M | 224M | 78M | 65% |
| main | 468M | 224M | 78M | 65% |
| 1.0.0 | 468M | 224M | 78M | 65% |
| latest | 468M | 224M | 78M | 65% |
| 0.10.2 | 80M | 0M | 23M | 28% |
| 0.11.0 | 79M | 0M | 23M | 28% |
| **site** | **2030M** | **895M** | **357M** | **61%** |

0.10.2 and 0.11.0 carry no `.doctrees` at all, so that half is a recent change; `_sources` affects every version.

The change adds `-d build/doctrees` to the three workflows, where that path sits outside the directory being zipped or published, and sets `html_copy_source = False`. On a scratch sphinx project this moves the doctrees out and leaves `_sources` empty.

#### Any other comments?

Unrelated to this issue, but noticed while measuring: `latest` and `main` are stored in `librosa/doc` as full directory trees rather than symlinks, so each duplicates `1.0.0` and `dev` respectively. The workflow creates them with `ln -srf`, so something in the publish step is dereferencing them. Happy to open a separate issue if that is worth pursuing.