### PR TITLE
Forward `window` to stft and istft in effects.hpss, harmonic and percussive

### DIFF
--- a/librosa/effects.py
+++ b/librosa/effects.py
@@ -140,6 +140,7 @@ def hpss(
         n_fft=n_fft,
         hop_length=hop_length,
         win_length=win_length,
+        window=window,
         center=center,
         pad_mode=pad_mode,
     )
@@ -156,6 +157,7 @@ def hpss(
         n_fft=n_fft,
         hop_length=hop_length,
         win_length=win_length,
+        window=window,
         center=center,
         length=y.shape[-1],
     )
@@ -165,6 +167,7 @@ def hpss(
         n_fft=n_fft,
         hop_length=hop_length,
         win_length=win_length,
+        window=window,
         center=center,
         length=y.shape[-1],
     )
@@ -263,6 +266,7 @@ def harmonic(
         n_fft=n_fft,
         hop_length=hop_length,
         win_length=win_length,
+        window=window,
         center=center,
         pad_mode=pad_mode,
     )
@@ -279,6 +283,7 @@ def harmonic(
         n_fft=n_fft,
         hop_length=hop_length,
         win_length=win_length,
+        window=window,
         center=center,
         length=y.shape[-1],
     )
@@ -377,6 +382,7 @@ def percussive(
         n_fft=n_fft,
         hop_length=hop_length,
         win_length=win_length,
+        window=window,
         center=center,
         pad_mode=pad_mode,
     )
@@ -393,6 +399,7 @@ def percussive(
         n_fft=n_fft,
         hop_length=hop_length,
         win_length=win_length,
+        window=window,
         center=center,
         length=y.shape[-1],
     )

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -201,6 +201,38 @@ def test_harmonic(ysr):
     assert np.allclose(yh1, yh2)
 
 
+@pytest.mark.parametrize(
+    "effect_fn",
+    [librosa.effects.hpss, librosa.effects.harmonic, librosa.effects.percussive],
+)
+def test_effects_window(ysr, effect_fn):
+    # The window must reach the STFT.  Asserting only that the outputs differ
+    # would also pass if it reached stft but not istft, so the reconstruction
+    # check below pins both.
+    y, sr = ysr
+
+    def first(result):
+        return result[0] if isinstance(result, tuple) else result
+
+    y_hann = first(effect_fn(y=y, window="hann"))
+    y_hamming = first(effect_fn(y=y, window="hamming"))
+    y_blackman = first(effect_fn(y=y, window="blackman"))
+
+    assert not np.allclose(y_hann, y_hamming)
+    assert not np.allclose(y_hann, y_blackman)
+
+
+@pytest.mark.parametrize("window", ["hann", "hamming", "blackman"])
+def test_hpss_window_reconstruction(ysr, window):
+    # Analysis and synthesis must use the same window, otherwise the harmonic
+    # and percussive parts no longer sum back to the input.
+    y, sr = ysr
+
+    y_harm, y_perc = librosa.effects.hpss(y=y, window=window)
+
+    assert np.allclose(y_harm + y_perc, y, atol=1e-6)
+
+
 @pytest.fixture(scope="module", params=[False, True], ids=["mono", "stereo"])
 def y_trim(request):
     # construct 5 seconds of stereo silence


### PR DESCRIPTION
Fixes #2096.

`effects.hpss`, `effects.harmonic` and `effects.percussive` accept and document a `window` argument that never reached the transform. Seven call sites — one `core.stft` and one or two `core.istft` per function — now receive it.

Before:

```python
librosa.effects.hpss(y=y, window="hann")[0]
librosa.effects.hpss(y=y, window="blackman")[0]
# max|difference| = 0.0
```

After: `0.0234` for blackman, `0.0108` for hamming.

## Why `istft` is included and not just `stft`

Forwarding to the forward transform alone would leave analysis and synthesis on different windows, and `hpss` would stop reconstructing. That is pinned by a second test:

```
window=hann      max|(harm + perc) - y| = 0.0000
window=hamming   max|(harm + perc) - y| = 0.0000
window=blackman  max|(harm + perc) - y| = 0.0000
```

I did check whether a synthesis window differing from the analysis window is ever wanted here, and could not see a case for it in these three functions, since they are convenience wrappers around a single analyse-modify-resynthesise cycle. Happy to be told otherwise.

## Defaults

Unchanged, verified bitwise against unmodified 1.0.0 for all four outputs:

```
hpss_h        0.0e+00
hpss_p        0.0e+00
harmonic      0.0e+00
percussive    0.0e+00
```

## Tests

- `test_effects_window` — output differs across hann, hamming and blackman for all three functions. On its own this would also pass if `window` reached `stft` but not `istft`, which is why the next one accompanies it.
- `test_hpss_window_reconstruction` — `y_harm + y_perc` still sums to the input for each window.

321 pass in `tests/test_effects.py` and `tests/test_decompose.py`, 13 xfailed.

## On the linting question from #2096

> it's strange that ruff (or earlier linting actions) didn't catch this for us

It would have, but the rule is not enabled. `ARG` (flake8-unused-arguments) is absent from `select` in `pyproject.toml`, and ruff does not enable it by default.

I expected turning it on to be impractical, so I measured it rather than guessing:

```
$ ruff check --select ARG librosa/
Found 16 errors.
```

Three of those were the `window` arguments fixed here; `ruff check --select ARG librosa/effects.py` now passes. Sixteen across the whole package seems small enough to be worth a look, though I have not examined the other thirteen and some are likely deliberate — a `# noqa: ARG001` or a per-file ignore would cover those.

Left out of this PR entirely, since it is a repo-wide policy decision rather than part of the fix. Happy to open it as a separate issue if useful.

For what it is worth, this class of defect is why I ran an AST scan in the first place: a parameter added to a signature but never wired into the call still runs, still returns plausible values, and still passes every existing test, because no test varies it. A linter catches it in seconds. It has turned up in five projects I looked at this week, including a PR of my own.

No rush on review — enjoy the vacation.
