### PR TITLE
Revising linkcheck action again

### DIFF
--- a/.github/workflows/docs-ci-linkcheck.yml
+++ b/.github/workflows/docs-ci-linkcheck.yml
@@ -1,0 +1,47 @@
+name: Post Linkcheck Comment
+on:
+  workflow_run:
+    workflows: ["CI Docs"]
+    types: [completed]
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: linkcheck-results
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Parse status
+        id: status
+        run: echo "outcome=$(cat status.txt)" >> $GITHUB_OUTPUT
+
+      - name: Format failure preamble
+        if: github.event_name == 'pull_request' && steps.linkcheck.outcome == 'failure'
+        run: |
+          echo "### ⚠️ Sphinx Linkcheck Failed" > linkcheck-comment.md
+          echo "The following URLs reported errors or timeouts. Inspect to determine if these are transient network failures:" >> linkcheck-comment.md
+          echo '```text' >> linkcheck-comment.md
+          cat docs/_build/linkcheck/output.txt >> linkcheck-comment.md
+          echo '```' >> linkcheck-comment.md
+
+      - name: Post or update PR comment (Failure)
+        if: github.event_name == 'pull_request' && steps.linkcheck.outcome == 'failure'
+        uses: marocchino/sticky-pull-request-comment@v3
+        with:
+          header: linkcheck-failure-log
+          path: linkcheck-comment.md
+
+      - name: Update PR comment (Success)
+        if: github.event_name == 'pull_request' && steps.linkcheck.outcome == 'success'
+        uses: marocchino/sticky-pull-request-comment@v3
+        with:
+          header: linkcheck-failure-log
+          message: |
+            ### ✅ Sphinx Linkcheck Passed
+            All target links are resolving successfully.

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -97,30 +97,18 @@ jobs:
           run: make linkcheck
           continue-on-error: true
 
-        - name: Format failure preamble
-          if: github.event_name == 'pull_request' && steps.linkcheck.outcome == 'failure'
-          run: |
-            echo "### ⚠️ Sphinx Linkcheck Failed" > linkcheck-comment.md
-            echo "The following URLs reported errors or timeouts. Inspect to determine if these are transient network failures:" >> linkcheck-comment.md
-            echo '```text' >> linkcheck-comment.md
-            cat docs/_build/linkcheck/output.txt >> linkcheck-comment.md
-            echo '```' >> linkcheck-comment.md
+        - name: Save linkcheck status
+          run: echo "${{ steps.linkcheck.outcome }}" > status.txt
 
-        - name: Post or update PR comment (Failure)
-          if: github.event_name == 'pull_request' && steps.linkcheck.outcome == 'failure'
-          uses: marocchino/sticky-pull-request-comment@v3
-          with:
-            header: linkcheck-failure-log
-            path: linkcheck-comment.md
+        - name: Save linkcheck output
+          run: cp docs/_build/linkcheck/output.txt output.txt || touch output.txt
 
-        - name: Update PR comment (Success)
-          if: github.event_name == 'pull_request' && steps.linkcheck.outcome == 'success'
-          uses: marocchino/sticky-pull-request-comment@v3
+        - uses: actions/upload-artifact@v4
           with:
-            header: linkcheck-failure-log
-            message: |
-              ### ✅ Sphinx Linkcheck Passed
-              All target links are resolving successfully.
+            name: linkcheck-results
+            path: |
+              status.txt
+              output.txt
 
         - name: Warn on linkcheck failure
           if: steps.linkcheck.outcome == 'failure'


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This PR separates the docs CI linkcheck into two steps so that comments can be posted from PRs originating in external forks.
