### PR TITLE
making linkcheck failures not catastrophic for CI

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -100,7 +100,15 @@ jobs:
         - name: Warn on linkcheck failure
           if: steps.linkcheck.outcome == 'failure'
           run: |
-            echo "::warning Linkcheck failed. Please check the logs for details."
+            OUTPUT=$(cat build/linkcheck/output.txt)
+            echo "::warning Linkcheck failed: $OUTPUT"
+
+        - name: Post or update PR comment
+          if: github.event_name == 'pull_request' && steps.linkcheck.outcome == 'failure'
+          uses: marocchino/sticky-pull-request-comment@v2
+          with:
+            header: linkcheck-failure-log # Unique key used to find and update the comment
+            path: docs/_build/linkcheck/output.txt
 
         - name: Check for broken symbolic links
           shell: bash -l {0}

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -97,18 +97,36 @@ jobs:
           run: make linkcheck
           continue-on-error: true
 
+        - name: Format failure preamble
+          if: github.event_name == 'pull_request' && steps.linkcheck.outcome == 'failure'
+          run: |
+            echo "### ⚠️ Sphinx Linkcheck Failed" > linkcheck-comment.md
+            echo "The following URLs reported errors or timeouts. Inspect to determine if these are transient network failures:" >> linkcheck-comment.md
+            echo '```text' >> linkcheck-comment.md
+            cat docs/_build/linkcheck/output.txt >> linkcheck-comment.md
+            echo '```' >> linkcheck-comment.md
+
+        - name: Post or update PR comment (Failure)
+          if: github.event_name == 'pull_request' && steps.linkcheck.outcome == 'failure'
+          uses: marocchino/sticky-pull-request-comment@v4
+          with:
+            header: linkcheck-failure-log
+            path: linkcheck-comment.md
+
+        - name: Update PR comment (Success)
+          if: github.event_name == 'pull_request' && steps.linkcheck.outcome == 'success'
+          uses: marocchino/sticky-pull-request-comment@v3
+          with:
+            header: linkcheck-failure-log
+            message: |
+              ### ✅ Sphinx Linkcheck Passed
+              All target links are resolving successfully.
+
         - name: Warn on linkcheck failure
           if: steps.linkcheck.outcome == 'failure'
           run: |
             OUTPUT=$(cat docs/_build/linkcheck/output.txt)
             echo "::warning Linkcheck failed: $OUTPUT"
-
-        - name: Post or update PR comment
-          if: github.event_name == 'pull_request' && steps.linkcheck.outcome == 'failure'
-          uses: marocchino/sticky-pull-request-comment@v3
-          with:
-            header: linkcheck-failure-log # Unique key used to find and update the comment
-            path: docs/_build/linkcheck/output.txt
 
         - name: Check for broken symbolic links
           shell: bash -l {0}

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -95,8 +95,14 @@ jobs:
           shell: bash -l {0}
           working-directory: docs
           run: make linkcheck
+          continue-on-error: true
 
-        - name: Check for broken links
+        - name: Warn on linkcheck failure
+          if: steps.linkcheck.outcome == 'failure'
+          run: |
+            echo "::warning Linkcheck failed. Please check the logs for details."
+
+        - name: Check for broken symbolic links
           shell: bash -l {0}
           run: |
             if [[ -n "$(find build/html/ -type l ! -exec test -e {} \; -print -quit)" ]]; then false; fi

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -99,18 +99,16 @@ jobs:
 
         - name: Warn on linkcheck failure
           if: steps.linkcheck.outcome == 'failure'
-          working-directory: docs
           run: |
-            OUTPUT=$(cat _build/linkcheck/output.txt)
+            OUTPUT=$(cat docs/_build/linkcheck/output.txt)
             echo "::warning Linkcheck failed: $OUTPUT"
 
         - name: Post or update PR comment
           if: github.event_name == 'pull_request' && steps.linkcheck.outcome == 'failure'
           uses: marocchino/sticky-pull-request-comment@v3
-          working-directory: docs
           with:
             header: linkcheck-failure-log # Unique key used to find and update the comment
-            path: _build/linkcheck/output.txt
+            path: docs/_build/linkcheck/output.txt
 
         - name: Check for broken symbolic links
           shell: bash -l {0}

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -106,7 +106,7 @@ jobs:
 
         - name: Post or update PR comment
           if: github.event_name == 'pull_request' && steps.linkcheck.outcome == 'failure'
-          uses: marocchino/sticky-pull-request-comment@v2
+          uses: marocchino/sticky-pull-request-comment@v3
           working-directory: docs
           with:
             header: linkcheck-failure-log # Unique key used to find and update the comment

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -108,7 +108,7 @@ jobs:
 
         - name: Post or update PR comment (Failure)
           if: github.event_name == 'pull_request' && steps.linkcheck.outcome == 'failure'
-          uses: marocchino/sticky-pull-request-comment@v4
+          uses: marocchino/sticky-pull-request-comment@v3
           with:
             header: linkcheck-failure-log
             path: linkcheck-comment.md

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -99,16 +99,18 @@ jobs:
 
         - name: Warn on linkcheck failure
           if: steps.linkcheck.outcome == 'failure'
+          working-directory: docs
           run: |
-            OUTPUT=$(cat build/linkcheck/output.txt)
+            OUTPUT=$(cat _build/linkcheck/output.txt)
             echo "::warning Linkcheck failed: $OUTPUT"
 
         - name: Post or update PR comment
           if: github.event_name == 'pull_request' && steps.linkcheck.outcome == 'failure'
           uses: marocchino/sticky-pull-request-comment@v2
+          working-directory: docs
           with:
             header: linkcheck-failure-log # Unique key used to find and update the comment
-            path: docs/_build/linkcheck/output.txt
+            path: _build/linkcheck/output.txt
 
         - name: Check for broken symbolic links
           shell: bash -l {0}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -467,7 +467,7 @@ linkcheck_timeout = 10
 linkcheck_workers = 10
 linkcheck_report_timeouts_as_broken = False
 linkcheck_ignore = ["https://www.ee.columbia.edu/~dpwe/resources/.*",
-                    "https://htk.eng.cam.ac.uk/.*",
+                    #"https://htk.eng.cam.ac.uk/.*",
                     # Ignore broken links to publishers, as they throttle scrapers
                     "https://zenodo.org/.*",
                     "https://transactions.ismir.net/.*"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -467,7 +467,7 @@ linkcheck_timeout = 10
 linkcheck_workers = 10
 linkcheck_report_timeouts_as_broken = False
 linkcheck_ignore = ["https://www.ee.columbia.edu/~dpwe/resources/.*",
-                    #"https://htk.eng.cam.ac.uk/.*",
+                    "https://htk.eng.cam.ac.uk/.*",
                     # Ignore broken links to publishers, as they throttle scrapers
                     "https://zenodo.org/.*",
                     "https://transactions.ismir.net/.*"]


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This PR softens the failure of the `linkcheck` step in the docs CI.  It should now raise a warning when linkcheck fails, rather than going completely red.

#### Any other comments?

I've temporarily removed one of our known failure targets to try to trigger this step in the action.  I'll reset it back to normal prior to merging.